### PR TITLE
Gallery 3 catalog service

### DIFF
--- a/shell/src/app/gallery/services/default-presets.ts
+++ b/shell/src/app/gallery/services/default-presets.ts
@@ -1,0 +1,220 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pre-defined rich visual component rendering presets.
+ * Maps component types to A2UI structures/configurations.
+ */
+export const DEFAULT_PRESETS: Record<string, unknown> = {
+  AudioPlayer: [
+    {
+      id: 'target',
+      component: 'AudioPlayer',
+      url: 'https://www.w3schools.com/html/horse.mp3',
+      description: 'Audio Clip',
+    },
+  ],
+  Button: [
+    {
+      id: 'target',
+      component: 'Button',
+      child: 'ButtonLabel',
+      event: {
+        name: 'submit',
+        context: [
+          {
+            key: 'formId',
+            value: 'contact-form',
+          },
+        ],
+      },
+    },
+    {
+      id: 'ButtonLabel',
+      component: 'Text',
+      text: 'Click Me',
+    },
+  ],
+  Card: [
+    {
+      id: 'target',
+      component: 'Card',
+      child: 'CardContent',
+    },
+    {
+      id: 'CardContent',
+      component: 'Text',
+      text: 'This is card content.',
+    },
+  ],
+  CheckBox: [
+    {
+      id: 'target',
+      component: 'CheckBox',
+      label: 'I agree to the terms',
+      value: false,
+    },
+  ],
+  ChoicePicker: [
+    {
+      id: 'target',
+      component: 'ChoicePicker',
+      label: 'Select your role',
+      options: [
+        {label: 'Admin', value: 'admin'},
+        {label: 'Editor', value: 'editor'},
+        {label: 'Viewer', value: 'viewer'},
+      ],
+      value: ['viewer'],
+    },
+  ],
+  Column: [
+    {
+      id: 'target',
+      component: 'Column',
+      children: ['ColItem1', 'ColItem2'],
+    },
+    {
+      id: 'ColItem1',
+      component: 'Text',
+      text: 'Vertical Item 1',
+    },
+    {
+      id: 'ColItem2',
+      component: 'Text',
+      text: 'Vertical Item 2',
+    },
+  ],
+  DateTimeInput: [
+    {
+      id: 'target',
+      component: 'DateTimeInput',
+      label: 'Meeting Time',
+      value: '2026-06-16T12:00:00Z',
+      enableDate: true,
+      enableTime: true,
+    },
+  ],
+  Divider: [
+    {
+      id: 'target',
+      component: 'Divider',
+      axis: 'horizontal',
+    },
+  ],
+  Icon: [
+    {
+      id: 'target',
+      component: 'Icon',
+      name: 'home',
+    },
+  ],
+  Image: [
+    {
+      id: 'target',
+      component: 'Image',
+      url: 'https://images.unsplash.com/photo-1579783900882-c0d3dad7b119',
+      description: 'Visual Artwork',
+    },
+  ],
+  List: [
+    {
+      id: 'target',
+      component: 'List',
+      children: ['list-item-1', 'list-item-2'],
+    },
+    {
+      id: 'list-item-1',
+      component: 'Text',
+      text: 'List Item One',
+    },
+    {
+      id: 'list-item-2',
+      component: 'Text',
+      text: 'List Item Two',
+    },
+  ],
+  Row: [
+    {
+      id: 'target',
+      component: 'Row',
+      children: ['RowItem1', 'RowItem2'],
+    },
+    {
+      id: 'RowItem1',
+      component: 'Text',
+      text: 'Horizontal Item 1',
+    },
+    {
+      id: 'RowItem2',
+      component: 'Text',
+      text: 'Horizontal Item 2',
+    },
+  ],
+  Slider: [
+    {
+      id: 'target',
+      component: 'Slider',
+      label: 'Volume',
+      min: 0,
+      max: 100,
+      value: 50,
+    },
+  ],
+  Tabs: [
+    {
+      id: 'target',
+      component: 'Tabs',
+      tabs: [
+        {title: 'Tab One', child: 'tab-content-1'},
+        {title: 'Tab Two', child: 'tab-content-2'},
+      ],
+    },
+    {
+      id: 'tab-content-1',
+      component: 'Text',
+      text: 'Content of Tab One',
+    },
+    {
+      id: 'tab-content-2',
+      component: 'Text',
+      text: 'Content of Tab Two',
+    },
+  ],
+  Text: [
+    {
+      id: 'target',
+      component: 'Text',
+      text: 'Headline Large (H1)',
+      variant: 'h1',
+    },
+  ],
+  TextField: [
+    {
+      id: 'target',
+      component: 'TextField',
+      label: 'Username',
+      variant: 'shortText',
+    },
+  ],
+  Video: [
+    {
+      id: 'target',
+      component: 'Video',
+      url: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    },
+  ],
+};

