### PR TITLE
Testing thresholds

### DIFF
--- a/.agents/rules/testing_and_qa_workflow.md
+++ b/.agents/rules/testing_and_qa_workflow.md
@@ -46,7 +46,7 @@ Before committing any change, you MUST execute the following pipeline.
 - After addressing all review findings, spawn a separate QA subagent (which
   MUST be a `Gemini Pro` model) to perform a comprehensive quality review,
   looking for:
-  - Sufficient testing of both happy and unhappy paths.
-  - Sufficient code coverage (as reported by `yarn test`).
+  - Tests exist to cover both happy and unhappy paths.
+  - Sufficient code coverage (as reported by `yarn test --coverage`).
 - If the QA agent flags anything, it MUST be addressed and then reviewed again
   by a separate review agent (repeating Step 1).

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "esbuild src/preview-bridge.ts src/lit/lit-bridge.ts src/angular/angular-bridge.ts src/react/react-bridge.ts src/lit/index.ts src/angular/index.ts src/react/index.ts --bundle --format=esm --target=es2022 --outdir=dist --tsconfig=tsconfig.bridge.json --external:lit --external:@lit/context '--external:@angular/*' '--external:@a2ui/*' '--external:react' '--external:react-dom' --external:../preview-bridge.js && tsc --project tsconfig.bridge.json --emitDeclarationOnly",
     "clean": "rm -rf dist",
