### PR TITLE
add material icons stylesheet link in basic catalog index

### DIFF
--- a/samples/ng-basic-catalog/src/index.html
+++ b/samples/ng-basic-catalog/src/index.html
@@ -20,6 +20,9 @@
     <meta charset="utf-8" />
     <title>A2UI Basic Catalog Angular Sandbox</title>
     <base href="/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>


### PR DESCRIPTION
# Description

Enables correct rendering of material icons inside the sandboxed preview iframe running the ng-basic-catalog app.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