--- a/shell/src/app/gallery/services/gallery-catalog.spec.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.spec.ts
@@ -1,0 +1,726 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {signal} from '@angular/core';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {GalleryCatalog} from './gallery-catalog';
+import {Catalog} from '../../storage/models/catalog-storage.model';
+import {DEFAULT_PRESETS} from './default-presets';
+
+class MockCatalogManagement {
+  readonly activeCatalog = signal<Catalog | null>(null);
+}
+
+describe('GalleryCatalog', () => {
+  let service: GalleryCatalog;
+  let catalogManagementMock: MockCatalogManagement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GalleryCatalog, {provide: CatalogManagement, useClass: MockCatalogManagement}],
+    });
+
+    service = TestBed.inject(GalleryCatalog);
+    catalogManagementMock = TestBed.inject(CatalogManagement) as unknown as MockCatalogManagement;
+  });
+
+  it('starts with selected component key set to null', () => {
+    expect(service.selectedComponentKey()).toBeNull();
+  });
+
+  it('updates selected component key when selectComponent is called', () => {
+    service.selectComponent('Text');
+    expect(service.selectedComponentKey()).toBe('Text');
+
+    service.selectComponent(null);
+    expect(service.selectedComponentKey()).toBeNull();
+  });
+
+  it('categorizes and alphabetizes components from the active catalog correctly', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Column: {type: 'object'},
+        Row: {type: 'object'},
+        Text: {type: 'object'},
+        Button: {type: 'object'},
+        ChoicePicker: {type: 'object'},
+        Alert: {type: 'object'},
+        CustomComp: {type: 'object'},
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    const list = service.componentsList();
+    expect(list).toEqual([
+      {
+        category: 'Layout',
+        components: ['Column', 'Row'],
+      },
+      {
+        category: 'Content',
+        components: ['Text'],
+      },
+      {
+        category: 'Input',
+        components: ['Button', 'ChoicePicker'],
+      },
+      {
+        category: 'Feedback',
+        components: ['Alert'],
+      },
+      {
+        category: 'Other',
+        components: ['CustomComp'],
+      },
+    ]);
+  });
+
+  it('returns empty array for componentsList when catalog or components are null', () => {
+    catalogManagementMock.activeCatalog.set(null);
+    expect(service.componentsList()).toEqual([]);
+
+    catalogManagementMock.activeCatalog.set({});
+    expect(service.componentsList()).toEqual([]);
+  });
+
+  it('returns empty properties and null preset when no component is selected', () => {
+    expect(service.selectedComponentProperties()).toEqual([]);
+    expect(service.selectedComponentPreset()).toBeNull();
+  });
+
+  it('retrieves visual preset from static mock presets list if it exists', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+            variant: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Text');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Text',
+        text: 'Headline Large (H1)',
+        variant: 'h1',
+      },
+    ]);
+  });
+
+  it('generates dynamic fallback presets for components lacking static presets using required properties of all types', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        CustomComp: {
+          type: 'object',
+          properties: {
+            id: {type: 'string'},
+            reqStr: {type: 'string'},
+            reqNum: {type: 'number'},
+            reqInt: {type: 'integer'},
+            reqUnion: {type: 'boolean | string'},
+            reqBool: {type: 'boolean'},
+            reqArr: {type: 'array'},
+            reqObj: {type: 'object'},
+            reqUnknown: {type: 'anything-else'},
+            optBool: {type: 'boolean'},
+          },
+          required: [
+            'id',
+            'reqStr',
+            'reqNum',
+            'reqInt',
+            'reqUnion',
+            'reqBool',
+            'reqArr',
+            'reqObj',
+            'reqUnknown',
+          ],
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('CustomComp');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'CustomComp',
+        reqStr: '',
+        reqNum: 0,
+        reqInt: 0,
+        reqUnion: false,
+        reqBool: false,
+        reqArr: [],
+        reqObj: {},
+        reqUnknown: null,
+      },
+    ]);
+  });
+
+  it('delivers a deep copy of the visual preset to prevent global mutation', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+            variant: {type: 'string'},
+          },
+        },
+        Column: {type: 'object'},
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Text');
+
+    const preset1 = service.selectedComponentPreset() as Record<string, unknown>[];
+    preset1[0]['text'] = 'Mutated Title'; // Mutate the returned object
+
+    // Toggle selection to trigger computed re-evaluation when selecting Text again
+    service.selectComponent('Column');
+    service.selectedComponentPreset();
+
+    service.selectComponent('Text');
+    const preset2 = service.selectedComponentPreset() as Record<string, unknown>[];
+    expect(preset2[0]['text']).toBe('Headline Large (H1)'); // Original is untouched
+  });
+
+  it('categorizes components with Material prefix correctly using keyword matching', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        MaterialText: {type: 'object'},
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    expect(service.componentsList()).toEqual([
+      {
+        category: 'Content',
+        components: ['MaterialText'],
+      },
+    ]);
+  });
+
+  it('categorizes other prefixes and handles case insensitivity', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        AntTabs: {type: 'object'},
+        NzDateTimePicker: {type: 'object'},
+        nztimepicker: {type: 'object'},
+        tabs: {type: 'object'},
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    const list = service.componentsList();
+    expect(list).toEqual([
+      {
+        category: 'Layout',
+        components: ['AntTabs', 'tabs'],
+      },
+      {
+        category: 'Input',
+        components: ['NzDateTimePicker', 'nztimepicker'],
+      },
+    ]);
+  });
+
+  it('respects priority order when component contains multiple keywords', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        ButtonRow: {type: 'object'}, // matches "button" (Input) and "row" (Layout)
+        TextAlert: {type: 'object'}, // matches "text" (Content) and "alert" (Feedback)
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    const list = service.componentsList();
+    expect(list).toEqual([
+      {
+        category: 'Input',
+        components: ['ButtonRow'], // Input > Layout
+      },
+      {
+        category: 'Feedback',
+        components: ['TextAlert'], // Feedback > Content
+      },
+    ]);
+  });
+
+  it('serializes an empty array preset directly as JSON inside selectedComponentUsage', () => {
+    DEFAULT_PRESETS['EmptyArrComp'] = [];
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          EmptyArrComp: {type: 'object'},
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('EmptyArrComp');
+
+      const usage = service.selectedComponentUsage();
+      expect(JSON.parse(usage)).toEqual([]);
+    } finally {
+      delete DEFAULT_PRESETS['EmptyArrComp'];
+    }
+  });
+
+  it('serializes a single-component preset directly inside selectedComponentUsage', () => {
+    const mockCatalog: Catalog = {
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+            variant: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Text');
+
+    const usage = service.selectedComponentUsage();
+    const parsed = JSON.parse(usage);
+
+    expect(parsed).toEqual([
+      {
+        id: 'target',
+        component: 'Text',
+        text: 'Headline Large (H1)',
+        variant: 'h1',
+      },
+    ]);
+  });
+
+  it('serializes an array preset directly inside selectedComponentUsage', () => {
+    const mockCatalog: Catalog = {
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Row: {
+          type: 'object',
+          properties: {
+            children: {type: 'array'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Row');
+
+    const usage = service.selectedComponentUsage();
+    const parsed = JSON.parse(usage);
+
+    expect(parsed).toEqual([
+      {
+        id: 'target',
+        component: 'Row',
+        children: ['RowItem1', 'RowItem2'],
+      },
+      {
+        id: 'RowItem1',
+        component: 'Text',
+        text: 'Horizontal Item 1',
+      },
+      {
+        id: 'RowItem2',
+        component: 'Text',
+        text: 'Horizontal Item 2',
+      },
+    ]);
+  });
+
+  it('returns empty string inside selectedComponentUsage when no component is selected', () => {
+    expect(service.selectedComponentUsage()).toBe('');
+  });
+
+  it('handles scenario when a component is selected but active catalog is null', () => {
+    service.selectComponent('CustomComp');
+    catalogManagementMock.activeCatalog.set(null);
+
+    expect(service.selectedComponentProperties()).toEqual([]);
+    expect(service.selectedComponentPreset()).toEqual([{id: 'target', component: 'CustomComp'}]);
+    expect(service.selectedComponentUsage()).not.toBe('');
+  });
+
+  it('resolves preset for vendor-prefixed components using normalized names', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        MaterialText: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+            variant: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('MaterialText');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'MaterialText',
+        text: 'Headline Large (H1)',
+        variant: 'h1',
+      },
+    ]);
+  });
+
+  it('generates fallback preset with child elements when children property is an array and Text component exists', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        CustomContainer: {
+          type: 'object',
+          properties: {
+            children: {
+              type: 'array',
+              items: {type: 'string'},
+            },
+            requiredProp: {type: 'string'},
+          },
+          required: ['requiredProp'],
+        },
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('CustomContainer');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'CustomContainer',
+        requiredProp: '',
+        children: ['target-child-0'],
+      },
+      {
+        id: 'target-child-0',
+        component: 'Text',
+        text: 'Child Element',
+      },
+    ]);
+  });
+
+  it('omits child fallback elements if Text component does not exist in the catalog', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        CustomContainer: {
+          type: 'object',
+          properties: {
+            children: {
+              type: 'array',
+              items: {type: 'string'},
+            },
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('CustomContainer');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'CustomContainer',
+      },
+    ]);
+  });
+
+  it('propagates parent library prefix to nested child components in static presets', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        MaterialRow: {
+          type: 'object',
+          properties: {
+            children: {type: 'array'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('MaterialRow');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'MaterialRow',
+        children: ['RowItem1', 'RowItem2'],
+      },
+      {
+        id: 'RowItem1',
+        component: 'MaterialText',
+        text: 'Horizontal Item 1',
+      },
+      {
+        id: 'RowItem2',
+        component: 'MaterialText',
+        text: 'Horizontal Item 2',
+      },
+    ]);
+  });
+
+  it('generates dynamic fallback child components with prefix when selecting MaterialList (forcing fallback)', () => {
+    const originalListPreset = DEFAULT_PRESETS['List'];
+    delete DEFAULT_PRESETS['List'];
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          MaterialList: {
+            type: 'object',
+            properties: {
+              children: {
+                type: 'array',
+                items: {type: 'string'},
+              },
+            },
+          },
+          MaterialText: {
+            type: 'object',
+            properties: {
+              text: {type: 'string'},
+            },
+          },
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('MaterialList');
+
+      const preset = service.selectedComponentPreset();
+      expect(preset).toEqual([
+        {
+          id: 'target',
+          component: 'MaterialList',
+          children: ['target-child-0'],
+        },
+        {
+          id: 'target-child-0',
+          component: 'MaterialText',
+          text: 'Child Element',
+        },
+      ]);
+    } finally {
+      DEFAULT_PRESETS['List'] = originalListPreset;
+    }
+  });
+
+  it('strips properties not defined in the component schema from visual presets', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Text');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Text',
+        text: 'Headline Large (H1)',
+      },
+    ]);
+  });
+
+  it('prunes child components from preset if children property is stripped', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Row: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Row');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Row',
+      },
+    ]);
+  });
+
+  it('prunes child component from preset if child property is stripped', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Card: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Card');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Card',
+      },
+    ]);
+  });
+
+  it('prunes child components from preset if tabs property is stripped', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Tabs: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Tabs');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Tabs',
+      },
+    ]);
+  });
+
+  it('ignores non-string component names when propagating prefixes in presets', () => {
+    DEFAULT_PRESETS['TestBadComponent'] = [
+      {id: 'target', component: 'TestBadComponent'},
+      {id: 'child-1', component: 123}, // invalid component type
+      {id: 'child-2'}, // missing component property
+    ];
+
+    try {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'mock-id',
+        components: {
+          MaterialTestBadComponent: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      });
+
+      service.selectComponent('MaterialTestBadComponent');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset() as Record<string, unknown>[];
+      expect(preset).toBeTruthy();
+      expect(preset[1]['component']).toBe(123);
+      expect(preset[2]['component']).toBeUndefined();
+    } finally {
+      delete DEFAULT_PRESETS['TestBadComponent'];
+    }
+  });
+
+  it('ignores non-string child IDs when pruning children', () => {
+    DEFAULT_PRESETS['TestBadChildren'] = [
+      {id: 'target', component: 'TestBadChildren', children: ['child-1', 123, null]},
+      {id: 'child-1', component: 'Text'},
+    ];
+
+    try {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'mock-id',
+        components: {
+          TestBadChildren: {
+            type: 'object',
+            properties: {}, // empty properties strips children
+          },
+        },
+      });
+
+      service.selectComponent('TestBadChildren');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset() as Record<string, unknown>[];
+      // child-1 should be pruned since it was a string child ID, target should be stripped of children
+      expect(preset.length).toBe(1);
+      expect(preset[0]['id']).toBe('target');
+      expect(preset[0]['children']).toBeUndefined();
+    } finally {
+      delete DEFAULT_PRESETS['TestBadChildren'];
+    }
+  });
+
+  it('ignores invalid tab configs when pruning tab child components', () => {
+    DEFAULT_PRESETS['TestBadTabs'] = [
+      {
+        id: 'target',
+        component: 'TestBadTabs',
+        tabs: [
+          null,
+          123,
+          {label: 'Tab 1'},
+          {label: 'Tab 2', child: 123},
+          {label: 'Tab 3', child: 'child-1'},
+        ],
+      },
+      {id: 'child-1', component: 'Text'},
+    ];
+
+    try {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'mock-id',
+        components: {
+          TestBadTabs: {
+            type: 'object',
+            properties: {}, // empty properties strips tabs
+          },
+        },
+      });
+
+      service.selectComponent('TestBadTabs');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset() as Record<string, unknown>[];
+      // child-1 should be pruned (referenced by tab 3 child string), target should be stripped of tabs
+      expect(preset.length).toBe(1);
+      expect(preset[0]['id']).toBe('target');
+      expect(preset[0]['tabs']).toBeUndefined();
+    } finally {
+      delete DEFAULT_PRESETS['TestBadTabs'];
+    }
+  });
+});

