### PR TITLE
Reintroduce index.ts files

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -9,20 +9,20 @@
       "default": "./dist/preview-bridge.js"
     },
     "./lit": {
-      "types": "./dist/lit/lit-bridge.d.ts",
-      "default": "./dist/lit/lit-bridge.js"
+      "types": "./dist/lit/index.d.ts",
+      "default": "./dist/lit/index.js"
     },
     "./angular": {
-      "types": "./dist/angular/angular-bridge.d.ts",
-      "default": "./dist/angular/angular-bridge.js"
+      "types": "./dist/angular/index.d.ts",
+      "default": "./dist/angular/index.js"
     },
     "./react": {
-      "types": "./dist/react/react-bridge.d.ts",
-      "default": "./dist/react/react-bridge.js"
+      "types": "./dist/react/index.d.ts",
+      "default": "./dist/react/index.js"
     }
   },
   "scripts": {
-    "build": "esbuild src/preview-bridge.ts src/lit/lit-bridge.ts src/angular/angular-bridge.ts src/react/react-bridge.ts --bundle --format=esm --target=es2022 --outdir=dist --tsconfig=tsconfig.bridge.json --external:lit '--external:@angular/*' '--external:@a2ui/*' '--external:react' '--external:react-dom' --external:../preview-bridge.js && tsc --project tsconfig.bridge.json --emitDeclarationOnly",
+    "build": "esbuild src/preview-bridge.ts src/lit/lit-bridge.ts src/angular/angular-bridge.ts src/react/react-bridge.ts src/lit/index.ts src/angular/index.ts src/react/index.ts --bundle --format=esm --target=es2022 --outdir=dist --tsconfig=tsconfig.bridge.json --external:lit '--external:@angular/*' '--external:@a2ui/*' '--external:react' '--external:react-dom' --external:../preview-bridge.js && tsc --project tsconfig.bridge.json --emitDeclarationOnly",
     "clean": "rm -rf dist",
     "test": "NODE_ENV=test vitest run",
     "prettier": "prettier --ignore-path ../.prettierignore --write . | grep -v '(unchanged)'"

--- a/bridge/src/angular/index.ts
+++ b/bridge/src/angular/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type {AngularSandboxOptions} from './angular-bridge.js';
+export {A2uiSandboxConnection, provideA2uiSandbox} from './angular-bridge.js';

--- a/bridge/src/lit/index.ts
+++ b/bridge/src/lit/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type {LitSandboxOptions} from './lit-bridge.js';
+export {A2uiSandboxRoot, bootstrapLitSandbox} from './lit-bridge.js';

--- a/bridge/src/react/index.ts
+++ b/bridge/src/react/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type {UseA2uiSandboxResult, ReactSandboxOptions} from './react-bridge.js';
+export {useA2uiSandbox} from './react-bridge.js';


### PR DESCRIPTION
# Description

After renaming the previous `index.ts` files, we can re-introduce them. This has a few benefits:
* Eliminating "Tab Hell": Working across multiple UI framework adapters simultaneously will no longer clutter your IDE workspace with identical index.ts tabs. Distinct basenames provide instant visual clarity and quick navigation.
* Fuzzy File Search (Ctrl+P / Cmd+P): Searching for lit-b or ang-b immediately targets the correct implementation file without filtering out dozens of repository-wide index files.
* Stack Trace Attribution: Runtime exceptions, console logging, and unit test failures will explicitly report angular-bridge.ts:L45 instead of index.ts:L45, providing immediate pinpoint attribution during debugging sessions and CI pipelines.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