-    "test": "NODE_ENV=test vitest run",
+    "test": "NODE_ENV=test vitest run --coverage",
     "prettier": "prettier --ignore-path ../.prettierignore --write . | grep -v '(unchanged)'"
   },
   "devDependencies": {

--- a/bridge/src/angular/angular-bridge.spec.ts
+++ b/bridge/src/angular/angular-bridge.spec.ts
@@ -17,38 +17,23 @@
 import '@angular/compiler';
 
 // @vitest-environment jsdom
-import {describe, it, expect, afterEach, beforeEach, vi, Mock} from 'vitest';
-import {A2uiSandboxConnection} from './angular-bridge';
+import {describe, it, expect, afterEach, vi} from 'vitest';
+import {getTestBed, TestBed} from '@angular/core/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
+import {A2uiSandboxConnection, provideA2uiSandbox} from './angular-bridge';
+import {A2UI_RENDERER_CONFIG, A2uiRendererService} from '@a2ui/angular/v0_9';
 import {a2uiBridge} from '../preview-bridge';
-import {Catalog, ComponentApi} from '@a2ui/web_core/v0_9';
+import {Catalog, ComponentApi, A2uiClientAction} from '@a2ui/web_core/v0_9';
 
-declare global {
-  var mockInject: Mock<(token: unknown) => unknown> | undefined;
+if (!getTestBed().platform) {
+  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 }
 
-// Mock @angular/core inject dynamically using globalThis delegation
-vi.mock('@angular/core', async importOriginal => {
-  const original = await importOriginal<typeof import('@angular/core')>();
-  return {
-    ...original,
-    inject: <T>(token: Parameters<typeof original.inject>[0]): T => {
-      if (globalThis.mockInject) {
-        return globalThis.mockInject(token) as T;
-      }
-      return original.inject(token) as T;
-    },
-  };
-});
-
 describe('Angular Sandbox Connection Spec', () => {
-  beforeEach(() => {
-    globalThis.mockInject = vi.fn();
-  });
-
   afterEach(() => {
-    globalThis.mockInject = undefined;
     a2uiBridge.destroy();
     vi.restoreAllMocks();
+    TestBed.resetTestingModule();
   });
 
   it('aligns catalogs inside A2UI_RENDERER_CONFIG with the resolved catalogId when onCatalogResolved is triggered', () => {
@@ -70,23 +55,19 @@ describe('Angular Sandbox Connection Spec', () => {
       catalogs: [myCatalog],
     };
 
-    const mockInject = globalThis.mockInject;
-    if (!mockInject) {
-      throw new Error('mockInject is not defined');
-    }
-    mockInject.mockImplementation((token: unknown) => {
-      if (token && typeof token === 'function' && token.name === 'A2uiRendererService') {
-        return mockRendererService;
-      }
-      return mockRendererConfig;
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: A2uiRendererService, useValue: mockRendererService},
+        {provide: A2UI_RENDERER_CONFIG, useValue: mockRendererConfig},
+      ],
     });
 
     const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
 
-    const connection = new A2uiSandboxConnection();
+    const connection = TestBed.runInInjectionContext(() => new A2uiSandboxConnection());
 
     expect(attachSpy).toHaveBeenCalled();
-    const configPassed = attachSpy.mock.calls[0][1];
+    const configPassed = attachSpy.mock.lastCall![1];
     expect(configPassed.onCatalogResolved).toBeDefined();
 
     // Trigger the callback
@@ -95,5 +76,108 @@ describe('Angular Sandbox Connection Spec', () => {
     expect(myCatalog.id).toBe('urn:a2ui:catalog:angular_resolved_id');
 
     connection.ngOnDestroy();
+  });
+
+  it('delegates processMessages payload to the underlying A2uiRendererService', () => {
+    const mockRendererService = {
+      surfaceGroup: {
+        onSurfaceCreated: {subscribe: vi.fn().mockReturnValue({unsubscribe: vi.fn()})},
+      },
+      processMessages: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: A2uiRendererService, useValue: mockRendererService},
+        {provide: A2UI_RENDERER_CONFIG, useValue: {}},
+      ],
+    });
+
+    const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
+    const connection = TestBed.runInInjectionContext(() => new A2uiSandboxConnection());
+
+    const processor = attachSpy.mock.lastCall![0];
+    const payload = [{version: 'v0.9'}] as any;
+
+    processor.processMessages(payload);
+
+    expect(mockRendererService.processMessages).toHaveBeenCalledWith(payload);
+
+    connection.ngOnDestroy();
+  });
+
+  it('updates surfaceId reactive signal when onSurfaceReady and onSurfaceCleared are invoked', () => {
+    const mockRendererService = {
+      surfaceGroup: {
+        onSurfaceCreated: {subscribe: vi.fn().mockReturnValue({unsubscribe: vi.fn()})},
+      },
+      processMessages: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: A2uiRendererService, useValue: mockRendererService},
+        {provide: A2UI_RENDERER_CONFIG, useValue: {}},
+      ],
+    });
+
+    const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
+    const connection = TestBed.runInInjectionContext(() => new A2uiSandboxConnection());
+
+    const config = attachSpy.mock.lastCall![1];
+
+    expect(connection.surfaceId()).toBe('');
+
+    config.onSurfaceReady('surf-123');
+    expect(connection.surfaceId()).toBe('surf-123');
+
+    if (config.onSurfaceCleared) {
+      config.onSurfaceCleared();
+    }
+    expect(connection.surfaceId()).toBe('');
+
+    connection.ngOnDestroy();
+  });
+
+  it('configures standalone DI providers via provideA2uiSandbox and routes actions to a2uiBridge.sendAction', () => {
+    class MockCatalog {}
+    const mockCatalogInstance = new MockCatalog();
+
+    const mockRendererService = {
+      surfaceGroup: {
+        onSurfaceCreated: {subscribe: vi.fn().mockReturnValue({unsubscribe: vi.fn()})},
+      },
+      processMessages: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideA2uiSandbox([MockCatalog as any], {catalogJson: {key: 'val'}}),
+        {provide: MockCatalog, useValue: mockCatalogInstance},
+        {provide: A2uiRendererService, useValue: mockRendererService},
+      ],
+    });
+
+    // 1. Verify A2uiSandboxConnection factory
+    const connInstance = TestBed.inject(A2uiSandboxConnection);
+    expect(connInstance).toBeInstanceOf(A2uiSandboxConnection);
+
+    // 2. Verify A2UI_RENDERER_CONFIG factory and actionHandler
+    const config = TestBed.inject(A2UI_RENDERER_CONFIG);
+
+    expect(config.catalogs).toEqual([mockCatalogInstance]);
+
+    const sendActionSpy = vi.spyOn(a2uiBridge, 'sendAction');
+    const dummyAction: A2uiClientAction = {
+      name: 'testAction',
+      surfaceId: 'surf-1',
+      sourceComponentId: 'comp-1',
+      timestamp: '2026-06-09T00:00:00Z',
+      context: {},
+    };
+    config.actionHandler!(dummyAction);
+    expect(sendActionSpy).toHaveBeenCalledWith(dummyAction);
+
+    connInstance.ngOnDestroy();
   });
 });

--- a/bridge/src/instrumentation-overrides.spec.ts
+++ b/bridge/src/instrumentation-overrides.spec.ts
@@ -16,6 +16,9 @@
 
 import {describe, it, expect, beforeEach, afterEach, vi, MockInstance} from 'vitest';
 
