### PR TITLE
Fix A2UI Catalog postMessage property minification

### DIFF
--- a/bridge/src/bridge-message.ts
+++ b/bridge/src/bridge-message.ts
@@ -31,6 +31,11 @@ export enum PreviewBridgeMessageType {
 
 /**
  * Represents a message structure transmitted across the Preview Bridge iframe boundary.
+ *
+ * NOTE: To prevent compilers from renaming properties during minification in
+ * production builds, all properties of this message must be constructed using
+ * quoted keys (e.g. {'type': ...}) and accessed using bracket notation (e.g.
+ * message['type']) when communicating across compilation boundaries.
  */
 export interface BridgeMessage {
   /** The unique type identifier representing the event. */
@@ -38,5 +43,81 @@ export interface BridgeMessage {
   /** Optional payload data associated with the message event. */
   payload?: unknown;
   /** Extensible custom properties. */
+  [key: string]: unknown;
+}
+
+/** Payload for CONSOLE_LOG message type. */
+export interface ConsoleLogPayload {
+  level: string;
+  message: string;
+  stack?: string;
+}
+
+/** Base interface for all surface layout commands containing surfaceId. */
+export interface BaseSurfaceDetails {
+  surfaceId: string;
+}
+
+/** Inner details for DATA_MODEL_CHANGE payload. */
+export interface UpdateDataModelDetails extends BaseSurfaceDetails {
+  path?: string;
+  value: unknown;
+}
+
+/** Payload for DATA_MODEL_CHANGE message type. */
+export interface DataModelChangePayload {
+  updateDataModel: UpdateDataModelDetails;
+}
+
+/** Payload for SET_BLOCKING_STATE message type. */
+export interface SetBlockingStatePayload {
+  blocked: boolean;
+  message?: string;
+}
+
+/** Details for error in A2UI_CATALOG handshake. */
+export interface CatalogErrorDetails {
+  message: string;
+}
+
+/** Payload for A2UI_CATALOG message type. */
+export interface CatalogHandshakePayload {
+  error?: CatalogErrorDetails;
+  [key: string]: unknown;
+}
+
+/** Payload for SEND_TO_SERVER message type. */
+export interface SendToServerPayload {
+  version: string;
+  action: unknown;
+}
+
+/** Inner details for createSurface command in RENDER_A2UI payload. */
+export interface CreateSurfaceDetails extends BaseSurfaceDetails {
+  catalogId: string;
+  sendDataModel?: boolean;
+}
+
+/** Layout command structure containing createSurface in RENDER_A2UI payload. */
+export interface CreateSurfaceCommand {
+  createSurface?: CreateSurfaceDetails;
+  [key: string]: unknown;
+}
+
+/** Inner details for updateComponents command in RENDER_A2UI payload. */
+export interface UpdateComponentsDetails extends BaseSurfaceDetails {
+  components: unknown[];
+}
+
+/** Inner details for deleteSurface command in RENDER_A2UI payload. */
+export type DeleteSurfaceDetails = BaseSurfaceDetails;
+
+/** Represents a single layout command item inside the RENDER_A2UI array. */
+export interface RenderA2uiItem {
+  version: string;
+  createSurface?: CreateSurfaceDetails;
+  updateComponents?: UpdateComponentsDetails;
+  updateDataModel?: UpdateDataModelDetails;
+  deleteSurface?: DeleteSurfaceDetails;
   [key: string]: unknown;
 }

--- a/bridge/src/instrumentation-overrides.ts
+++ b/bridge/src/instrumentation-overrides.ts
@@ -169,12 +169,14 @@ function overrideConsoleMethods(sender: TelemetrySender): void {
         const errorArg = args.find(arg => arg instanceof Error);
         const stack = errorArg ? (errorArg as Error).stack : undefined;
 
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         sender.sendMessage({
-          type: PreviewBridgeMessageType.CONSOLE_LOG,
-          payload: {
-            level: method,
-            message,
-            stack,
+          'type': PreviewBridgeMessageType.CONSOLE_LOG,
+          'payload': {
+            'level': method,
+            'message': message,
+            'stack': stack,
           },
         });
       } catch (err) {
@@ -199,12 +201,14 @@ function overrideWindowError(sender: TelemetrySender): void {
     error: Error | undefined,
   ): boolean => {
     try {
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       sender.sendMessage({
-        type: PreviewBridgeMessageType.CONSOLE_LOG,
-        payload: {
-          level: 'error',
-          message: String(message),
-          stack: error ? error.stack : `${source || ''}:${lineno || 0}:${colno || 0}`,
+        'type': PreviewBridgeMessageType.CONSOLE_LOG,
+        'payload': {
+          'level': 'error',
+          'message': String(message),
+          'stack': error ? error.stack : `${source || ''}:${lineno || 0}:${colno || 0}`,
         },
       });
     } catch (err) {
@@ -231,12 +235,14 @@ function overrideUnhandledRejection(sender: TelemetrySender): void {
       const message = event.reason instanceof Error ? event.reason.message : String(event.reason);
       const stack = event.reason instanceof Error ? event.reason.stack : undefined;
 
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       sender.sendMessage({
-        type: PreviewBridgeMessageType.CONSOLE_LOG,
-        payload: {
-          level: 'error',
-          message: `Unhandled Rejection: ${message}`,
-          stack,
+        'type': PreviewBridgeMessageType.CONSOLE_LOG,
+        'payload': {
+          'level': 'error',
+          'message': `Unhandled Rejection: ${message}`,
+          'stack': stack,
         },
       });
     } catch (err) {

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -20,7 +20,13 @@ import {
 
 import type {A2uiMessage} from '@a2ui/web_core/v0_9';
 
-import {PreviewBridgeMessageType, BridgeMessage} from './bridge-message';
+import {
+  PreviewBridgeMessageType,
+  BridgeMessage,
+  SetBlockingStatePayload,
+  DataModelChangePayload,
+  CreateSurfaceCommand,
+} from './bridge-message';
 export * from './bridge-message';
 
 import type {
@@ -186,7 +192,11 @@ export class PreviewBridge {
     // bootstrapping and attached its active renderer. This guarantees that the
     // parent receives the ready signal when the sandbox is truly capable of mounting
     // surfaces, structurally eliminating the inter-frame timing race conditions.
-    this.sendMessage({type: PreviewBridgeMessageType.RENDERER_READY});
+    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+    // prettier-ignore
+    this.sendMessage({
+      'type': PreviewBridgeMessageType.RENDERER_READY,
+    });
 
     const attachConnection = {
       unsubscribe: () => {
@@ -260,9 +270,14 @@ export class PreviewBridge {
    * @param [version='v0.9'] The A2UI protocol specification version.
    */
   sendAction(action: unknown, version = 'v0.9'): void {
+    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+    // prettier-ignore
     this.sendMessage({
-      type: PreviewBridgeMessageType.SEND_TO_SERVER,
-      payload: {version, action},
+      'type': PreviewBridgeMessageType.SEND_TO_SERVER,
+      'payload': {
+        'version': version,
+        'action': action,
+      },
     });
   }
 
@@ -278,19 +293,21 @@ export class PreviewBridge {
     if (event.source !== window.parent && event.source !== window) return;
 
     const data = event.data as BridgeMessage;
-    if (!data || typeof data !== 'object' || !data.type) return;
+    // NOTE: Bracket notation is used to access properties on the parsed postMessage event
+    // to prevent compilers from renaming these property accesses during minification.
+    if (!data || typeof data !== 'object' || !data['type']) return;
 
-    switch (data.type) {
+    switch (data['type']) {
       case PreviewBridgeMessageType.SET_BLOCKING_STATE:
-        this.handleSetBlockingState(data.payload);
+        this.handleSetBlockingState(data['payload']);
         break;
 
       case PreviewBridgeMessageType.DATA_MODEL_CHANGE:
-        this.handleIncomingDataModelChange(data.payload);
+        this.handleIncomingDataModelChange(data['payload']);
         break;
 
       case PreviewBridgeMessageType.RENDER_A2UI:
-        this.dispatchRenderA2ui(data.payload !== undefined ? data.payload : data);
+        this.dispatchRenderA2ui(data['payload'] !== undefined ? data['payload'] : data);
         break;
 
       case PreviewBridgeMessageType.GET_CATALOG:
@@ -298,7 +315,7 @@ export class PreviewBridge {
         break;
 
       default:
-        console.warn(`PreviewBridge: Unrecognized incoming message type: ${data.type}`);
+        console.warn(`PreviewBridge: Unrecognized incoming message type: ${data['type']}`);
     }
   };
 
@@ -306,9 +323,11 @@ export class PreviewBridge {
    * Handles incoming blocking overlay requests.
    */
   private handleSetBlockingState(payload: unknown): void {
-    const payloadObj = payload as {blocked?: boolean; message?: string} | undefined;
-    const blocked = !!(payloadObj && payloadObj.blocked);
-    const messageStr = payloadObj && payloadObj.message;
+    // NOTE: Bracket notation is used to access properties on cross-frame message payloads
+    // to prevent compilers from renaming these properties during production minification.
+    const payloadObj = payload as SetBlockingStatePayload | undefined;
+    const blocked = !!(payloadObj && payloadObj['blocked']);
+    const messageStr = payloadObj && payloadObj['message'];
     this.handleBlockingOverlay(blocked, messageStr);
   }
 
@@ -316,12 +335,15 @@ export class PreviewBridge {
    * Dynamic interceptor mapping incoming state changes back into a standard render lifecycle payload.
    */
   private handleIncomingDataModelChange(payload: unknown): void {
-    const payloadObj = payload as {updateDataModel?: unknown} | undefined;
-    if (payloadObj && payloadObj.updateDataModel) {
+    // NOTE: Bracket notation is used to access properties on cross-frame message payloads
+    // to prevent compilers from renaming these properties during production minification.
+    const payloadObj = payload as DataModelChangePayload | undefined;
+    if (payloadObj && payloadObj['updateDataModel']) {
+      // prettier-ignore
       const renderPayload = [
         {
-          version: 'v0.9',
-          updateDataModel: payloadObj.updateDataModel,
+          'version': 'v0.9',
+          'updateDataModel': payloadObj['updateDataModel'],
         },
       ];
       this.dispatchRenderA2ui(renderPayload);
@@ -393,14 +415,18 @@ export class PreviewBridge {
     if (Array.isArray(payload)) {
       const createSurfaceCommand = payload.find(
         (item: unknown) => item && typeof item === 'object' && 'createSurface' in item,
-      ) as {createSurface?: {surfaceId?: string; catalogId?: string}} | undefined;
+      ) as CreateSurfaceCommand | undefined;
 
-      if (createSurfaceCommand && createSurfaceCommand.createSurface) {
-        const catalogId = createSurfaceCommand.createSurface.catalogId;
+      let hasCreateSurface = false;
+      let surfaceId: string | undefined;
+      const createSurface = createSurfaceCommand && createSurfaceCommand['createSurface'];
+      if (createSurface) {
+        hasCreateSurface = true;
+        const catalogId = createSurface['catalogId'];
         if (catalogId) {
           this.notifyCatalogResolved(catalogId);
         }
-        const surfaceId = createSurfaceCommand.createSurface.surfaceId;
+        surfaceId = createSurface['surfaceId'];
         if (surfaceId) {
           // Track the surface BEFORE processing. If a subsequent command in
           // the payload has a typo and throws an error, we still want to
@@ -413,8 +439,8 @@ export class PreviewBridge {
 
       this.activeRenderer.processor.processMessages(payload as A2uiMessage[]);
 
-      if (createSurfaceCommand && createSurfaceCommand.createSurface?.surfaceId) {
-        this.activeRenderer.config.onSurfaceReady(createSurfaceCommand.createSurface.surfaceId);
+      if (hasCreateSurface && surfaceId) {
+        this.activeRenderer.config.onSurfaceReady(surfaceId);
       }
     } else {
       console.warn('PreviewBridge: Unexpected non-array RENDER_A2UI payload received:', payload);
@@ -477,12 +503,14 @@ export class PreviewBridge {
 
         try {
           const modelSub = surface.dataModel.subscribe('', (newValue: unknown) => {
+            // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+            // prettier-ignore
             this.sendMessage({
-              type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
-              payload: {
-                updateDataModel: {
-                  surfaceId: surface.id,
-                  value: newValue,
+              'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,
+              'payload': {
+                'updateDataModel': {
+                  'surfaceId': surface.id,
+                  'value': newValue,
                 },
               },
             });
@@ -576,7 +604,12 @@ export class PreviewBridge {
         });
 
         button.addEventListener('click', () => {
-          this.sendMessage({type: PreviewBridgeMessageType.FORCE_UNBLOCK, payload: {}});
+          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+          // prettier-ignore
+          this.sendMessage({
+            'type': PreviewBridgeMessageType.FORCE_UNBLOCK,
+            'payload': {},
+          });
           this.handleBlockingOverlay(false);
         });
 
@@ -690,23 +723,33 @@ export class PreviewBridge {
 
       const catalog = this.parseCatalogData(resolved.rawData);
 
-      const catalogId = (catalog as {catalogId?: string})?.catalogId;
+      const catalogId = (catalog as Record<string, unknown> | undefined)?.['catalogId'] as
+        | string
+        | undefined;
       if (catalogId) {
         this.notifyCatalogResolved(catalogId);
       }
 
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       this.sendMessage({
-        type: PreviewBridgeMessageType.A2UI_CATALOG,
-        payload: catalog,
+        'type': PreviewBridgeMessageType.A2UI_CATALOG,
+        'payload': catalog,
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       if (resolved?.isInMemory) {
         console.error('PreviewBridge: Error processing/parsing in-memory catalog:', error);
       }
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       this.sendMessage({
-        type: PreviewBridgeMessageType.A2UI_CATALOG,
-        payload: {error: {message: errorMessage}},
+        'type': PreviewBridgeMessageType.A2UI_CATALOG,
+        'payload': {
+          'error': {
+            'message': errorMessage,
+          },
+        },
       });
     }
   }

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -344,8 +344,8 @@ export class ChatCoordinator {
     const catalog = this.catalogManagement.activeCatalog();
     const componentHealMap: Record<string, string> = {};
 
-    if (catalog && catalog.components) {
-      for (const key of Object.keys(catalog.components)) {
+    if (catalog && catalog['components']) {
+      for (const key of Object.keys(catalog['components'])) {
         const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, '');
         componentHealMap[normalizedKey] = key;
       }

--- a/shell/src/app/debug/data-model/data-model.ts
+++ b/shell/src/app/debug/data-model/data-model.ts
@@ -103,13 +103,15 @@ export class DataModel {
         const localStr = JSON.stringify(parsed);
 
         if (incomingStr !== localStr) {
+          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+          // prettier-ignore
           this.hostComm.sendMessage({
-            type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
-            payload: {
-              updateDataModel: {
-                surfaceId: this.lastSurfaceId,
-                path: this.lastPath,
-                value: parsed,
+            'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,
+            'payload': {
+              'updateDataModel': {
+                'surfaceId': this.lastSurfaceId,
+                'path': this.lastPath,
+                'value': parsed,
               },
             },
           });

--- a/shell/src/app/debug/events/events.ts
+++ b/shell/src/app/debug/events/events.ts
@@ -70,9 +70,11 @@ export class Events {
     effect(() => {
       const envelope = this.hostComm.messageStream();
       if (envelope?.type === PreviewBridgeMessageType.SEND_TO_SERVER) {
-        const payload = envelope?.payload as RawServerPayload;
-        if (payload && payload.action) {
-          let action = payload.action;
+        // NOTE: Bracket notation is used to access properties on the parsed postMessage payload
+        // to prevent compiler minification renaming from breaking property reads.
+        const payload = envelope?.payload as RawServerPayload | undefined;
+        if (payload && payload['action']) {
+          let action = payload['action'];
           if (typeof action === 'string') {
             try {
               action = JSON.parse(action);
@@ -81,13 +83,16 @@ export class Events {
             }
           }
           if (action && typeof action === 'object') {
-            const timestamp = action.timestamp || envelope.timestamp;
+            // NOTE: Bracket notation prevents compiler minification renaming of keys that
+            // originate from external cross-frame events.
+            const actionObj = action as RawActionDetails;
+            const timestamp = actionObj['timestamp'] || envelope.timestamp;
             const mappedItem = {
               time: formatTimestamp(timestamp),
-              action: action.name || '',
-              surface: action.surfaceId || '',
-              component: action.sourceComponentId || action.sourceComponent || '',
-              context: action.context || action.contextParameters || null,
+              action: actionObj['name'] || '',
+              surface: actionObj['surfaceId'] || '',
+              component: actionObj['sourceComponentId'] || actionObj['sourceComponent'] || '',
+              context: actionObj['context'] || actionObj['contextParameters'] || null,
             };
             untracked(() => {
               this.eventsLog.update(logs => {

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -86,10 +86,12 @@ export class ComposerWorkspace implements OnInit {
     this.hostComm.messageStream$.pipe(takeUntilDestroyed()).subscribe(envelope => {
       if (!envelope) return;
 
-      const payload = envelope.payload as WorkspaceMessagePayload;
+      // NOTE: Bracket notation is used to access properties on cross-frame message payloads
+      // to prevent compilers from renaming these properties during production minification.
+      const payload = envelope.payload as WorkspaceMessagePayload | undefined;
       const activeTab = this.selectedTabIndex();
 
-      if (envelope.type === PreviewBridgeMessageType.SEND_TO_SERVER && payload?.action) {
+      if (envelope.type === PreviewBridgeMessageType.SEND_TO_SERVER && payload?.['action']) {
         if (activeTab !== EVENTS_TAB_INDEX) {
           this.unreadEventsCount.update(count => count + 1);
         }
@@ -99,9 +101,9 @@ export class ComposerWorkspace implements OnInit {
         }
       } else if (
         envelope.type === PreviewBridgeMessageType.DATA_MODEL_CHANGE &&
-        payload?.validationErrors
+        payload?.['validationErrors']
       ) {
-        const validationErrors = payload.validationErrors;
+        const validationErrors = payload['validationErrors'];
         const hasErrors = Array.isArray(validationErrors)
           ? validationErrors.length > 0
           : typeof validationErrors === 'object' && validationErrors !== null

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {
+  PreviewBridgeMessageType,
+  RenderA2uiItem,
+  BaseSurfaceDetails,
+  CreateSurfaceDetails,
+  UpdateComponentsDetails,
+  UpdateDataModelDetails,
+} from 'a2ui-bridge';
 
 /**
  * Hardens postMessage channels by validating outgoing layout schemas,
@@ -27,15 +34,20 @@ export class CrossFrameValidator {
       return false;
     }
 
-    if (typeof message.type !== 'string' || !message.type.trim()) {
+    // NOTE: Bracket notation is used to access properties on the incoming message object
+    // to prevent compilers from renaming these property accesses during minification.
+    const msgType = message['type'];
+    const msgPayload = message['payload'];
+
+    if (typeof msgType !== 'string' || !msgType.trim()) {
       console.error('Malformed message: type must be a non-empty string.');
       return false;
     }
 
-    switch (message.type) {
+    switch (msgType) {
       case PreviewBridgeMessageType.GET_CATALOG: {
-        if (message.payload !== undefined && message.payload !== null) {
-          if (typeof message.payload !== 'object' || Array.isArray(message.payload)) {
+        if (msgPayload !== undefined && msgPayload !== null) {
+          if (typeof msgPayload !== 'object' || Array.isArray(msgPayload)) {
             console.error(
               'Malformed payload for GET_CATALOG: must be an object, null, or undefined.',
             );
@@ -46,18 +58,18 @@ export class CrossFrameValidator {
       }
 
       case PreviewBridgeMessageType.RENDER_A2UI: {
-        if (!message.payload || !Array.isArray(message.payload)) {
+        if (!msgPayload || !Array.isArray(msgPayload)) {
           console.error('Malformed payload for RENDER_A2UI: must be an Array.');
           return false;
         }
 
-        for (const item of message.payload) {
+        for (const item of msgPayload) {
           if (!item || typeof item !== 'object' || Array.isArray(item)) {
             console.error('Malformed payload for RENDER_A2UI: array items must be objects.');
             return false;
           }
 
-          const itemObj = item as Record<string, unknown>;
+          const itemObj = item as RenderA2uiItem;
           if (itemObj['version'] !== 'v0.9') {
             console.error(
               'Malformed payload for RENDER_A2UI: array items must specify version "v0.9".',
@@ -99,8 +111,8 @@ export class CrossFrameValidator {
             return false;
           }
 
-          const u = updateObj as Record<string, unknown>;
-          if (typeof u['surfaceId'] !== 'string') {
+          const updateData = updateObj as BaseSurfaceDetails;
+          if (typeof updateData['surfaceId'] !== 'string') {
             console.error(
               `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
             );
@@ -108,26 +120,31 @@ export class CrossFrameValidator {
           }
 
           if (updateType === 'createSurface') {
-            if (typeof u['catalogId'] !== 'string') {
+            const createDetails = updateObj as CreateSurfaceDetails;
+            if (typeof createDetails['catalogId'] !== 'string') {
               console.error(
                 'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
               );
               return false;
             }
-            if (u['sendDataModel'] !== undefined && typeof u['sendDataModel'] !== 'boolean') {
+            if (
+              createDetails['sendDataModel'] !== undefined &&
+              typeof createDetails['sendDataModel'] !== 'boolean'
+            ) {
               console.error(
                 'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
               );
               return false;
             }
           } else if (updateType === 'updateComponents') {
-            if (!Array.isArray(u['components'])) {
+            const updateCompDetails = updateObj as UpdateComponentsDetails;
+            if (!Array.isArray(updateCompDetails['components'])) {
               console.error(
                 'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
               );
               return false;
             }
-            for (const comp of u['components']) {
+            for (const comp of updateCompDetails['components']) {
               if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
                 console.error(
                   'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
@@ -136,7 +153,11 @@ export class CrossFrameValidator {
               }
             }
           } else if (updateType === 'updateDataModel') {
-            if (u['path'] !== undefined && typeof u['path'] !== 'string') {
+            const updateModelDetails = updateObj as UpdateDataModelDetails;
+            if (
+              updateModelDetails['path'] !== undefined &&
+              typeof updateModelDetails['path'] !== 'string'
+            ) {
               console.error(
                 'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
               );
@@ -148,23 +169,22 @@ export class CrossFrameValidator {
       }
 
       case PreviewBridgeMessageType.SET_BLOCKING_STATE: {
-        if (
-          !message.payload ||
-          typeof message.payload !== 'object' ||
-          Array.isArray(message.payload)
-        ) {
+        if (!msgPayload || typeof msgPayload !== 'object' || Array.isArray(msgPayload)) {
           console.error('Malformed payload for SET_BLOCKING_STATE: must be an object.');
           return false;
         }
 
-        const p = message.payload as Record<string, unknown>;
-        if (typeof p['blocked'] !== 'boolean') {
+        const blockingState = msgPayload as Record<string, unknown>;
+        if (typeof blockingState['blocked'] !== 'boolean') {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: must contain boolean property blocked.',
           );
           return false;
         }
-        if (p['message'] !== undefined && typeof p['message'] !== 'string') {
+        if (
+          blockingState['message'] !== undefined &&
+          typeof blockingState['message'] !== 'string'
+        ) {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: message property must be a string if present.',
           );
@@ -174,17 +194,13 @@ export class CrossFrameValidator {
       }
 
       case PreviewBridgeMessageType.DATA_MODEL_CHANGE: {
-        if (
-          !message.payload ||
-          typeof message.payload !== 'object' ||
-          Array.isArray(message.payload)
-        ) {
+        if (!msgPayload || typeof msgPayload !== 'object' || Array.isArray(msgPayload)) {
           console.error('Malformed payload for DATA_MODEL_CHANGE: must be an object.');
           return false;
         }
 
-        const p = message.payload as Record<string, unknown>;
-        const updateObj = p['updateDataModel'];
+        const changePayload = msgPayload as Record<string, unknown>;
+        const updateObj = changePayload['updateDataModel'];
         if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: must contain an updateDataModel object.',
@@ -192,14 +208,14 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const u = updateObj as Record<string, unknown>;
-        if (typeof u['surfaceId'] !== 'string') {
+        const updateData = updateObj as Record<string, unknown>;
+        if (typeof updateData['surfaceId'] !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel must contain a valid surfaceId string.',
           );
           return false;
         }
-        if (u['path'] !== undefined && typeof u['path'] !== 'string') {
+        if (updateData['path'] !== undefined && typeof updateData['path'] !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel path must be a string if present.',
           );
@@ -209,7 +225,7 @@ export class CrossFrameValidator {
       }
 
       default: {
-        console.warn(`Unrecognized message type: ${message.type}`);
+        console.warn(`Unrecognized message type: ${msgType}`);
         return true;
       }
     }

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -128,11 +128,13 @@ export class HostCommunication implements OnDestroy {
   private readonly messageListener = (event: MessageEvent) => {
     const activeWindow = this.iframeElement ? this.iframeElement.contentWindow : this.iframeWindow;
     if (!activeWindow) {
+      // NOTE: Bracket notation is used to access properties on the incoming postMessage event
+      // to prevent compilers from renaming these property accesses during minification.
       const isBridgeMessage =
         event.data &&
         typeof event.data === 'object' &&
-        Object.values(PreviewBridgeMessageType).includes(event.data.type);
-      if (!isBridgeMessage || event.data.type === PreviewBridgeMessageType.CONSOLE_LOG) {
+        Object.values(PreviewBridgeMessageType).includes(event.data['type']);
+      if (!isBridgeMessage || event.data['type'] === PreviewBridgeMessageType.CONSOLE_LOG) {
         return;
       }
       this.earlyMessageBuffer.push(event);
@@ -160,11 +162,13 @@ export class HostCommunication implements OnDestroy {
     }
 
     const data = event.data;
-    if (data && typeof data === 'object' && data.type) {
-      const type = data.type;
+    // NOTE: Bracket notation is used to access properties on the incoming postMessage event
+    // to prevent compilers from renaming these property accesses during minification.
+    if (data && typeof data === 'object' && data['type']) {
+      const type = data['type'] as string;
       const envelope: MessageEnvelope = {
         type,
-        payload: data.payload,
+        payload: data['payload'],
         origin: event.origin,
         timestamp: Date.now(),
       };
@@ -262,7 +266,12 @@ export class HostCommunication implements OnDestroy {
    * @param payload Array of layout nodes or configuration objects
    */
   sendRenderA2UI(payload: unknown[]): void {
-    this.sendMessage({type: PreviewBridgeMessageType.RENDER_A2UI, payload});
+    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+    // prettier-ignore
+    this.sendMessage({
+      'type': PreviewBridgeMessageType.RENDER_A2UI,
+      'payload': payload,
+    });
   }
 
   ngOnDestroy(): void {

--- a/shell/src/app/storage/catalog-management/catalog-management.spec.ts
+++ b/shell/src/app/storage/catalog-management/catalog-management.spec.ts
@@ -611,4 +611,28 @@ describe('CatalogManagement', () => {
     expect(service.catalogError()).toBeNull();
     expect(service.isHandshakeInProgress()).toBe(false);
   });
+
+  it('correctly resolves and sanitizes title and description from raw postMessage catalog payload using bracket notation', async () => {
+    // prettier-ignore
+    const payload = {
+      'title': 'Test Title <b>Bold</b>',
+      'description': 'Test Description <i>Italic</i>',
+      'catalogId': 'custom-catalog-id',
+      'components': {},
+    };
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.A2UI_CATALOG,
+      origin: 'http://localhost',
+      payload,
+      timestamp: 2005,
+    });
+    TestBed.tick();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(service.activeCatalogTitle()).toBe('Test Title <b>Bold</b>');
+    expect(service.activeCatalogDescription()).toBe('Test Description <i>Italic</i>');
+    expect(service.activeCatalog()?.['catalogId']).toBe('custom-catalog-id');
+  });
 });

--- a/shell/src/app/storage/catalog-management/catalog-management.ts
+++ b/shell/src/app/storage/catalog-management/catalog-management.ts
@@ -136,8 +136,10 @@ export class CatalogManagement {
             this._isHandshakeInProgress.set(true);
             this._watchdogFired.set(false);
             this._catalogError.set(null);
+            // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+            // prettier-ignore
             this.hostCommunication.sendMessage({
-              type: PreviewBridgeMessageType.GET_CATALOG,
+              'type': PreviewBridgeMessageType.GET_CATALOG,
             });
 
             this.watchdogTimerId = setTimeout(() => {
@@ -170,14 +172,16 @@ export class CatalogManagement {
               return of(null);
             }
 
+            // NOTE: Bracket notation is used to access properties on cross-frame message payloads
+            // to prevent compilers from renaming these properties during production minification.
             const payload = rawPayload as {
               error?: {message?: string};
             } & Catalog;
+            const errorObj = payload['error'];
 
-            if (payload.error) {
+            if (errorObj) {
               const errorMsg =
-                payload.error.message ||
-                'Unknown error occurred in preview bridge during handshake.';
+                errorObj['message'] || 'Unknown error occurred in preview bridge during handshake.';
               this._catalogError.set(errorMsg);
               console.error('Handshake failed with bridge error:', errorMsg);
               this._isHandshakeInProgress.set(false);
@@ -188,11 +192,11 @@ export class CatalogManagement {
             let catalogString: string;
             try {
               catalogObj = structuredClone(payload as Catalog);
-              if (typeof catalogObj.title === 'string') {
-                catalogObj.title = sanitizeHtml(catalogObj.title).toString();
+              if (typeof catalogObj['title'] === 'string') {
+                catalogObj['title'] = sanitizeHtml(catalogObj['title']).toString();
               }
-              if (typeof catalogObj.description === 'string') {
-                catalogObj.description = sanitizeHtml(catalogObj.description).toString();
+              if (typeof catalogObj['description'] === 'string') {
+                catalogObj['description'] = sanitizeHtml(catalogObj['description']).toString();
               }
               catalogString = stableStringify(catalogObj);
             } catch (err: unknown) {
@@ -245,8 +249,8 @@ export class CatalogManagement {
                   }
 
                   this._activeCatalog.set(catalogObj);
-                  this._activeCatalogTitle.set(catalogObj.title || '');
-                  this._activeCatalogDescription.set(catalogObj.description || '');
+                  this._activeCatalogTitle.set(catalogObj['title'] || '');
+                  this._activeCatalogDescription.set(catalogObj['description'] || '');
 
                   this._catalogError.set(null);
                   this._isHandshakeInProgress.set(false);


### PR DESCRIPTION
# Description

Use quoted keys ('type', 'payload') for cross-frame message objects and bracket notation to access properties on the receiver side. This prevents compilers from renaming properties in production builds, which causes handshake failures when communicating between minified and unminified contexts.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