--- a/shell/src/app/gallery/services/gallery-catalog.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.ts
@@ -1,0 +1,425 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable, inject, signal, computed} from '@angular/core';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {CatalogSchemaResolver, ParsedProperty} from '../schema/catalog-schema-resolver';
+import {DEFAULT_PRESETS} from './default-presets';
+
+/**
+ * Represents components grouped under a specific category name.
+ */
+export interface CategorizedComponents {
+  /** The visual/functional category of the components. */
+  category: string;
+  /** Sorted list of component keys belonging to this category. */
+  components: string[];
+}
+
+interface CategoryRule {
+  category: string;
+  keywords: string[];
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    category: 'Input',
+    keywords: [
+      'button',
+      'btn',
+      'input',
+      'field',
+      'check',
+      'select',
+      'pick',
+      'slide',
+      'date',
+      'time',
+      'switch',
+      'toggle',
+      'form',
+      'search',
+      'upload',
+      'radio',
+      'area',
+    ],
+  },
+  {
+    category: 'Feedback',
+    keywords: [
+      'progress',
+      'spinner',
+      'alert',
+      'snackbar',
+      'banner',
+      'toast',
+      'message',
+      'loading',
+      'loader',
+    ],
+  },
+  {
+    category: 'Layout',
+    keywords: [
+      'row',
+      'column',
+      'grid',
+      'list',
+      'card',
+      'tab',
+      'modal',
+      'drawer',
+      'sheet',
+      'panel',
+      'surface',
+      'box',
+      'flex',
+      'container',
+      'accordion',
+      'expansion',
+      'sidenav',
+      'nav',
+    ],
+  },
+  {
+    category: 'Content',
+    keywords: [
+      'text',
+      'image',
+      'img',
+      'icon',
+      'video',
+      'audio',
+      'divider',
+      'separator',
+      'avatar',
+      'chip',
+      'badge',
+      'link',
+      'label',
+      'header',
+      'footer',
+      'title',
+      'paragraph',
+      'heading',
+    ],
+  },
+];
+
+const CATEGORIES_ORDER = ['Layout', 'Content', 'Input', 'Feedback', 'Other'];
+
+/**
+ * Resolves the visual category for a component using rule-based keyword mapping.
+ *
+ * @param key The component key.
+ * @returns The category string (e.g. 'Layout', 'Content', 'Input', 'Feedback', 'Other').
+ */
+function getCategoryForComponent(key: string): string {
+  const lowerKey = key.toLowerCase();
+  for (const rule of CATEGORY_RULES) {
+    for (const keyword of rule.keywords) {
+      if (lowerKey.includes(keyword)) {
+        return rule.category;
+      }
+    }
+  }
+  return 'Other';
+}
+
+/**
+ * Coordinates visual gallery state including component categories, selections,
+ * schema property resolutions, visual presets, and usage snippet generations.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class GalleryCatalog {
+  private readonly catalogManagement = inject(CatalogManagement);
+
+  /**
+   * Resolves schema for the active catalog.
+   */
+  readonly catalogSchemaResolver = computed(() => {
+    const catalog = this.catalogManagement.activeCatalog();
+    return catalog ? new CatalogSchemaResolver(catalog) : null;
+  });
+
+  private readonly _selectedComponentKey = signal<string | null>(null);
+  /** The actively selected component key. */
+  readonly selectedComponentKey = this._selectedComponentKey.asReadonly();
+
+  /**
+   * Sorts and groups all components in the active catalog into categories.
+   */
+  readonly componentsList = computed<CategorizedComponents[]>(() => {
+    const catalog = this.catalogManagement.activeCatalog();
+    if (catalog == null || catalog['components'] == null) {
+      return [];
+    }
+
+    const grouped: Record<string, string[]> = {
+      Layout: [],
+      Content: [],
+      Input: [],
+      Feedback: [],
+      Other: [],
+    };
+
+    for (const key of Object.keys(catalog['components'])) {
+      const cat = getCategoryForComponent(key);
+      grouped[cat].push(key);
+    }
+
+    return CATEGORIES_ORDER.map(category => ({
+      category,
+      components: [...grouped[category]].sort(),
+    })).filter(item => item.components.length > 0);
+  });
+
+  /**
+   * Resolves and parses property specifications for the selected component.
+   */
+  readonly selectedComponentProperties = computed<ParsedProperty[]>(() => {
+    const key = this.selectedComponentKey();
+    const resolver = this.catalogSchemaResolver();
+    if (!key || !resolver) {
+      return [];
+    }
+    return resolver.resolveComponentProperties(key);
+  });
+
+  readonly selectedComponentPreset = computed<Record<string, unknown>[] | null>(() => {
+    const key = this.selectedComponentKey();
+    if (!key) {
+      return null;
+    }
+
+    const {prefix, normalizedName} = this.parseComponentName(key);
+    let preset = this.resolveStaticPreset(key, prefix, normalizedName);
+    if (!preset) {
+      preset = this.generateFallbackPreset(key, prefix);
+    }
+
+    return this.validateAndPrunePreset(preset);
+  });
+
+  /**
+   * Returns a formatted JSON string of the preset array.
+   */
+  readonly selectedComponentUsage = computed<string>(() => {
+    const key = this.selectedComponentKey();
+    if (!key) {
+      return '';
+    }
+
+    const preset = this.selectedComponentPreset();
+    return JSON.stringify(preset, null, 2);
+  });
+
+  /**
+   * Sets the actively selected component key.
+   *
+   * @param key The component name or null to deselect.
+   */
+  selectComponent(key: string | null): void {
+    this._selectedComponentKey.set(key);
+  }
+
+  /**
+   * Resolves a static preset from DEFAULT_PRESETS if it exists.
+   *
+   * @param key The selected component key (e.g. 'materialButton').
+   * @param prefix The library prefix (e.g. 'material').
+   * @param normalizedKey The normalized key without prefix (e.g. 'Button').
+   * @returns The resolved static preset with prefix propagated to child components, or null if no preset exists.
+   */
+  private resolveStaticPreset(
+    key: string,
+    prefix: string,
+    normalizedKey: string,
+  ): Record<string, unknown>[] | null {
+    if (!DEFAULT_PRESETS[normalizedKey]) {
+      return null;
+    }
+
+    // We clone the preset to avoid mutating the shared DEFAULT_PRESETS object.
+    const preset = structuredClone(DEFAULT_PRESETS[normalizedKey]) as Record<string, unknown>[];
+
+    // Prefix propagation: static presets in DEFAULT_PRESETS use prefix-less component names
+    // for children to remain library-agnostic. We must restore the active prefix here
+    // so they resolve to correct library implementations (e.g., 'Text' -> 'materialText').
+    for (const item of preset) {
+      if (item['id'] === 'target') {
+        item['component'] = key;
+      } else if (typeof item['component'] === 'string') {
+        item['component'] = `${prefix}${item['component']}`;
+      }
+    }
+    return preset;
+  }
+
+  /**
+   * Generates a fallback preset when no static preset is defined.
+   *
+   * @param key The selected component key.
+   * @param prefix The library prefix.
+   * @returns A generated preset with required properties populated and default children linked if supported.
+   */
+  private generateFallbackPreset(key: string, prefix: string): Record<string, unknown>[] {
+    const props = this.selectedComponentProperties();
+    const fallback: Record<string, unknown> = {
+      id: 'target',
+      component: key,
+    };
+
+    let hasChildren = false;
+    let childrenPropType = '';
+
+    // Inspect schema to find required properties and check if it accepts children.
+    for (const prop of props) {
+      if (prop.name === 'children') {
+        hasChildren = true;
+        childrenPropType = prop.type;
+      }
+      if (
+        prop.required &&
+        prop.name !== 'component' &&
+        prop.name !== 'children' &&
+        prop.name !== 'id'
+      ) {
+        fallback[prop.name] = this.getDefaultValueForType(prop.type);
+      }
+    }
+
+    // If the component accepts a children array, we link a default child component.
+    // This provides a better out-of-the-box visual representation in the gallery.
+    if (hasChildren && childrenPropType.includes('array')) {
+      const textComponent = `${prefix}Text`;
+      const catalog = this.catalogManagement.activeCatalog();
+      const textComponentExists = !!(
+        catalog?.components &&
+        Object.prototype.hasOwnProperty.call(catalog.components, textComponent)
+      );
+
+      if (textComponentExists) {
+        const childId = 'target-child-0';
+        const childFallback: Record<string, unknown> = {
+          id: childId,
+          component: textComponent,
+          text: 'Child Element',
+        };
+        fallback['children'] = [childId];
+        return [fallback, childFallback];
+      }
+    }
+
+    return [fallback];
+  }
+
+  /**
+   * Validates the preset against the catalog schema and prunes orphaned child components.
+   *
+   * Checking against valid properties in the catalog schema prevents guest rendering crashes
+   * because passing invalid properties to components might cause them to throw errors during rendering.
+   *
+   * We prune orphaned child components to clean up the preset array when their parent reference is removed.
+   *
+   * @param preset The preset to validate and prune.
+   * @returns The cleaned preset.
+   */
+  private validateAndPrunePreset(preset: Record<string, unknown>[]): Record<string, unknown>[] {
+    const validProps = new Set(this.selectedComponentProperties().map(p => p.name));
+    validProps.add('id');
+    validProps.add('component');
+
+    const targetItem = preset.find(item => item['id'] === 'target');
+    if (!targetItem) {
+      return preset;
+    }
+
+    const keysToDelete: string[] = [];
+    for (const key of Object.keys(targetItem)) {
+      if (!validProps.has(key)) {
+        keysToDelete.push(key);
+      }
+    }
+
+    const childIdsToPrune = new Set<string>();
+
+    for (const key of keysToDelete) {
+      if (key === 'children' && Array.isArray(targetItem['children'])) {
+        for (const id of targetItem['children']) {
+          if (typeof id === 'string') {
+            childIdsToPrune.add(id);
+          }
+        }
+      } else if (key === 'child' && typeof targetItem['child'] === 'string') {
+        childIdsToPrune.add(targetItem['child']);
+      } else if (key === 'tabs' && Array.isArray(targetItem['tabs'])) {
+        for (const tab of targetItem['tabs']) {
+          if (
+            tab &&
+            typeof tab === 'object' &&
+            'child' in tab &&
+            typeof (tab as Record<string, unknown>)['child'] === 'string'
+          ) {
+            childIdsToPrune.add((tab as Record<string, unknown>)['child'] as string);
+          }
+        }
+      }
+      delete targetItem[key];
+    }
+
+    if (childIdsToPrune.size > 0) {
+      return preset.filter(item => !childIdsToPrune.has(item['id'] as string));
+    }
+
+    return preset;
+  }
+
+  private parseComponentName(name: string): {prefix: string; normalizedName: string} {
+    const match = name.match(/^(material|ant|nz|mdc|ui|my)/i);
+    const prefix = match ? match[0] : '';
+    const normalizedName = name.slice(prefix.length);
+    return {prefix, normalizedName};
+  }
+
+  /**
+   * Resolves a default value for a given schema type string.
+   * Handles union types by taking the first type in the union.
+   *
+   * @param type The schema type (e.g., 'string', 'number', 'string | number').
+   * @returns A default value matching the type, or null if unsupported.
+   */
+  private getDefaultValueForType(type: string): unknown {
+    const primaryType = type.split('|')[0].trim();
+    switch (primaryType) {
+      case 'string':
+        return '';
+      case 'number':
+      case 'integer':
+        return 0;
+      case 'boolean':
+        return false;
+      case 'array':
+        return [];
+      case 'object':
+        return {};
+      default:
+        return null;
+    }
+  }
+}


### PR DESCRIPTION
# Description

implement gallery catalog state service and visual presets

Adds GalleryCatalogService to maintain component selection and cache parsed schema properties. Groups components into sorted categories and maps selection to usage JSON payloads using mock presets.

This is the 3rd in a series of PRs which culminates in a dynamically generated page to show the components of the current catalog: 
<img width="1586" height="961" alt="image" src="https://github.com/user-attachments/assets/1fd0b818-8c81-4a9e-a926-3d0057551944" />


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