+const consoleLogSpy = vi.hoisted(() => {
+  return vi.spyOn(console, 'log').mockImplementation(() => {});
+});
 const consoleErrorSpy = vi.hoisted(() => {
   return vi.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -41,6 +44,7 @@ describe('InstrumentationOverrides Diagnostics Telemetry', () => {
 
   afterEach(() => {
     teardownInstrumentationOverrides();
+    consoleLogSpy.mockClear();
     consoleErrorSpy.mockClear();
     spy.mockClear();
   });
@@ -345,5 +349,60 @@ describe('InstrumentationOverrides Diagnostics Telemetry', () => {
     teardownInstrumentationOverrides();
 
     expect(console.log).not.toBe(wrappedLog);
+  });
+
+  it('serializes Date, RegExp, and nested undefined values safely inside deepCloneSafe', () => {
+    const testDate = new Date('2026-06-09T12:00:00.000Z');
+    const testRegExp = /test-pattern/gi;
+    console.log({
+      date: testDate,
+      regexp: testRegExp,
+      empty: undefined,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          message:
+            '{"date":"2026-06-09T12:00:00.000Z","regexp":"/test-pattern/gi","empty":"undefined"}',
+        }),
+      }),
+    );
+  });
+
+  it('returns early without double-wrapping when setupInstrumentationOverrides is called repeatedly', () => {
+    const currentLog = console.log;
+    setupInstrumentationOverrides(mockSender);
+    expect(console.log).toBe(currentLog);
+  });
+
+  it('captures direct top-level undefined arguments in console calls', () => {
+    console.log(undefined);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: PreviewBridgeMessageType.CONSOLE_LOG,
+        payload: expect.objectContaining({
+          level: 'log',
+          message: 'undefined',
+        }),
+      }),
+    );
+  });
+
+  it('captures direct top-level Error instances and includes their stack trace', () => {
+    const topError = new Error('Direct fatal error');
+    console.log(topError);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: PreviewBridgeMessageType.CONSOLE_LOG,
+        payload: {
+          level: 'log',
+          message: 'Direct fatal error',
+          stack: topError.stack,
+        },
+      }),
+    );
   });
 });

--- a/bridge/src/lit/lit-bridge.spec.ts
+++ b/bridge/src/lit/lit-bridge.spec.ts
@@ -32,6 +32,7 @@ describe('Lit Framework Adapter Spec', () => {
     A2uiSandboxRoot.catalogJson = undefined;
     A2uiSandboxRoot.markdownRenderer = undefined;
     a2uiBridge.destroy();
+    vi.restoreAllMocks();
   });
 
   it('defines custom element using customTagName from options block', () => {
@@ -88,9 +89,7 @@ describe('Lit Framework Adapter Spec', () => {
   it('handles context-request events for A2UIMarkdown and cleanly removes the listener on disconnect', () => {
     bootstrapLitSandbox([dummyCatalog], {
       elementTagName: 'app-root',
-      markdownRenderer: ((text: string) => `<h1>${text}</h1>`) as unknown as (
-        text: string,
-      ) => unknown,
+      markdownRenderer: async (text: string) => `<h1>${text}</h1>`,
     });
 
     const element = new A2uiSandboxRoot();
@@ -123,5 +122,89 @@ describe('Lit Framework Adapter Spec', () => {
 
     element.dispatchEvent(postRemoveEvent);
     expect(afterRemoveRenderer).toBeNull();
+  });
+
+  it('dispatches outbound component actions to a2uiBridge.sendAction', async () => {
+    const sendActionSpy = vi.spyOn(a2uiBridge, 'sendAction');
+    bootstrapLitSandbox([dummyCatalog], {elementTagName: 'app-root'});
+
+    const element = new A2uiSandboxRoot();
+    document.body.appendChild(element);
+
+    const processor = element['processor'] as any;
+
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'surf-action',
+          catalogId: dummyCatalog.id,
+        },
+      },
+    ]);
+
+    const surface = processor.model.getSurface('surf-action');
+    surface['_onAction'].emit({action: {click: true}});
+
+    expect(sendActionSpy).toHaveBeenCalled();
+
+    element.remove();
+  });
+
+  it('renders active a2ui-surface element onSurfaceReady and reverts to waiting banner onSurfaceCleared', () => {
+    bootstrapLitSandbox([dummyCatalog], {elementTagName: 'app-root'});
+    const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
+
+    const element = new A2uiSandboxRoot();
+    document.body.appendChild(element);
+
+    const config = attachSpy.mock.lastCall![1];
+
+    // Initial render is waiting banner
+    let rendered = element.render() as any;
+    expect(rendered.strings.join('')).toContain('A2UI Lit Sandbox active');
+
+    // Trigger onSurfaceReady via real message processing
+    const processor = element['processor'] as any;
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'surf-lit',
+          catalogId: dummyCatalog.id,
+        },
+      },
+    ]);
+
+    const mockSurface = processor.model.getSurface('surf-lit');
+    config.onSurfaceReady('surf-lit');
+
+    expect(element['surface']).toBe(mockSurface);
+
+    rendered = element.render() as any;
+    expect(rendered.strings.join('')).toContain('a2ui-surface');
+
+    // Trigger onSurfaceCleared
+    if (config.onSurfaceCleared) {
+      config.onSurfaceCleared();
+    }
+    expect(element['surface']).toBeUndefined();
+
+    rendered = element.render() as any;
+    expect(rendered.strings.join('')).toContain('A2UI Lit Sandbox active');
+
+    element.remove();
+  });
+
+  it('defines an anonymous subclass if A2uiSandboxRoot constructor is already registered to another tag', () => {
+    bootstrapLitSandbox([dummyCatalog], {elementTagName: 'app-root'});
+    const tag2 = 'app-root-second';
+
+    bootstrapLitSandbox([dummyCatalog], {elementTagName: tag2});
+
+    const ctor = customElements.get(tag2);
+    expect(ctor).toBeDefined();
+    expect(ctor).not.toBe(A2uiSandboxRoot);
+    expect(new ctor!()).toBeInstanceOf(A2uiSandboxRoot);
   });
 });

