### PR TITLE
Gallery 4 UI layout

### DIFF
--- a/shell/e2e/workspace-routing-bootstrapping.e2e.ts
+++ b/shell/e2e/workspace-routing-bootstrapping.e2e.ts
@@ -52,11 +52,11 @@ test.describe('Workspace Navigation & Layout Modes', () => {
   }, testInfo) => {
     await page.goto('/gallery');
 
-    const galleryPlaceholder = page.locator('.gallery-placeholder');
-    await expect(galleryPlaceholder).toBeVisible();
-    await expect(galleryPlaceholder).toContainText('Components Gallery Placeholder');
+    const galleryContainer = page.locator('.gallery-container');
+    await expect(galleryContainer).toBeVisible();
+    await expect(page.getByRole('heading', {name: 'No Component Selected'})).toBeVisible();
     const screenshotBuffer = await page.screenshot();
-    await testInfo.attach('gallery-placeholder-direct', {
+    await testInfo.attach('gallery-container-direct', {
       body: screenshotBuffer,
       contentType: 'image/png',
     });

--- a/shell/src/app/gallery/gallery.ng.html
+++ b/shell/src/app/gallery/gallery.ng.html
@@ -14,4 +14,140 @@
  limitations under the License.
 -->
 
-<div class="gallery-placeholder">Components Gallery Placeholder</div>
+<mat-sidenav-container class="gallery-container">
+  <mat-sidenav mode="side" opened class="gallery-sidenav">
+    <mat-nav-list class="catalog-list">
+      @for (group of componentsList(); track group.category) {
+        <div mat-subheader class="category-header">{{ group.category }}</div>
+        @for (comp of group.components; track comp) {
+          <button
+            mat-list-item
+            [activated]="comp === selectedComponentKey()"
+            (click)="selectComponent(comp)"
+            class="component-nav-item"
+          >
+            <span matListItemTitle>{{ comp }}</span>
+          </button>
+        }
+      }
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content class="gallery-content">
+    <div [class.hidden-frame]="!selectedComponentKey()">
+      <mat-card class="preview-card">
+        <mat-card-header>
+          <mat-card-title>Preview</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <a2ui-composer-rendered-frame></a2ui-composer-rendered-frame>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    @if (selectedComponentKey() && catalogManagement.activeCatalog()) {
+      <div class="details-panel">
+        <div class="details-header">
+          <h2 class="component-title">{{ selectedComponentKey() }}</h2>
+          @if (selectedComponentDescription()) {
+            <p class="component-description">{{ selectedComponentDescription() }}</p>
+          }
+        </div>
+
+        <mat-card class="usage-card">
+          <mat-card-header class="usage-header">
+            <mat-card-title>Usage</mat-card-title>
+            <button
+              mat-icon-button
+              (click)="copyToClipboard()"
+              aria-label="Copy to Clipboard"
+              class="copy-button"
+            >
+              <mat-icon>content_copy</mat-icon>
+            </button>
+          </mat-card-header>
+          <mat-card-content>
+            <pre
+              class="usage-code-block"
+            ><code class="usage-code">{{ selectedComponentUsage() }}</code></pre>
+          </mat-card-content>
+        </mat-card>
+
+        <mat-card class="properties-card">
+          <mat-card-header>
+            <mat-card-title>Properties</mat-card-title>
+          </mat-card-header>
+          <mat-card-content class="properties-content">
+            <table mat-table [dataSource]="selectedComponentProperties()" class="properties-table">
+              <!-- Name Column -->
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef>Name</th>
+                <td mat-cell *matCellDef="let prop" class="prop-name">{{ prop.name }}</td>
+              </ng-container>
+
+              <!-- Description Column -->
+              <ng-container matColumnDef="description">
+                <th mat-header-cell *matHeaderCellDef>Description</th>
+                <td mat-cell *matCellDef="let prop" class="prop-description">
+                  {{ prop.description || '-' }}
+                </td>
+              </ng-container>
+
+              <!-- Type Column -->
+              <ng-container matColumnDef="type">
+                <th mat-header-cell *matHeaderCellDef>Type</th>
+                <td mat-cell *matCellDef="let prop" class="prop-type">
+                  <code>{{ prop.type }}</code>
+                </td>
+              </ng-container>
+
+              <!-- Required Column -->
+              <ng-container matColumnDef="required">
+                <th mat-header-cell *matHeaderCellDef>Required</th>
+                <td mat-cell *matCellDef="let prop" class="prop-required">
+                  @if (prop.required) {
+                    <mat-icon color="primary">check_circle</mat-icon>
+                  } @else {
+                    <span class="optional-label">optional</span>
+                  }
+                </td>
+              </ng-container>
+
+              <!-- Default Value Column -->
+              <ng-container matColumnDef="defaultValue">
+                <th mat-header-cell *matHeaderCellDef>Default</th>
+                <td mat-cell *matCellDef="let prop" class="prop-default">
+                  @if (prop.defaultValue !== undefined) {
+                    <code>{{ prop.defaultValue | json }}</code>
+                  } @else {
+                    -
+                  }
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+            </table>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    } @else if (catalogManagement.catalogError()) {
+      <div class="empty-state error-state">
+        <mat-icon class="empty-icon text-danger">error_outline</mat-icon>
+        <h3 class="empty-title">Catalog Configuration Required</h3>
+        <p class="empty-subtitle">
+          {{ catalogManagement.catalogError() }}
+        </p>
+      </div>
+    } @else {
+      <div class="empty-state">
+        <mat-icon class="empty-icon">analytics</mat-icon>
+        <h3 class="empty-title">No Component Selected</h3>
+        <p class="empty-subtitle">
+          Choose a component from the sidebar catalog to view its schema details, presets, and usage
+          snippet.
+        </p>
+      </div>
+    }
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/shell/src/app/gallery/gallery.scss
+++ b/shell/src/app/gallery/gallery.scss
@@ -14,4 +14,222 @@
  * limitations under the License.
  */
 
-/* Gallery placeholder styles */
+.gallery-container {
+  height: 100%;
+  width: 100%;
+}
+
+.gallery-sidenav {
+  width: 240px;
+  border-right: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  background-color: var(--mat-sys-surface-container-low, #fcfcfc);
+}
+
+.catalog-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--mat-sys-on-surface, #1c1b1f);
+}
+
+.gallery-sidenav .catalog-list {
+  .category-header {
+    font: var(--mat-sys-typescale-label-medium);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+  }
+
+  .component-nav-item {
+    display: flex;
+    justify-content: flex-start;
+    text-align: left;
+    border: none;
+    background: transparent;
+    border-radius: 20px;
+    margin: 2px 12px;
+    padding-left: 12px;
+    width: calc(100% - 24px);
+    box-sizing: border-box;
+    --mdc-list-list-item-container-height: 36px;
+    cursor: pointer;
+
+    ::ng-deep .mdc-list-item__content {
+      text-align: left;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: var(--mat-sys-surface-container-low, #f2f2f2);
+    }
+
+    &.mat-mdc-list-item-activated,
+    &[activated='true'] {
+      background-color: var(--mat-sys-surface-container-high, #e2e2e2);
+
+      span[matListItemTitle] {
+        font-weight: 500;
+      }
+    }
+
+    span[matListItemTitle] {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: block;
+    }
+  }
+}
+
+.gallery-content {
+  padding: 24px;
+  background-color: var(--mat-sys-background, #fafafa);
+  overflow-y: auto;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 80%;
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant, #666);
+}
+
+.empty-icon {
+  font-size: 48px;
+  height: 48px;
+  width: 48px;
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.empty-title {
+  margin: 0 0 8px 0;
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+.empty-subtitle {
+  margin: 0;
+  max-width: 400px;
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.details-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.details-header {
+  border-bottom: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  padding-bottom: 16px;
+}
+
+.component-title {
+  margin: 0 0 8px 0;
+  font-size: 1.75rem;
+  font-weight: 400;
+}
+
+.component-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--mat-sys-on-surface-variant, #49454f);
+  line-height: 1.4;
+}
+
+.preview-card,
+.usage-card,
+.properties-card {
+  border-radius: 8px;
+  border: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  background-color: var(--mat-sys-surface, #ffffff);
+}
+
+.preview-placeholder {
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--mat-sys-surface-container-highest, #f0f0f0);
+  border: 2px dashed var(--mat-sys-outline-variant, #e0e0e0);
+  border-radius: 4px;
+  font-style: italic;
+  color: var(--mat-sys-on-surface-variant, #777);
+}
+
+.usage-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 8px;
+}
+
+.copy-button {
+  color: var(--mat-sys-primary, #6750a4);
+}
+
+.usage-code-block {
+  margin: 0;
+  padding: 12px;
+  background-color: var(--mat-sys-surface-container-high, #f5f5f5);
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.usage-code {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--mat-sys-on-surface, #333);
+}
+
+.properties-table {
+  width: 100%;
+  background: transparent;
+
+  th {
+    font-weight: 600;
+  }
+
+  .prop-name {
+    font-weight: 500;
+    color: var(--mat-sys-primary, #6750a4);
+  }
+
+  .prop-type code {
+    background-color: var(--mat-sys-surface-container-high, #f0f0f0);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+  }
+
+  .prop-required {
+    mat-icon {
+      font-size: 18px;
+      height: 18px;
+      width: 18px;
+    }
+  }
+
+  .optional-label {
+    font-size: 0.8rem;
+    font-style: italic;
+    opacity: 0.6;
+  }
+
+  .prop-default code {
+    background-color: var(--mat-sys-surface-container-high, #f0f0f0);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+  }
+}
+
+.hidden-frame {
+  display: none;
+}

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -15,26 +15,573 @@
  */
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {Gallery} from './gallery';
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {signal} from '@angular/core';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {Gallery} from './gallery';
 import {GalleryHarness} from './test/gallery.harness';
-import {describe, it, expect, beforeEach} from 'vitest';
+import {GalleryCatalog, CategorizedComponents} from './services/gallery-catalog';
+import {CatalogManagement} from '../storage/catalog-management/catalog-management';
+import {ParsedProperty} from './schema/catalog-schema-resolver';
+import {Catalog} from '../storage/models/catalog-storage.model';
+import {HostCommunication} from '../shell/host-communication/host-communication';
 
-describe('Gallery Placeholder', () => {
+interface TestFriendlyGallery {
+  catalogId: () => string | null;
+  selectedComponentDescription: () => string;
+  copyToClipboard: () => void;
+}
+
+class MockGalleryCatalogService {
+  readonly componentsList = signal<CategorizedComponents[]>([]);
+  readonly selectedComponentKey = signal<string | null>(null);
+  readonly selectedComponentProperties = signal<ParsedProperty[]>([]);
+  readonly selectedComponentUsage = signal<string>('');
+
+  selectComponent = vi.fn((key: string | null) => {
+    this.selectedComponentKey.set(key);
+  });
+}
+
+class MockCatalogManagement {
+  readonly activeCatalog = signal<Catalog | null>(null);
+  readonly catalogError = signal<string | null>(null);
+}
+
+class MockHostCommunication {
+  sendRenderA2UI = vi.fn();
+}
+
+describe('Gallery Component', () => {
   let fixture: ComponentFixture<Gallery>;
   let harness: GalleryHarness;
+  let catalogServiceMock: MockGalleryCatalogService;
+  let catalogManagementMock: MockCatalogManagement;
+  let hostCommunicationMock: MockHostCommunication;
+  let writeTextSpy: ReturnType<typeof vi.fn>;
+  let originalClipboard: typeof navigator.clipboard;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Gallery],
+      providers: [
+        provideNoopAnimations(),
+        {provide: GalleryCatalog, useClass: MockGalleryCatalogService},
+        {provide: CatalogManagement, useClass: MockCatalogManagement},
+        {provide: HostCommunication, useClass: MockHostCommunication},
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Gallery);
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, GalleryHarness);
+
+    catalogServiceMock = TestBed.inject(GalleryCatalog) as unknown as MockGalleryCatalogService;
+    catalogManagementMock = TestBed.inject(CatalogManagement) as unknown as MockCatalogManagement;
+    hostCommunicationMock = TestBed.inject(HostCommunication) as unknown as MockHostCommunication;
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/default_catalog.json',
+      components: {
+        Text: {type: 'object'},
+        Row: {type: 'object'},
+        Column: {type: 'object'},
+      },
+    });
+
+    writeTextSpy = vi.fn();
+    originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {writeText: writeTextSpy},
+      configurable: true,
+      writable: true,
+    });
   });
 
-  it('creates the gallery placeholder component via test harness', async () => {
-    expect(harness).toBeTruthy();
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', {value: originalClipboard});
+    }
+  });
+
+  it('renders components list grouped by categories and sorted alphabetically by default', async () => {
+    catalogServiceMock.componentsList.set([
+      {category: 'Layout', components: ['Column', 'Row']},
+      {category: 'Content', components: ['Text']},
+    ]);
+    fixture.detectChanges();
+
+    const headers = await harness.getCategoryHeadersText();
+    expect(headers).toEqual(['Layout', 'Content']);
+
+    const links = await harness.getNavigationLinksText();
+    expect(links).toEqual(['Column', 'Row', 'Text']);
+  });
+
+  it('calls selectComponent on the catalog service when a sidebar navigation link is clicked', async () => {
+    catalogServiceMock.componentsList.set([{category: 'Content', components: ['Text']}]);
+    fixture.detectChanges();
+
+    await harness.clickNavigationLink('Text');
+    expect(catalogServiceMock.selectComponent).toHaveBeenCalledWith('Text');
+  });
+
+  it('updates the details card header with name and description when a component is selected', async () => {
+    const mockCatalog: Catalog = {
+      catalogId: 'https://a2ui.org/default_catalog.json',
+      components: {
+        Text: {
+          type: 'object',
+          description: 'A text block.',
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const title = await harness.getSelectedComponentTitle();
+    const description = await harness.getSelectedComponentDescription();
+
+    expect(title).toBe('Text');
+    expect(description).toBe('A text block.');
+  });
+
+  it('renders correct properties inside the properties table', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentProperties.set([
+      {
+        name: 'text',
+        description: 'The content string.',
+        type: 'string',
+        required: true,
+        defaultValue: 'hello',
+      },
+      {
+        name: 'variant',
+        description: 'The typographic scale.',
+        type: 'string',
+        required: false,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const data = await harness.getPropertiesTableData();
+    expect(data.length).toBe(2);
+    expect(data[0]).toEqual({
+      name: 'text',
+      description: 'The content string.',
+      type: 'string',
+      required: 'check_circle',
+      defaultValue: '"hello"',
+    });
+    expect(data[1]).toEqual({
+      name: 'variant',
+      description: 'The typographic scale.',
+      type: 'string',
+      required: 'optional',
+      defaultValue: '-',
+    });
+  });
+
+  it('renders the usage JSON envelope and copies the formatted A2UI JSONLines payload to the clipboard', async () => {
+    writeTextSpy.mockResolvedValue(undefined);
+
+    const mockCatalog: Catalog = {
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {},
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    const mockComponents = [{id: 'target', component: 'Text'}];
+    const mockUsage = JSON.stringify(mockComponents, null, 2);
+    catalogServiceMock.selectedComponentUsage.set(mockUsage);
+    fixture.detectChanges();
+
+    const usageText = await harness.getUsageCodeText();
+    expect(usageText).toBe(mockUsage);
+
+    await harness.clickCopyButton();
+
+    const expectedPayload =
+      `{"version":"v0.9","createSurface":{"surfaceId":"gallery-preview","catalogId":"https://a2ui.org/custom_catalog.json"}}\n` +
+      `{"version":"v0.9","updateComponents":{"surfaceId":"gallery-preview","components":[{"id":"target","component":"Text"}]}}`;
+
+    expect(writeTextSpy).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('displays empty state illustration when no component is selected', async () => {
+    catalogServiceMock.selectedComponentKey.set(null);
+    fixture.detectChanges();
+
+    const title = await harness.getSelectedComponentTitle();
+    expect(title).toBeNull();
+
+    const desc = await harness.getSelectedComponentDescription();
+    expect(desc).toBeNull();
+
+    const usage = await harness.getUsageCodeText();
+    expect(usage).toBeNull();
+
+    const placeholderText = await harness.getEmptyStateSubtitleText();
+    expect(placeholderText).toContain('Choose a component from the sidebar catalog');
+  });
+
+  it('updates the details card header with name and empty description when component has no description', async () => {
+    const mockCatalog: Catalog = {
+      catalogId: 'https://a2ui.org/default_catalog.json',
+      components: {
+        Text: {
+          type: 'object',
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const title = await harness.getSelectedComponentTitle();
+    expect(title).toBe('Text');
+
+    const description = await harness.getSelectedComponentDescription();
+    expect(description).toBeNull();
+  });
+
+  it('logs an error to the console when copying to the clipboard fails', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    writeTextSpy.mockRejectedValue(new Error('Clipboard error'));
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set('[]');
+    fixture.detectChanges();
+
+    await harness.clickCopyButton();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to copy A2UI component usage to clipboard: ',
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs an error and returns gracefully when clipboard API is completely unavailable', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set('[]');
+    fixture.detectChanges();
+
+    await harness.clickCopyButton();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Clipboard API is not available in this environment.',
+    );
+    expect(writeTextSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs an error to the console when copying malformed JSON usage to the clipboard', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set('{invalid-json}');
+    fixture.detectChanges();
+
+    await harness.clickCopyButton();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to parse or format A2UI usage payload: ',
+      expect.any(SyntaxError),
+    );
+    expect(writeTextSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs an error to the console when copying a non-array JSON usage to the clipboard', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set('{"not": "an array"}');
+    fixture.detectChanges();
+
+    await harness.clickCopyButton();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to parse or format A2UI usage payload: ',
+      expect.any(Error),
+    );
+    expect(writeTextSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('throws an error in the harness when trying to click a non-existent navigation link', async () => {
+    await expect(harness.clickNavigationLink('NonExistent')).rejects.toThrow(
+      'Could not find navigation link with text: "NonExistent"',
+    );
+  });
+
+  it('throws an error in the harness when trying to click copy button in empty state', async () => {
+    catalogServiceMock.selectedComponentKey.set(null);
+    fixture.detectChanges();
+
+    await expect(harness.clickCopyButton()).rejects.toThrow('Clipboard copy button is not present');
+  });
+
+  it('returns an empty array in the harness when reading table rows in empty state', async () => {
+    catalogServiceMock.selectedComponentKey.set(null);
+    fixture.detectChanges();
+
+    const data = await harness.getPropertiesTableData();
+    expect(data).toEqual([]);
+  });
+
+  it('does not attempt to copy to the clipboard if selectedComponentUsage resolves to an empty string', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set('');
+    fixture.detectChanges();
+
+    await harness.clickCopyButton();
+
+    expect(writeTextSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null for empty state subtitle when a component is selected', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const subtitleText = await harness.getEmptyStateSubtitleText();
+    expect(subtitleText).toBeNull();
+  });
+
+  it('renders the details cards with updated header titles', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const titles = await harness.getCardTitlesText();
+    expect(titles).toEqual(['Preview', 'Usage', 'Properties']);
+  });
+
+  it('displays catalog configuration error state when catalogError is set', async () => {
+    catalogManagementMock.catalogError.set('Mock Catalog Error: Connection Failed');
+    fixture.detectChanges();
+
+    const placeholderText = await harness.getEmptyStateSubtitleText();
+    expect(placeholderText).toContain('Mock Catalog Error: Connection Failed');
+  });
+
+  it('dispatches the rendering payload to HostCommunication when selection changes', async () => {
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    // Since 'Column' is in the default mock catalog, it should wrap it
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/default_catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: [
+            {id: 'root', component: 'Column', children: ['target']},
+            {id: 'target', component: 'Text'},
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('does not wrap in Column layout if Column is not defined in the catalog', async () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Text: {type: 'object'},
+      }, // No Column component
+    });
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/custom_catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: [{id: 'target', component: 'Text'}],
+        },
+      },
+    ]);
+  });
+
+  it('logs an error when rendering effect fails to parse component usage JSON', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    catalogServiceMock.selectedComponentUsage.set('{invalid}');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to parse component usage JSON:',
+      expect.any(SyntaxError),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not dispatch rendering payload if usage is not an array', async () => {
+    catalogServiceMock.selectedComponentUsage.set('{"not": "an array"}');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
+  });
+
+  it('wraps the component in Column layout using the exact casing defined in the catalog (e.g. coLuMn)', async () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Text: {type: 'object'},
+        coLuMn: {type: 'object'}, // Case variation
+      },
+    });
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/custom_catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: [
+            {id: 'root', component: 'coLuMn', children: ['target']},
+            {id: 'target', component: 'Text'},
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('catalogId returns null when activeCatalog is null', () => {
+    catalogManagementMock.activeCatalog.set(null);
+    expect((fixture.componentInstance as unknown as TestFriendlyGallery).catalogId()).toBeNull();
+  });
+
+  it('catalogId returns null if both catalogId and $id are missing in activeCatalog', () => {
+    catalogManagementMock.activeCatalog.set({
+      components: {},
+    });
+    expect((fixture.componentInstance as unknown as TestFriendlyGallery).catalogId()).toBeNull();
+  });
+
+  it('resolves catalogId from $id in computed and rendering effect if catalogId is missing', () => {
+    catalogManagementMock.activeCatalog.set({
+      $id: 'https://a2ui.org/fallback_catalog.json',
+      components: {
+        Text: {type: 'object'},
+      },
+    });
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect((fixture.componentInstance as unknown as TestFriendlyGallery).catalogId()).toBe(
+      'https://a2ui.org/fallback_catalog.json',
+    );
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/fallback_catalog.json',
+        },
+      },
+      expect.anything(),
+    ]);
+  });
+
+  it('selectedComponentDescription returns empty string if components catalog is missing', () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'mock-id',
+    });
+    catalogServiceMock.selectedComponentKey.set('Text');
+    expect(
+      (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
+    ).toBe('');
+  });
+
+  it('selectedComponentDescription returns empty string if active catalog is null and key is truthy', () => {
+    catalogManagementMock.activeCatalog.set(null);
+    catalogServiceMock.selectedComponentKey.set('Text');
+    expect(
+      (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
+    ).toBe('');
+  });
+
+  it('selectedComponentDescription returns empty string if selectedComponentKey is null', () => {
+    catalogServiceMock.selectedComponentKey.set(null);
+    expect(
+      (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
+    ).toBe('');
+  });
+
+  it('handles active catalogs with undefined components list safely', () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/empty.json',
+    });
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    // Should safely proceed without throwing errors and render unwrapped
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalled();
+  });
+
+  it('does not copy to clipboard if active catalog has no valid ID', () => {
+    catalogManagementMock.activeCatalog.set(null);
+    catalogServiceMock.selectedComponentUsage.set('[]');
+    fixture.detectChanges();
+    (fixture.componentInstance as unknown as TestFriendlyGallery).copyToClipboard();
+    expect(writeTextSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch render command if active catalog is null', () => {
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+    catalogManagementMock.activeCatalog.set(null);
+    catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
   });
 });

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -14,17 +14,203 @@
  * limitations under the License.
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, effect, inject} from '@angular/core';
+import {JsonPipe} from '@angular/common';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatListModule} from '@angular/material/list';
+import {MatCardModule} from '@angular/material/card';
+import {MatTableModule} from '@angular/material/table';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {GalleryCatalog} from './services/gallery-catalog';
+import {CatalogManagement} from '../storage/catalog-management/catalog-management';
+import {RenderedFrame} from '../preview/rendered/rendered-frame';
+import {HostCommunication} from '../shell/host-communication/host-communication';
 
 /**
- * Displays a visual catalog gallery of pre-configured A2UI components
- * and layouts for rapid prototyping and reference.
+ * Displays a split visual catalog gallery enabling search, interactive component selection,
+ * schema properties introspection, live preview placeholders, and usage clipboard exports.
  */
 @Component({
   selector: 'a2ui-composer-gallery',
   standalone: true,
-  imports: [],
+  imports: [
+    JsonPipe,
+    MatSidenavModule,
+    MatListModule,
+    MatCardModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    RenderedFrame,
+  ],
   templateUrl: './gallery.ng.html',
   styleUrl: './gallery.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class Gallery {}
+export class Gallery {
+  private readonly catalogService = inject(GalleryCatalog);
+  protected readonly catalogManagement = inject(CatalogManagement);
+  private readonly hostCommunication = inject(HostCommunication);
+
+  private static readonly A2UI_v09 = 'v0.9';
+  private static readonly DEMO_SURFACE_ID = 'gallery-preview';
+
+  constructor() {
+    effect(() => {
+      const usageString = this.selectedComponentUsage();
+      if (!usageString) return;
+
+      try {
+        const parsed = JSON.parse(usageString) as unknown;
+        if (!Array.isArray(parsed)) return;
+
+        const componentsArray = parsed as unknown[];
+        const catalog = this.catalogManagement.activeCatalog();
+        const catalogId = this.catalogId();
+        if (!catalog || !catalogId) return;
+
+        // To visually anchor and center the selected component within the sandboxed preview frame,
+        // we wrap it in a 'Column' container. This prevents individual components (like buttons)
+        // from stretching to fill the entire screen, ensuring a more realistic preview.
+        // We perform a case-insensitive lookup (e.g., matching 'Column' or 'column') to support
+        // different naming conventions that different catalogs might use. If no such column layout
+        // component is found in the catalog, we fall back to rendering the target component directly
+        // as the root.
+        const componentKeys = Object.keys(catalog['components'] || {});
+        const columnKey = componentKeys.find(k => k.toLowerCase() === 'column');
+
+        let componentsPayload: unknown[];
+        if (columnKey) {
+          componentsPayload = [
+            {id: 'root', component: columnKey, children: ['target']},
+            ...componentsArray,
+          ];
+        } else {
+          componentsPayload = componentsArray;
+        }
+
+        /* prettier-ignore */
+        const cmd1 = {
+          'version': Gallery.A2UI_v09,
+          'createSurface': {
+            'surfaceId': Gallery.DEMO_SURFACE_ID,
+            'catalogId': catalogId,
+          },
+        };
+
+        /* prettier-ignore */
+        const cmd2 = {
+          'version': Gallery.A2UI_v09,
+          'updateComponents': {
+            'surfaceId': Gallery.DEMO_SURFACE_ID,
+            'components': componentsPayload,
+          },
+        };
+
+        const payload = [cmd1, cmd2];
+        this.hostCommunication.sendRenderA2UI(payload);
+      } catch (e) {
+        console.error('Failed to parse component usage JSON:', e);
+      }
+    });
+  }
+
+  /** The alphabetized component list categorized by Layout, Content, Input, Feedback, Other. */
+  protected readonly componentsList = this.catalogService.componentsList;
+
+  /** The key of the currently selected component. */
+  protected readonly selectedComponentKey = this.catalogService.selectedComponentKey;
+
+  /** The parsed property specifications for the selected component. */
+  protected readonly selectedComponentProperties = this.catalogService.selectedComponentProperties;
+
+  /** The formatted JSON usage snippet wrapped in the A2UI spec envelope. */
+  protected readonly selectedComponentUsage = this.catalogService.selectedComponentUsage;
+
+  protected readonly catalogId = computed<string | null>(() => {
+    const catalog = this.catalogManagement.activeCatalog();
+    if (!catalog) return null;
+    return (catalog['catalogId'] || catalog['$id']) ?? null;
+  });
+
+  /** The table column names mapped by MatTable. */
+  protected readonly displayedColumns: string[] = [
+    'name',
+    'description',
+    'type',
+    'required',
+    'defaultValue',
+  ];
+
+  /** The resolved schema description for the selected component. */
+  protected readonly selectedComponentDescription = computed<string>(() => {
+    const key = this.selectedComponentKey();
+    if (!key) return '';
+    const catalog = this.catalogManagement.activeCatalog();
+    const comp = catalog?.['components']?.[key];
+    return comp && typeof comp['description'] === 'string' ? comp['description'] : '';
+  });
+
+  /**
+   * Sets the selected component key.
+   *
+   * @param key The component key or null to deselect.
+   */
+  protected selectComponent(key: string | null): void {
+    this.catalogService.selectComponent(key);
+  }
+
+  /**
+   * Copies the usage JSON payload to the system clipboard.
+   */
+  protected copyToClipboard(): void {
+    const usage = this.selectedComponentUsage();
+    if (!usage) {
+      return;
+    }
+
+    try {
+      const components = JSON.parse(usage);
+      if (!Array.isArray(components)) {
+        throw new Error('Component usage is not an array');
+      }
+
+      const catalogId = this.catalogId();
+      if (!catalogId) {
+        return;
+      }
+
+      /* prettier-ignore */
+      const createSurfaceLine = JSON.stringify({
+        'version': 'v0.9',
+        'createSurface': {
+          'surfaceId': 'gallery-preview',
+          'catalogId': catalogId,
+        },
+      });
+
+      /* prettier-ignore */
+      const updateComponentsLine = JSON.stringify({
+        'version': 'v0.9',
+        'updateComponents': {
+          'surfaceId': 'gallery-preview',
+          'components': components,
+        },
+      });
+
+      const payload = `${createSurfaceLine}\n${updateComponentsLine}`;
+
+      if (!navigator.clipboard) {
+        console.error('Clipboard API is not available in this environment.');
+        return;
+      }
+
+      navigator.clipboard.writeText(payload).catch(err => {
+        console.error('Failed to copy A2UI component usage to clipboard: ', err);
+      });
+    } catch (err) {
+      console.error('Failed to parse or format A2UI usage payload: ', err);
+    }
+  }
+}

--- a/shell/src/app/gallery/test/gallery.harness.ts
+++ b/shell/src/app/gallery/test/gallery.harness.ts
@@ -15,7 +15,131 @@
  */
 
 import {ComponentHarness} from '@angular/cdk/testing';
+import {MatNavListHarness} from '@angular/material/list/testing';
+import {MatTableHarness} from '@angular/material/table/testing';
+import {MatButtonHarness} from '@angular/material/button/testing';
 
+/**
+ * Harness for interacting with the Gallery component in unit tests.
+ */
 export class GalleryHarness extends ComponentHarness {
+  /** The CSS selector used to locate the host element. */
   static hostSelector = 'a2ui-composer-gallery';
+
+  private readonly getCategoryHeaders = this.locatorForAll('.category-header');
+  private readonly getNavList = this.locatorFor(MatNavListHarness);
+  private readonly getTable = this.locatorForOptional(MatTableHarness);
+  private readonly getTitle = this.locatorForOptional('.component-title');
+  private readonly getDescription = this.locatorForOptional('.component-description');
+  private readonly getUsageCode = this.locatorForOptional('.usage-code');
+  private readonly getCopyButton = this.locatorForOptional(
+    MatButtonHarness.with({selector: '.copy-button'}),
+  );
+  private readonly getEmptySubtitle = this.locatorForOptional('.empty-subtitle');
+  private readonly getCardTitles = this.locatorForAll('mat-card-title');
+
+  /**
+   * Retrieves the text labels of all category subheaders.
+   */
+  async getCategoryHeadersText(): Promise<string[]> {
+    const headers = await this.getCategoryHeaders();
+    return Promise.all(headers.map(h => h.text()));
+  }
+
+  /**
+   * Retrieves the text contents of all component navigation list items.
+   */
+  async getNavigationLinksText(): Promise<string[]> {
+    const list = await this.getNavList();
+    const items = await list.getItems();
+    return Promise.all(items.map(item => item.getFullText()));
+  }
+
+  /**
+   * Clicks a component list item by its text value.
+   *
+   * @param text The component link text to click.
+   */
+  async clickNavigationLink(text: string): Promise<void> {
+    const list = await this.getNavList();
+    const items = await list.getItems({text});
+    if (items.length === 0) {
+      throw new Error(`Could not find navigation link with text: "${text}"`);
+    }
+    await items[0].click();
+  }
+
+  /**
+   * Retrieves the title of the active component details panel.
+   */
+  async getSelectedComponentTitle(): Promise<string | null> {
+    const titleEl = await this.getTitle();
+    return titleEl ? titleEl.text() : null;
+  }
+
+  /**
+   * Retrieves the description of the active component details panel.
+   */
+  async getSelectedComponentDescription(): Promise<string | null> {
+    const descEl = await this.getDescription();
+    return descEl ? descEl.text() : null;
+  }
+
+  /**
+   * Retrieves the current usage code block content.
+   */
+  async getUsageCodeText(): Promise<string | null> {
+    const codeEl = await this.getUsageCode();
+    return codeEl ? codeEl.text() : null;
+  }
+
+  /**
+   * Clicks the clipboard copy button.
+   */
+  async clickCopyButton(): Promise<void> {
+    const button = await this.getCopyButton();
+    if (!button) {
+      throw new Error('Clipboard copy button is not present');
+    }
+    await button.click();
+  }
+
+  /**
+   * Retrieves the empty state description text if visible.
+   */
+  async getEmptyStateSubtitleText(): Promise<string | null> {
+    const subtitleEl = await this.getEmptySubtitle();
+    return subtitleEl ? subtitleEl.text() : null;
+  }
+
+  /**
+   * Retrieves the card title texts of all detail panels.
+   */
+  async getCardTitlesText(): Promise<string[]> {
+    const titles = await this.getCardTitles();
+    return Promise.all(titles.map(t => t.text()));
+  }
+
+  /**
+   * Retrieves the properties table data as parsed records.
+   */
+  async getPropertiesTableData(): Promise<Array<Record<string, string>>> {
+    const table = await this.getTable();
+    if (!table) {
+      return [];
+    }
+    const rows = await table.getRows();
+    const records: Array<Record<string, string>> = [];
+    for (const row of rows) {
+      const columnText = await row.getCellTextByColumnName();
+      records.push({
+        name: columnText['name'],
+        description: columnText['description'],
+        type: columnText['type'],
+        required: columnText['required'],
+        defaultValue: columnText['defaultValue'],
+      });
+    }
+    return records;
+  }
 }

--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -50,7 +50,7 @@
   }
 }
 .composer-content {
-  padding: 16px;
+  padding: 0;
   box-sizing: border-box;
   height: 100%;
 }

--- a/shell/src/app/shell/composer-workspace/composer-workspace.scss
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.scss
@@ -24,6 +24,7 @@
   gap: 16px;
   height: 100%;
   box-sizing: border-box;
+  padding: 16px;
 
   &.extension-mode {
     flex-direction: column;

--- a/shell/src/app/storage/catalog-management/catalog-management.spec.ts
+++ b/shell/src/app/storage/catalog-management/catalog-management.spec.ts
@@ -157,7 +157,7 @@ describe('CatalogManagement', () => {
     hostCommunicationMock.messageStream$.next({
       type: PreviewBridgeMessageType.A2UI_CATALOG,
       origin: 'http://localhost',
-      payload: {},
+      payload: {catalogId: 'test-catalog'},
       timestamp: 1005,
     });
     TestBed.tick();
@@ -169,7 +169,7 @@ describe('CatalogManagement', () => {
 
     expect(service.isHandshakeInProgress()).toBe(false);
     expect(service.catalogError()).toBeNull();
-    expect(service.activeCatalog()).toEqual({});
+    expect(service.activeCatalog()).toEqual({catalogId: 'test-catalog'});
   });
 
   it(
@@ -213,7 +213,7 @@ describe('CatalogManagement', () => {
     hostCommunicationMock.messageStream$.next({
       type: PreviewBridgeMessageType.A2UI_CATALOG,
       origin: 'http://localhost',
-      payload: {},
+      payload: {catalogId: 'test-catalog'},
       timestamp: 1008,
     });
     TestBed.tick();
@@ -315,6 +315,7 @@ describe('CatalogManagement', () => {
 
   it('sanitizes HTML tags in title and description and computes SHA-256 hash', async () => {
     const payload = {
+      catalogId: 'test-catalog',
       title: 'Catalog Title <script>alert(1)</script>',
       description: 'Catalog Description <img src=x onerror=alert(1)>',
       components: {
@@ -350,6 +351,7 @@ describe('CatalogManagement', () => {
 
     // Verify deterministic hashing for identical catalog structures
     const payloadIdentical = {
+      catalogId: 'test-catalog',
       components: {
         button: {name: 'Button'},
       },
@@ -378,6 +380,7 @@ describe('CatalogManagement', () => {
     indexedDbStorageMock.getCatalogRecord.mockResolvedValue(null);
 
     const payload = {
+      catalogId: 'test-catalog',
       title: 'New Catalog',
       description: 'New Description',
       components: {},
@@ -420,6 +423,7 @@ describe('CatalogManagement', () => {
     });
 
     const payload = {
+      catalogId: 'test-catalog',
       title: 'Updated Catalog',
       description: 'Updated Description',
       components: {},
@@ -455,6 +459,7 @@ describe('CatalogManagement', () => {
 
   it('updates lastAccessed but delta is false when cached hash matches', async () => {
     const payload = {
+      catalogId: 'test-catalog',
       title: 'Matching Catalog',
       description: 'Matching Description',
       components: {},
@@ -521,7 +526,7 @@ describe('CatalogManagement', () => {
     hostCommunicationMock.messageStream$.next({
       type: PreviewBridgeMessageType.A2UI_CATALOG,
       origin: 'http://localhost',
-      payload: {},
+      payload: {catalogId: 'test-catalog'},
       timestamp: 2001,
     });
     TestBed.tick();
@@ -529,7 +534,7 @@ describe('CatalogManagement', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(service.catalogError()).toBeNull();
-    expect(service.activeCatalog()).toEqual({} as Catalog);
+    expect(service.activeCatalog()).toEqual({catalogId: 'test-catalog'} as Catalog);
     expect(service.isHandshakeInProgress()).toBe(false);
 
     Object.defineProperty(globalThis, 'crypto', {
@@ -549,7 +554,7 @@ describe('CatalogManagement', () => {
     hostCommunicationMock.messageStream$.next({
       type: PreviewBridgeMessageType.A2UI_CATALOG,
       origin: 'http://localhost',
-      payload: {},
+      payload: {catalogId: 'test-catalog'},
       timestamp: 2002,
     });
     TestBed.tick();
@@ -570,7 +575,7 @@ describe('CatalogManagement', () => {
     hostCommunicationMock.messageStream$.next({
       type: PreviewBridgeMessageType.A2UI_CATALOG,
       origin: 'http://localhost',
-      payload: {},
+      payload: {catalogId: 'test-catalog'},
       timestamp: 2003,
     });
     TestBed.tick();
@@ -588,6 +593,7 @@ describe('CatalogManagement', () => {
     indexedDbStorageMock.saveCatalogRecord.mockClear();
 
     const payload = {
+      catalogId: 'test-catalog',
       title: 'Null URL Catalog',
       description: 'Null URL Description',
       components: {},
@@ -634,5 +640,80 @@ describe('CatalogManagement', () => {
     expect(service.activeCatalogTitle()).toBe('Test Title <b>Bold</b>');
     expect(service.activeCatalogDescription()).toBe('Test Description <i>Italic</i>');
     expect(service.activeCatalog()?.['catalogId']).toBe('custom-catalog-id');
+  });
+
+  it('rejects A2UI_CATALOG payload if catalogId and $id are missing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.A2UI_CATALOG,
+      origin: 'http://localhost',
+      payload: {
+        title: 'No ID Catalog',
+        components: {},
+      },
+      timestamp: 2006,
+    });
+    TestBed.tick();
+
+    expect(service.catalogError()).toBe(
+      'Catalog is missing a valid identifier (catalogId or $id).',
+    );
+    expect(service.isHandshakeInProgress()).toBe(false);
+    expect(service.activeCatalog()).toBeNull();
+    errorSpy.mockRestore();
+  });
+
+  it('ignores watchdog timeout execution if watchdogTimerId is manually cleared', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Trigger RENDERER_READY to start the watchdog timer
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: 3001,
+    });
+    TestBed.tick();
+
+    // Manually corrupt private watchdogTimerId state
+    (service as unknown as {watchdogTimerId: ReturnType<typeof setTimeout> | null})[
+      'watchdogTimerId'
+    ] = null;
+
+    // Fast forward past the 5 second timeout limit
+    vi.advanceTimersByTime(5000);
+
+    // Expect the timeout handler to have returned early without throwing or setting errors
+    expect(service.catalogError()).toBeNull();
+    expect(service.isHandshakeInProgress()).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+
+  it('handles flat catalog error payloads without message, using default error message', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: 4001,
+    });
+    TestBed.tick();
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.A2UI_CATALOG,
+      origin: 'http://localhost',
+      payload: {
+        error: {}, // No message
+      },
+      timestamp: 4002,
+    });
+    TestBed.tick();
+
+    expect(service.catalogError()).toBe(
+      'Unknown error occurred in preview bridge during handshake.',
+    );
+    expect(service.isHandshakeInProgress()).toBe(false);
+    errorSpy.mockRestore();
   });
 });

--- a/shell/src/app/storage/catalog-management/catalog-management.ts
+++ b/shell/src/app/storage/catalog-management/catalog-management.ts
@@ -207,6 +207,15 @@ export class CatalogManagement {
               return of(null);
             }
 
+            const catalogId = catalogObj['catalogId'] || catalogObj['$id'];
+            if (!catalogId) {
+              const errorMsg = 'Catalog is missing a valid identifier (catalogId or $id).';
+              this._catalogError.set(errorMsg);
+              console.error(errorMsg, catalogObj);
+              this._isHandshakeInProgress.set(false);
+              return of(null);
+            }
+
             let hashHexPromise: Promise<string>;
             if (!globalThis.crypto?.subtle) {
               console.warn(


### PR DESCRIPTION
# Description

implement gallery split layout and properties table UI

Builds the components gallery page using mat-sidenav. Populates the left side list grouped by category and the right side with the properties table, usage block, and details card components.

This is the 4th in a series of PRs which culminates in a dynamically generated page to show the components of the current catalog: 
<img width="1586" height="961" alt="image" src="https://github.com/user-attachments/assets/1fd0b818-8c81-4a9e-a926-3d0057551944" />
## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
