### PR TITLE
Gallery 5 preview iframe

### DIFF
--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -26,6 +26,8 @@ import {CatalogManagement} from '../storage/catalog-management/catalog-managemen
 import {ParsedProperty} from './schema/catalog-schema-resolver';
 import {Catalog} from '../storage/models/catalog-storage.model';
 import {HostCommunication} from '../shell/host-communication/host-communication';
+import {StartupResolution} from '../shell/startup-resolution/startup-resolution';
+import {ChatState} from '../chat/chat-state/chat-state';
 
 interface TestFriendlyGallery {
   catalogId: () => string | null;
@@ -51,6 +53,17 @@ class MockCatalogManagement {
 
 class MockHostCommunication {
   sendRenderA2UI = vi.fn();
+  registerIframeElement = vi.fn();
+  registerIframe = vi.fn();
+}
+
+class MockStartupResolution {
+  readonly resolvedUrl = signal<string | null>('http://localhost/renderer');
+  getResolvedRendererUrl = vi.fn(() => 'http://localhost/renderer');
+}
+
+class MockChatState {
+  readonly isProgrammaticStreamActive = signal<boolean>(false);
 }
 
 describe('Gallery Component', () => {
@@ -70,6 +83,8 @@ describe('Gallery Component', () => {
         {provide: GalleryCatalog, useClass: MockGalleryCatalogService},
         {provide: CatalogManagement, useClass: MockCatalogManagement},
         {provide: HostCommunication, useClass: MockHostCommunication},
+        {provide: StartupResolution, useClass: MockStartupResolution},
+        {provide: ChatState, useClass: MockChatState},
       ],
     }).compileComponents();
 
@@ -583,5 +598,79 @@ describe('Gallery Component', () => {
     TestBed.flushEffects();
 
     expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
+  });
+
+  it('renders the a2ui-composer-rendered-frame element when a component is active', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const hasFrame = await harness.hasRenderedFrame();
+    expect(hasFrame).toBe(true);
+  });
+
+  it('triggers another rendering update call when changing component selection', async () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Text: {type: 'object'},
+        Button: {type: 'object'},
+        Column: {type: 'object'},
+      },
+    });
+
+    const usageText = [
+      {
+        id: 'target',
+        component: 'Text',
+        text: 'Headline Large (H1)',
+        variant: 'h1',
+      },
+    ];
+    const usageButton = [
+      {
+        id: 'target',
+        component: 'Button',
+        text: 'Click Me',
+      },
+    ];
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set(JSON.stringify(usageText));
+    fixture.detectChanges();
+
+    const expectedTextLine1 = {
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: 'gallery-preview',
+        catalogId: 'https://a2ui.org/custom_catalog.json',
+      },
+    };
+    const expectedTextLine2 = {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'gallery-preview',
+        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageText],
+      },
+    };
+    const expectedTextPayload = [expectedTextLine1, expectedTextLine2];
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith(expectedTextPayload);
+
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+
+    catalogServiceMock.selectedComponentKey.set('Button');
+    catalogServiceMock.selectedComponentUsage.set(JSON.stringify(usageButton));
+    fixture.detectChanges();
+
+    const expectedButtonLine2 = {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'gallery-preview',
+        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageButton],
+      },
+    };
+    const expectedButtonPayload = [expectedTextLine1, expectedButtonLine2];
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith(expectedButtonPayload);
   });
 });

--- a/shell/src/app/gallery/test/gallery.harness.ts
+++ b/shell/src/app/gallery/test/gallery.harness.ts
@@ -18,6 +18,7 @@ import {ComponentHarness} from '@angular/cdk/testing';
 import {MatNavListHarness} from '@angular/material/list/testing';
 import {MatTableHarness} from '@angular/material/table/testing';
 import {MatButtonHarness} from '@angular/material/button/testing';