--- a/bridge/src/preview-bridge.spec.ts
+++ b/bridge/src/preview-bridge.spec.ts
@@ -1667,4 +1667,71 @@ describe('PreviewBridge Core API Runtime', () => {
 
     expect(bridge['overlayElement']).toBeNull();
   });
+
+  it('logs error and returns empty handle when attachRenderer is called with null config', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processor = {processMessages: vi.fn()};
+
+    const handle = bridge.attachRenderer(processor, null as unknown as RendererConfig);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'PreviewBridge: config parameter is required in RendererConfig.',
+    );
+    expect(handle).toBeDefined();
+    expect(() => handle.unsubscribe()).not.toThrow();
+  });
+
+  it('logs error when connection.unsubscribe() throws during bridge.destroy()', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processor = {processMessages: vi.fn()};
+
+    const throwingGroup = {
+      onSurfaceCreated: {
+        subscribe: () => ({
+          unsubscribe: () => {
+            throw new Error('Unsubscribe failed');
+          },
+        }),
+      },
+    };
+
+    bridge.attachRenderer(processor, {
+      surfaceGroup: throwingGroup as unknown as SurfaceGroupLike,
+      onSurfaceReady: vi.fn(),
+    });
+
+    bridge.destroy();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'PreviewBridge: Error during connection unsubscribe:',
+      expect.any(Error),
+    );
+  });
+
+  it('returns empty subscription handle when connectSurfaceGroup is called on a group missing onSurfaceCreated', () => {
+    const handle = bridge['connectSurfaceGroup']({} as SurfaceGroupLike);
+    expect(handle).toBeDefined();
+    expect(() => handle.unsubscribe()).not.toThrow();
+  });
+
+  it('logs error when onCatalogResolved callback throws an unexpected exception', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockGroup = {onSurfaceCreated: {subscribe: vi.fn()}};
+    const processor = {processMessages: vi.fn()};
+
+    bridge.attachRenderer(processor, {
+      surfaceGroup: mockGroup as unknown as SurfaceGroupLike,
+      onSurfaceReady: vi.fn(),
+      onCatalogResolved: () => {
+        throw new Error('Catalog callback crashed');
+      },
+    });
+
+    bridge['notifyCatalogResolved']('urn:a2ui:catalog:test');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'PreviewBridge: Error inside onCatalogResolved callback:',
+      expect.any(Error),
+    );
+  });
 });

