### PR TITLE
Gallery 1 shell link

### DIFF
--- a/shell/e2e/workspace-routing-bootstrapping.e2e.ts
+++ b/shell/e2e/workspace-routing-bootstrapping.e2e.ts
@@ -40,13 +40,11 @@ test.describe('Workspace Navigation & Layout Modes', () => {
     });
   });
 
-  test('verifies components gallery navigation link is conditionally hidden by default', async ({
-    page,
-  }) => {
+  test('verifies components gallery navigation link is visible by default', async ({page}) => {
     await page.goto('/');
 
     const galleryLink = page.getByRole('link', {name: 'Components Gallery'});
-    await expect(galleryLink).toBeHidden();
+    await expect(galleryLink).toBeVisible();
   });
 
   test('loads components gallery view successfully via direct URL navigation', async ({

--- a/shell/src/app/shell/composer-shell/composer-shell.ng.html
+++ b/shell/src/app/shell/composer-shell/composer-shell.ng.html
@@ -45,9 +45,7 @@
   <mat-sidenav #sidenav mode="side" opened class="composer-sidenav">
     <mat-nav-list>
       <a mat-list-item routerLink="/">Composer Workspace</a>
-      @if (showComponentsGallery()) {
-        <a mat-list-item routerLink="/gallery">Components Gallery</a>
-      }
+      <a mat-list-item routerLink="/gallery">Components Gallery</a>
       <a mat-list-item routerLink="/settings">Settings</a>
     </mat-nav-list>
   </mat-sidenav>

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -189,6 +188,11 @@ describe('ComposerShell Layout', () => {
 
     await harness.clickThemeToggleButton();
     expect(configProviderMock.setThemePreference).toHaveBeenCalledWith('light');
+  });
+
+  it('renders the Components Gallery navigation link in the sidebar by default', async () => {
+    const links = await harness.getNavigationLinksText();
+    expect(links).toContain('Components Gallery');
   });
 
   it('applies aria-hidden attribute to purely decorative MatIcon elements across the composer shell', async () => {

--- a/shell/src/app/shell/composer-shell/composer-shell.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.ts
@@ -1,5 +1,4 @@
 /**
- * @license
  * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, computed, effect, inject, signal} from '@angular/core';
+import {Component, computed, effect, inject} from '@angular/core';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatButtonModule} from '@angular/material/button';
@@ -73,8 +72,6 @@ export class ComposerShell {
       }
     });
   }
-
-  showComponentsGallery = signal(false);
 
   /**
    * Switches between light and dark visual design system palettes.

--- a/shell/src/app/shell/composer-shell/test/composer-shell.harness.ts
+++ b/shell/src/app/shell/composer-shell/test/composer-shell.harness.ts
@@ -17,7 +17,11 @@
 import {ComponentHarness} from '@angular/cdk/testing';
 import {MatSidenavHarness} from '@angular/material/sidenav/testing';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing';
+import {MatNavListHarness} from '@angular/material/list/testing';
 
+/**
+ * Test harness for testing the `ComposerShell` component.
+ */
 export class ComposerShellHarness extends ComponentHarness {
   static hostSelector = 'a2ui-composer-shell';
 
@@ -27,6 +31,7 @@ export class ComposerShellHarness extends ComponentHarness {
   private getSidenav = this.locatorFor(MatSidenavHarness);
   private getResetButton = this.locatorFor('button.reset-session-button');
   private getHeaderTooltip = this.locatorFor(MatTooltipHarness);
+  private getNavList = this.locatorFor(MatNavListHarness);
 
   async getHeaderTitleText(): Promise<string> {
     const title = await this.getHeaderTitle();
@@ -57,6 +62,12 @@ export class ComposerShellHarness extends ComponentHarness {
   async isSidenavOpened(): Promise<boolean> {
     const sidenav = await this.getSidenav();
     return sidenav.isOpen();
+  }
+
+  async getNavigationLinksText(): Promise<string[]> {
+    const list = await this.getNavList();
+    const items = await list.getItems();
+    return Promise.all(items.map(item => item.getFullText()));
   }
 
   async getIconsAriaHidden(): Promise<(string | null)[]> {


### PR DESCRIPTION
# Description

Remove the showComponentsGallery signal to expose the components gallery link in the primary navigation sidebar.

This is the first in a series of PRs which culminates in a dynamically generated page to show the components of the current catalog: 
<img width="1586" height="961" alt="image" src="https://github.com/user-attachments/assets/1fd0b818-8c81-4a9e-a926-3d0057551944" />


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