+import {RenderedFrameHarness} from '../../preview/rendered/test/rendered-frame.harness';
 
 /**
  * Harness for interacting with the Gallery component in unit tests.
@@ -37,6 +38,7 @@ export class GalleryHarness extends ComponentHarness {
   );
   private readonly getEmptySubtitle = this.locatorForOptional('.empty-subtitle');
   private readonly getCardTitles = this.locatorForAll('mat-card-title');
+  private readonly getRenderedFrame = this.locatorForOptional(RenderedFrameHarness);
 
   /**
    * Retrieves the text labels of all category subheaders.
@@ -118,6 +120,14 @@ export class GalleryHarness extends ComponentHarness {
   async getCardTitlesText(): Promise<string[]> {
     const titles = await this.getCardTitles();
     return Promise.all(titles.map(t => t.text()));
+  }
+
+  /**
+   * Checks if the sandboxed preview rendered frame is present.
+   */
+  async hasRenderedFrame(): Promise<boolean> {
+    const frame = await this.getRenderedFrame();
+    return !!frame;
   }
 
   /**

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -21,6 +21,8 @@ import {
   CreateSurfaceDetails,
   UpdateComponentsDetails,
   UpdateDataModelDetails,
+  SetBlockingStatePayload,
+  DataModelChangePayload,
 } from 'a2ui-bridge';
 
 /**
@@ -64,105 +66,8 @@ export class CrossFrameValidator {
         }
 
         for (const item of msgPayload) {
-          if (!item || typeof item !== 'object' || Array.isArray(item)) {
-            console.error('Malformed payload for RENDER_A2UI: array items must be objects.');
+          if (!this.validateSingleRenderMessage(item)) {
             return false;
-          }
-
-          const itemObj = item as RenderA2uiItem;
-          if (itemObj['version'] !== 'v0.9') {
-            console.error(
-              'Malformed payload for RENDER_A2UI: array items must specify version "v0.9".',
-            );
-            return false;
-          }
-
-          const updateKeys = [
-            'createSurface',
-            'updateComponents',
-            'updateDataModel',
-            'deleteSurface',
-          ];
-          const presentKeys = updateKeys.filter(
-            key => key in itemObj && itemObj[key] !== undefined,
-          );
-
-          if (presentKeys.length === 0) {
-            console.error(
-              'Malformed payload for RENDER_A2UI: item must contain an update property (createSurface, updateComponents, updateDataModel, or deleteSurface).',
-            );
-            return false;
-          }
-
-          if (presentKeys.length > 1) {
-            console.error(
-              `Malformed payload for RENDER_A2UI: item must contain exactly one update property, but found: ${presentKeys.join(', ')}.`,
-            );
-            return false;
-          }
-
-          const updateType = presentKeys[0];
-          const updateObj = itemObj[updateType];
-
-          if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
-            console.error(
-              `Malformed payload for RENDER_A2UI: ${updateType} property must be an object.`,
-            );
-            return false;
-          }
-
-          const updateData = updateObj as BaseSurfaceDetails;
-          if (typeof updateData['surfaceId'] !== 'string') {
-            console.error(
-              `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
-            );
-            return false;
-          }
-
-          if (updateType === 'createSurface') {
-            const createDetails = updateObj as CreateSurfaceDetails;
-            if (typeof createDetails['catalogId'] !== 'string') {
-              console.error(
-                'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
-              );
-              return false;
-            }
-            if (
-              createDetails['sendDataModel'] !== undefined &&
-              typeof createDetails['sendDataModel'] !== 'boolean'
-            ) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
-              );
-              return false;
-            }
-          } else if (updateType === 'updateComponents') {
-            const updateCompDetails = updateObj as UpdateComponentsDetails;
-            if (!Array.isArray(updateCompDetails['components'])) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
-              );
-              return false;
-            }
-            for (const comp of updateCompDetails['components']) {
-              if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
-                console.error(
-                  'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
-                );
-                return false;
-              }
-            }
-          } else if (updateType === 'updateDataModel') {
-            const updateModelDetails = updateObj as UpdateDataModelDetails;
-            if (
-              updateModelDetails['path'] !== undefined &&
-              typeof updateModelDetails['path'] !== 'string'
-            ) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
-              );
-              return false;
-            }
           }
         }
         return true;
@@ -174,7 +79,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const blockingState = msgPayload as Record<string, unknown>;
+        const blockingState = msgPayload as SetBlockingStatePayload;
         if (typeof blockingState['blocked'] !== 'boolean') {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: must contain boolean property blocked.',
@@ -199,7 +104,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const changePayload = msgPayload as Record<string, unknown>;
+        const changePayload = msgPayload as DataModelChangePayload;
         const updateObj = changePayload['updateDataModel'];
         if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
           console.error(
@@ -208,7 +113,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const updateData = updateObj as Record<string, unknown>;
+        const updateData = updateObj as UpdateDataModelDetails;
         if (typeof updateData['surfaceId'] !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel must contain a valid surfaceId string.',
@@ -229,5 +134,101 @@ export class CrossFrameValidator {
         return true;
       }
     }
+  }
+
+  private static validateSingleRenderMessage(item: unknown): boolean {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      console.error('Malformed payload for RENDER_A2UI: array items must be objects.');
+      return false;
+    }
+
+    // NOTE: Bracket notation is used to access properties on cross-frame message objects
+    // to prevent compilers from renaming these properties during production minification.
+    const itemObj = item as RenderA2uiItem;
+    if (itemObj['version'] !== 'v0.9') {
+      console.error('Malformed payload for RENDER_A2UI: array items must specify version "v0.9".');
+      return false;
+    }
+
+    const updateKeys = ['createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface'];
+    const presentKeys = updateKeys.filter(key => key in itemObj && itemObj[key] !== undefined);
+
+    if (presentKeys.length === 0) {
+      console.error(
+        'Malformed payload for RENDER_A2UI: item must contain an update property (createSurface, updateComponents, updateDataModel, or deleteSurface).',
+      );
+      return false;
+    }
+
+    if (presentKeys.length > 1) {
+      console.error(
+        `Malformed payload for RENDER_A2UI: item must contain exactly one update property, but found: ${presentKeys.join(', ')}.`,
+      );
+      return false;
+    }
+
+    const updateType = presentKeys[0];
+    const updateObj = itemObj[updateType];
+
+    if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
+      console.error(`Malformed payload for RENDER_A2UI: ${updateType} property must be an object.`);
+      return false;
+    }
+
+    const updateData = updateObj as BaseSurfaceDetails;
+    if (typeof updateData['surfaceId'] !== 'string') {
+      console.error(
+        `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
+      );
+      return false;
+    }
+
+    if (updateType === 'createSurface') {
+      const createDetails = updateObj as CreateSurfaceDetails;
+      if (typeof createDetails['catalogId'] !== 'string') {
+        console.error(
+          'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
+        );
+        return false;
+      }
+      if (
+        createDetails['sendDataModel'] !== undefined &&
+        typeof createDetails['sendDataModel'] !== 'boolean'
+      ) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
+        );
+        return false;
+      }
+    } else if (updateType === 'updateComponents') {
+      const updateCompDetails = updateObj as UpdateComponentsDetails;
+      if (!Array.isArray(updateCompDetails['components'])) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
+        );
+        return false;
+      }
+      for (const comp of updateCompDetails['components']) {
+        if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
+          console.error(
+            'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
+          );
+          return false;
+        }
+      }
+    } else if (updateType === 'updateDataModel') {
+      const updateModelDetails = updateObj as UpdateDataModelDetails;
+      if (
+        updateModelDetails['path'] !== undefined &&
+        typeof updateModelDetails['path'] !== 'string'
+      ) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -455,4 +455,90 @@ describe('HostCommunication', () => {
 
     removeEventListenerSpy.mockRestore();
   });
+
+  it('caches the latest catalog envelope when receiving an A2UI_CATALOG message', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    const catalogPayload = {components: {}};
+    const event = new MessageEvent('message', {
+      source: mockIframeWindow,
+      origin: 'http://localhost:3000',
+      data: {
+        type: PreviewBridgeMessageType.A2UI_CATALOG,
+        payload: catalogPayload,
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    const latestCatalog = service.getLatestCatalog();
+    expect(latestCatalog).toEqual({
+      type: PreviewBridgeMessageType.A2UI_CATALOG,
+      payload: catalogPayload,
+      origin: 'http://localhost:3000',
+      timestamp: expect.any(Number),
+    });
+
+    const history = service.getHistoryBuffer();
+    expect(history.length).toBe(1);
+    expect(history[0].type).toBe(PreviewBridgeMessageType.A2UI_CATALOG);
+  });
+
+  it('caps the message history buffer at 100 entries strictly using FIFO eviction', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    for (let i = 0; i < 105; i++) {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {
+            type: PreviewBridgeMessageType.RENDERER_READY,
+            payload: {index: i},
+          },
+        }),
+      );
+    }
+
+    const history = service.getHistoryBuffer();
+    expect(history.length).toBe(100);
+    expect(history[0].payload).toEqual({index: 5});
+    expect(history[99].payload).toEqual({index: 104});
+  });
+
+  it('catches and logs errors thrown by listeners without crashing the message dispatch loop', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const throwingListener = vi.fn().mockImplementation(() => {
+      throw new Error('Listener failed');
+    });
+    const safeListener = vi.fn();
+
+    service.addListener(throwingListener);
+    service.addListener(safeListener);
+
+    const event = new MessageEvent('message', {
+      source: mockIframeWindow,
+      origin: 'http://localhost:3000',
+      data: {type: PreviewBridgeMessageType.RENDERER_READY},
+    });
+
+    window.dispatchEvent(event);
+
+    expect(throwingListener).toHaveBeenCalledTimes(1);
+    expect(safeListener).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error in HostCommunication listener:',
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+    service.removeListener(throwingListener);
+    service.removeListener(safeListener);
+  });
 });


### PR DESCRIPTION
# Description

integrate sandboxed rendering iframe in gallery preview

Mounts the rendered-frame component in the preview tab and registers an effect to post A2UI render events to the host iframe communication channel whenever the selected component selection updates.

This is the 5th in a series of PRs which culminates in a dynamically generated page to show the components of the current catalog: 
<img width="1586" height="961" alt="image" src="https://github.com/user-attachments/assets/1fd0b818-8c81-4a9e-a926-3d0057551944" />

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