--- a/bridge/src/react/react-bridge.spec.ts
+++ b/bridge/src/react/react-bridge.spec.ts
@@ -25,11 +25,12 @@ import {act} from 'react';
 
 describe('React Hook Adapter Spec', () => {
   beforeEach(() => {
-    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   });
 
   afterEach(() => {
     a2uiBridge.destroy();
+    vi.restoreAllMocks();
   });
 
   it('aligns active catalogs array with the resolved catalogId when onCatalogResolved is triggered', async () => {
@@ -67,6 +68,113 @@ describe('React Hook Adapter Spec', () => {
     });
 
     expect(myCatalog.id).toBe('urn:a2ui:catalog:react_resolved_id');
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('updates hook state with active surface onSurfaceReady and resets onSurfaceCleared', async () => {
+    const dummyCatalog = {
+      id: 'https://a2ui.org/specification/v0_9/basic_catalog.json',
+      components: new Map<string, ComponentApi>(),
+    } as unknown as Catalog<ComponentApi>;
+
+    const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
+
+    let renderedSurface: any = undefined;
+
+    function TestComponent() {
+      const {surface} = useA2uiSandbox([dummyCatalog]);
+      renderedSurface = surface;
+      return null;
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(TestComponent));
+    });
+
+    expect(attachSpy).toHaveBeenCalled();
+    const processor = attachSpy.mock.lastCall![0] as any;
+    const config = attachSpy.mock.lastCall![1];
+
+    expect(renderedSurface).toBeUndefined();
+
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'surf-react',
+          catalogId: dummyCatalog.id,
+        },
+      },
+    ]);
+
+    await act(async () => {
+      config.onSurfaceReady('surf-react');
+    });
+
+    expect(renderedSurface).toBeDefined();
+    expect(renderedSurface.id).toBe('surf-react');
+
+    await act(async () => {
+      if (config.onSurfaceCleared) {
+        config.onSurfaceCleared();
+      }
+    });
+
+    expect(renderedSurface).toBeUndefined();
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('dispatches outbound actions triggered within MessageProcessor out to a2uiBridge.sendAction', async () => {
+    const dummyCatalog = {
+      id: 'https://a2ui.org/specification/v0_9/basic_catalog.json',
+      components: new Map<string, ComponentApi>(),
+    } as unknown as Catalog<ComponentApi>;
+
+    const sendActionSpy = vi.spyOn(a2uiBridge, 'sendAction');
+    const attachSpy = vi.spyOn(a2uiBridge, 'attachRenderer');
+
+    function TestComponent() {
+      useA2uiSandbox([dummyCatalog]);
+      return null;
+    }
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(TestComponent));
+    });
+
+    expect(attachSpy).toHaveBeenCalled();
+    const processor = attachSpy.mock.lastCall![0] as any;
+
+    processor.processMessages([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'surf-action',
+          catalogId: dummyCatalog.id,
+        },
+      },
+    ]);
+
+    const surface = processor.model.getSurface('surf-action');
+    surface['_onAction'].emit({action: {click: true}});
+
+    expect(sendActionSpy).toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();

--- a/bridge/vitest.config.ts
+++ b/bridge/vitest.config.ts
@@ -19,5 +19,17 @@ import {defineConfig} from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    coverage: {
+      enabled: true,
+      clean: true,
+      reportsDirectory: './coverage',
+      reporter: ['text', 'html'],
+      thresholds: {
+        lines: 90,
+        functions: 90,
+        branches: 75,
+        statements: 85,
+      },
+    },
   },
 });

--- a/samples/ng-basic-catalog/src/test-setup.ts
+++ b/samples/ng-basic-catalog/src/test-setup.ts
@@ -15,11 +15,8 @@
  */
 
 import {getTestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 
 if (!getTestBed().platform) {
-  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "ng serve",
     "build": "ng build",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "e2e": "playwright test",
     "e2e-headless": "E2E_HEADLESS=true playwright test",
     "prettier": "prettier --ignore-path ../.prettierignore --write . | grep -v '(unchanged)'",

--- a/shell/src/test-setup.ts
+++ b/shell/src/test-setup.ts
@@ -15,10 +15,7 @@
  */
 
 import {getTestBed} from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {webcrypto} from 'node:crypto';
 
 if (typeof window !== 'undefined' && (!window.crypto || !window.crypto.subtle)) {
@@ -29,7 +26,7 @@ if (typeof window !== 'undefined' && (!window.crypto || !window.crypto.subtle)) 
 }
 
 if (!getTestBed().platform) {
-  getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 }
 
 import {beforeEach} from 'vitest';

--- a/shell/vitest.config.ts
+++ b/shell/vitest.config.ts
@@ -23,5 +23,17 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.spec.ts'],
+    coverage: {
+      enabled: true,
+      clean: true,
+      reportsDirectory: './coverage',
+      reporter: ['text', 'html'],
+      thresholds: {
+        lines: 90,
+        functions: 90,
+        branches: 75,
+        statements: 85,
+      },
+    },
   },
 });


### PR DESCRIPTION
# Description

In order to quantify "sufficient" tests in the .agents/testing_and_qa_workflow.md, both `shell` and `bridge` now enforce test coverage numbers.

Added some additional tests in `shell` to bring the coverage up.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
