### PR TITLE
Gallery 6 playwright e2e

### DIFF
--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {test, expect} from '@playwright/test';
+
+test.beforeEach(async ({page}) => {
+  page.on('pageerror', err => {
+    console.error(`Unhandled page error: ${err.message}`);
+  });
+});
+
+test.describe('Components Gallery User Journey', () => {
+  test.beforeEach(async ({page}) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('a2ui_composer_force_1p', 'true');
+      } catch (e) {}
+    });
+  });
+
+  test('verifies navigation from home and loading components catalog details', async ({
+    page,
+    context,
+  }, testInfo) => {
+    // Enable clipboard permissions
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    // 1. Navigate to home with a valid renderer to trigger the catalog handshake
+    await page.goto('/?renderer=http://localhost:3456');
+    await expect(page.locator('.workspace-container')).toBeVisible();
+
+    // Wait for the workspace to load, indicating handshake completed
+    const workspaceIframe = page.locator('.workspace-container iframe');
+    await expect(workspaceIframe).toBeVisible();
+
+    // Wait for the catalog handshake to complete (indicated by header title updating)
+    await expect(page.locator('.header-title')).toContainText('my_basic_catalog');
+
+    // 2. Click on the gallery link in the sidebar
+    const galleryLink = page.getByRole('link', {name: 'Components Gallery'});
+    await expect(galleryLink).toBeVisible();
+    await galleryLink.click();
+
+    // 3. Redirected to /gallery and layout loads successfully
+    await page.waitForURL('**/gallery');
+    await expect(page.locator('.gallery-container')).toBeVisible();
+    await expect(page.getByRole('heading', {name: 'No Component Selected'})).toBeVisible();
+
+    // 4. Verify component catalog navigation is visible
+    const navItems = page.locator('.catalog-list').getByRole('button');
+    await expect(navItems.first()).toBeVisible();
+
+    // Read the name of the first component dynamically to ensure test robustness
+    const firstComponentName = (await navItems.first().textContent())?.trim();
+    expect(firstComponentName).toBeTruthy();
+
+    // 5. Click the first component
+    await navItems.first().click();
+
+    // 6. Assert details pane is updated
+    await expect(page.getByRole('heading', {name: firstComponentName!, exact: true})).toBeVisible();
+
+    // Assert card headers are visible
+    const cardHeaders = page.locator('mat-card-header mat-card-title');
+    await expect(cardHeaders).toHaveText(['Preview', 'Usage', 'Properties']);
+
+    // 7. Assert properties table is populated
+    const propertiesTable = page.getByRole('table');
+    await expect(propertiesTable).toBeVisible();
+    const rows = propertiesTable.locator('tbody tr');
+    await expect(rows.first()).toBeVisible();
+
+    // 8. Assert usage card renders the usage JSON block representing a raw components array
+    const usageCode = page.locator('pre code');
+    await expect(usageCode).toBeVisible();
+    const usageCodeText = (await usageCode.textContent()) || '';
+    expect(usageCodeText.trim().startsWith('[')).toBe(true);
+    expect(usageCodeText.trim().endsWith(']')).toBe(true);
+    expect(usageCodeText).toContain(`"component": "${firstComponentName!}"`);
+    expect(usageCodeText).not.toContain('createSurface');
+    expect(usageCodeText).not.toContain('updateComponents');
+
+    // 9. Assert sandboxed preview frame is mounted and has an iframe
+    const renderedFrame = page.locator('a2ui-composer-rendered-frame');
+    await expect(renderedFrame).toBeVisible();
+    const iframe = renderedFrame.locator('iframe');
+    await expect(iframe).toBeVisible();
+
+    // 10. Click copy to clipboard and assert clipboard content represents a JSONLines envelope
+    const copyButton = page.getByRole('button', {name: /copy/i});
+    await expect(copyButton).toBeVisible();
+    await copyButton.click();
+
+    // Assert clipboard matches using expect.poll (avoiding waitForTimeout)
+    await expect
+      .poll(async () => {
+        const text = await page.evaluate(() => navigator.clipboard.readText());
+        const lines = text.trim().split('\n');
+        if (lines.length !== 2) {
+          return {error: `Expected 2 lines, got ${lines.length}`};
+        }
+        try {
+          const line1 = JSON.parse(lines[0]) as Record<string, unknown>;
+          const line2 = JSON.parse(lines[1]) as Record<string, unknown>;
+          const createSurface = line1['createSurface'] as Record<string, unknown> | undefined;
+          const updateComponents = line2['updateComponents'] as Record<string, unknown> | undefined;
+          const components = updateComponents?.['components'] as
+            | Array<Record<string, unknown>>
+            | undefined;
+          const hasComponent =
+            Array.isArray(components) &&
+            components.some(c => c['component'] === firstComponentName);
+          return {
+            line1Version: line1['version'],
+            hasCreateSurface: typeof createSurface === 'object' && createSurface !== null,
+            hasCatalogId: typeof createSurface?.['catalogId'] === 'string',
+            line2Version: line2['version'],
+            hasUpdateComponents: typeof updateComponents === 'object' && updateComponents !== null,
+            componentsArray: Array.isArray(components),
+            hasComponent,
+          };
+        } catch (e) {
+          return {error: 'Failed to parse JSON lines'};
+        }
+      })
+      .toEqual({
+        line1Version: 'v0.9',
+        hasCreateSurface: true,
+        hasCatalogId: true,
+        line2Version: 'v0.9',
+        hasUpdateComponents: true,
+        componentsArray: true,
+        hasComponent: true,
+      });
+
+    // 11. Verify in-place update when clicking the second component
+    const secondNavItem = navItems.nth(1);
+    await expect(secondNavItem).toBeVisible();
+    const secondComponentName = (await secondNavItem.textContent())?.trim();
+    expect(secondComponentName).toBeTruthy();
+
+    const detailsPanel = page.locator('.details-panel');
+    await detailsPanel.evaluate(el => {
+      el.setAttribute('data-test-marker', 'in-place-verify');
+    });
+
+    await secondNavItem.click();
+
+    // Title and usage code should update to second component
+    await expect(
+      page.getByRole('heading', {name: secondComponentName!, exact: true}),
+    ).toBeVisible();
+
+    const secondUsageCodeText = (await page.locator('pre code').textContent()) || '';
+    expect(secondUsageCodeText.trim().startsWith('[')).toBe(true);
+    expect(secondUsageCodeText.trim().endsWith(']')).toBe(true);
+    expect(secondUsageCodeText).toContain(`"component": "${secondComponentName!}"`);
+    expect(secondUsageCodeText).not.toContain('createSurface');
+    expect(secondUsageCodeText).not.toContain('updateComponents');
+
+    // Assert that the marker is still present, proving the DOM element was reused in-place
+    await expect(detailsPanel).toHaveAttribute('data-test-marker', 'in-place-verify');
+
+    // Take screenshot for verification
+    const screenshotBuffer = await page.screenshot();
+    await testInfo.attach('gallery-user-journey-success', {
+      body: screenshotBuffer,
+      contentType: 'image/png',
+    });
+  });
+});

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -26,6 +26,8 @@ import {CatalogManagement} from '../storage/catalog-management/catalog-managemen
 import {ParsedProperty} from './schema/catalog-schema-resolver';
 import {Catalog} from '../storage/models/catalog-storage.model';
 import {HostCommunication} from '../shell/host-communication/host-communication';
+import {StartupResolution} from '../shell/startup-resolution/startup-resolution';
+import {ChatState} from '../chat/chat-state/chat-state';
 
 interface TestFriendlyGallery {
   catalogId: () => string | null;
@@ -51,6 +53,17 @@ class MockCatalogManagement {
 
 class MockHostCommunication {
   sendRenderA2UI = vi.fn();
+  registerIframeElement = vi.fn();
+  registerIframe = vi.fn();
+}
+
+class MockStartupResolution {
+  readonly resolvedUrl = signal<string | null>('http://localhost/renderer');
+  getResolvedRendererUrl = vi.fn(() => 'http://localhost/renderer');
+}
+
+class MockChatState {
+  readonly isProgrammaticStreamActive = signal<boolean>(false);
 }
 
 describe('Gallery Component', () => {
@@ -70,6 +83,8 @@ describe('Gallery Component', () => {
         {provide: GalleryCatalog, useClass: MockGalleryCatalogService},
         {provide: CatalogManagement, useClass: MockCatalogManagement},
         {provide: HostCommunication, useClass: MockHostCommunication},
+        {provide: StartupResolution, useClass: MockStartupResolution},
+        {provide: ChatState, useClass: MockChatState},
       ],
     }).compileComponents();
 
@@ -583,5 +598,79 @@ describe('Gallery Component', () => {
     TestBed.flushEffects();
 
     expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
+  });
+
+  it('renders the a2ui-composer-rendered-frame element when a component is active', async () => {
+    catalogServiceMock.selectedComponentKey.set('Text');
+    fixture.detectChanges();
+
+    const hasFrame = await harness.hasRenderedFrame();
+    expect(hasFrame).toBe(true);
+  });
+
+  it('triggers another rendering update call when changing component selection', async () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/custom_catalog.json',
+      components: {
+        Text: {type: 'object'},
+        Button: {type: 'object'},
+        Column: {type: 'object'},
+      },
+    });
+
+    const usageText = [
+      {
+        id: 'target',
+        component: 'Text',
+        text: 'Headline Large (H1)',
+        variant: 'h1',
+      },
+    ];
+    const usageButton = [
+      {
+        id: 'target',
+        component: 'Button',
+        text: 'Click Me',
+      },
+    ];
+
+    catalogServiceMock.selectedComponentKey.set('Text');
+    catalogServiceMock.selectedComponentUsage.set(JSON.stringify(usageText));
+    fixture.detectChanges();
+
+    const expectedTextLine1 = {
+      version: 'v0.9',
+      createSurface: {
+        surfaceId: 'gallery-preview',
+        catalogId: 'https://a2ui.org/custom_catalog.json',
+      },
+    };
+    const expectedTextLine2 = {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'gallery-preview',
+        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageText],
+      },
+    };
+    const expectedTextPayload = [expectedTextLine1, expectedTextLine2];
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith(expectedTextPayload);
+
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+
+    catalogServiceMock.selectedComponentKey.set('Button');
+    catalogServiceMock.selectedComponentUsage.set(JSON.stringify(usageButton));
+    fixture.detectChanges();
+
+    const expectedButtonLine2 = {
+      version: 'v0.9',
+      updateComponents: {
+        surfaceId: 'gallery-preview',
+        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageButton],
+      },
+    };
+    const expectedButtonPayload = [expectedTextLine1, expectedButtonLine2];
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith(expectedButtonPayload);
   });
 });

--- a/shell/src/app/gallery/test/gallery.harness.ts
+++ b/shell/src/app/gallery/test/gallery.harness.ts
@@ -18,6 +18,7 @@ import {ComponentHarness} from '@angular/cdk/testing';
 import {MatNavListHarness} from '@angular/material/list/testing';
 import {MatTableHarness} from '@angular/material/table/testing';
 import {MatButtonHarness} from '@angular/material/button/testing';
+import {RenderedFrameHarness} from '../../preview/rendered/test/rendered-frame.harness';
 
 /**
  * Harness for interacting with the Gallery component in unit tests.
@@ -37,6 +38,7 @@ export class GalleryHarness extends ComponentHarness {
   );
   private readonly getEmptySubtitle = this.locatorForOptional('.empty-subtitle');
   private readonly getCardTitles = this.locatorForAll('mat-card-title');
+  private readonly getRenderedFrame = this.locatorForOptional(RenderedFrameHarness);
 
   /**
    * Retrieves the text labels of all category subheaders.
@@ -118,6 +120,14 @@ export class GalleryHarness extends ComponentHarness {
   async getCardTitlesText(): Promise<string[]> {
     const titles = await this.getCardTitles();
     return Promise.all(titles.map(t => t.text()));
+  }
+
+  /**
+   * Checks if the sandboxed preview rendered frame is present.
+   */
+  async hasRenderedFrame(): Promise<boolean> {
+    const frame = await this.getRenderedFrame();
+    return !!frame;
   }
 
   /**

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -21,6 +21,8 @@ import {
   CreateSurfaceDetails,
   UpdateComponentsDetails,
   UpdateDataModelDetails,
+  SetBlockingStatePayload,
+  DataModelChangePayload,
 } from 'a2ui-bridge';
 
 /**
@@ -64,105 +66,8 @@ export class CrossFrameValidator {
         }
 
         for (const item of msgPayload) {
-          if (!item || typeof item !== 'object' || Array.isArray(item)) {
-            console.error('Malformed payload for RENDER_A2UI: array items must be objects.');
+          if (!this.validateSingleRenderMessage(item)) {
             return false;
-          }
-
-          const itemObj = item as RenderA2uiItem;
-          if (itemObj['version'] !== 'v0.9') {
-            console.error(
-              'Malformed payload for RENDER_A2UI: array items must specify version "v0.9".',
-            );
-            return false;
-          }
-
-          const updateKeys = [
-            'createSurface',
-            'updateComponents',
-            'updateDataModel',
-            'deleteSurface',
-          ];
-          const presentKeys = updateKeys.filter(
-            key => key in itemObj && itemObj[key] !== undefined,
-          );
-
-          if (presentKeys.length === 0) {
-            console.error(
-              'Malformed payload for RENDER_A2UI: item must contain an update property (createSurface, updateComponents, updateDataModel, or deleteSurface).',
-            );
-            return false;
-          }
-
-          if (presentKeys.length > 1) {
-            console.error(
-              `Malformed payload for RENDER_A2UI: item must contain exactly one update property, but found: ${presentKeys.join(', ')}.`,
-            );
-            return false;
-          }
-
-          const updateType = presentKeys[0];
-          const updateObj = itemObj[updateType];
-
-          if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
-            console.error(
-              `Malformed payload for RENDER_A2UI: ${updateType} property must be an object.`,
-            );
-            return false;
-          }
-
-          const updateData = updateObj as BaseSurfaceDetails;
-          if (typeof updateData['surfaceId'] !== 'string') {
-            console.error(
-              `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
-            );
-            return false;
-          }
-
-          if (updateType === 'createSurface') {
-            const createDetails = updateObj as CreateSurfaceDetails;
-            if (typeof createDetails['catalogId'] !== 'string') {
-              console.error(
-                'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
-              );
-              return false;
-            }
-            if (
-              createDetails['sendDataModel'] !== undefined &&
-              typeof createDetails['sendDataModel'] !== 'boolean'
-            ) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
-              );
-              return false;
-            }
-          } else if (updateType === 'updateComponents') {
-            const updateCompDetails = updateObj as UpdateComponentsDetails;
-            if (!Array.isArray(updateCompDetails['components'])) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
-              );
-              return false;
-            }
-            for (const comp of updateCompDetails['components']) {
-              if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
-                console.error(
-                  'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
-                );
-                return false;
-              }
-            }
-          } else if (updateType === 'updateDataModel') {
-            const updateModelDetails = updateObj as UpdateDataModelDetails;
-            if (
-              updateModelDetails['path'] !== undefined &&
-              typeof updateModelDetails['path'] !== 'string'
-            ) {
-              console.error(
-                'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
-              );
-              return false;
-            }
           }
         }
         return true;
@@ -174,7 +79,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const blockingState = msgPayload as Record<string, unknown>;
+        const blockingState = msgPayload as SetBlockingStatePayload;
         if (typeof blockingState['blocked'] !== 'boolean') {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: must contain boolean property blocked.',
@@ -199,7 +104,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const changePayload = msgPayload as Record<string, unknown>;
+        const changePayload = msgPayload as DataModelChangePayload;
         const updateObj = changePayload['updateDataModel'];
         if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
           console.error(
@@ -208,7 +113,7 @@ export class CrossFrameValidator {
           return false;
         }
 
-        const updateData = updateObj as Record<string, unknown>;
+        const updateData = updateObj as UpdateDataModelDetails;
         if (typeof updateData['surfaceId'] !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel must contain a valid surfaceId string.',
@@ -229,5 +134,101 @@ export class CrossFrameValidator {
         return true;
       }
     }
+  }
+
+  private static validateSingleRenderMessage(item: unknown): boolean {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      console.error('Malformed payload for RENDER_A2UI: array items must be objects.');
+      return false;
+    }
+
+    // NOTE: Bracket notation is used to access properties on cross-frame message objects
+    // to prevent compilers from renaming these properties during production minification.
+    const itemObj = item as RenderA2uiItem;
+    if (itemObj['version'] !== 'v0.9') {
+      console.error('Malformed payload for RENDER_A2UI: array items must specify version "v0.9".');
+      return false;
+    }
+
+    const updateKeys = ['createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface'];
+    const presentKeys = updateKeys.filter(key => key in itemObj && itemObj[key] !== undefined);
+
+    if (presentKeys.length === 0) {
+      console.error(
+        'Malformed payload for RENDER_A2UI: item must contain an update property (createSurface, updateComponents, updateDataModel, or deleteSurface).',
+      );
+      return false;
+    }
+
+    if (presentKeys.length > 1) {
+      console.error(
+        `Malformed payload for RENDER_A2UI: item must contain exactly one update property, but found: ${presentKeys.join(', ')}.`,
+      );
+      return false;
+    }
+
+    const updateType = presentKeys[0];
+    const updateObj = itemObj[updateType];
+
+    if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
+      console.error(`Malformed payload for RENDER_A2UI: ${updateType} property must be an object.`);
+      return false;
+    }
+
+    const updateData = updateObj as BaseSurfaceDetails;
+    if (typeof updateData['surfaceId'] !== 'string') {
+      console.error(
+        `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
+      );
+      return false;
+    }
+
+    if (updateType === 'createSurface') {
+      const createDetails = updateObj as CreateSurfaceDetails;
+      if (typeof createDetails['catalogId'] !== 'string') {
+        console.error(
+          'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
+        );
+        return false;
+      }
+      if (
+        createDetails['sendDataModel'] !== undefined &&
+        typeof createDetails['sendDataModel'] !== 'boolean'
+      ) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
+        );
+        return false;
+      }
+    } else if (updateType === 'updateComponents') {
+      const updateCompDetails = updateObj as UpdateComponentsDetails;
+      if (!Array.isArray(updateCompDetails['components'])) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
+        );
+        return false;
+      }
+      for (const comp of updateCompDetails['components']) {
+        if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
+          console.error(
+            'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
+          );
+          return false;
+        }
+      }
+    } else if (updateType === 'updateDataModel') {
+      const updateModelDetails = updateObj as UpdateDataModelDetails;
+      if (
+        updateModelDetails['path'] !== undefined &&
+        typeof updateModelDetails['path'] !== 'string'
+      ) {
+        console.error(
+          'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -455,4 +455,90 @@ describe('HostCommunication', () => {
 
     removeEventListenerSpy.mockRestore();
   });
+
+  it('caches the latest catalog envelope when receiving an A2UI_CATALOG message', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    const catalogPayload = {components: {}};
+    const event = new MessageEvent('message', {
+      source: mockIframeWindow,
+      origin: 'http://localhost:3000',
+      data: {
+        type: PreviewBridgeMessageType.A2UI_CATALOG,
+        payload: catalogPayload,
+      },
+    });
+
+    window.dispatchEvent(event);
+
+    const latestCatalog = service.getLatestCatalog();
+    expect(latestCatalog).toEqual({
+      type: PreviewBridgeMessageType.A2UI_CATALOG,
+      payload: catalogPayload,
+      origin: 'http://localhost:3000',
+      timestamp: expect.any(Number),
+    });
+
+    const history = service.getHistoryBuffer();
+    expect(history.length).toBe(1);
+    expect(history[0].type).toBe(PreviewBridgeMessageType.A2UI_CATALOG);
+  });
+
+  it('caps the message history buffer at 100 entries strictly using FIFO eviction', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    for (let i = 0; i < 105; i++) {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {
+            type: PreviewBridgeMessageType.RENDERER_READY,
+            payload: {index: i},
+          },
+        }),
+      );
+    }
+
+    const history = service.getHistoryBuffer();
+    expect(history.length).toBe(100);
+    expect(history[0].payload).toEqual({index: 5});
+    expect(history[99].payload).toEqual({index: 104});
+  });
+
+  it('catches and logs errors thrown by listeners without crashing the message dispatch loop', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const throwingListener = vi.fn().mockImplementation(() => {
+      throw new Error('Listener failed');
+    });
+    const safeListener = vi.fn();
+
+    service.addListener(throwingListener);
+    service.addListener(safeListener);
+
+    const event = new MessageEvent('message', {
+      source: mockIframeWindow,
+      origin: 'http://localhost:3000',
+      data: {type: PreviewBridgeMessageType.RENDERER_READY},
+    });
+
+    window.dispatchEvent(event);
+
+    expect(throwingListener).toHaveBeenCalledTimes(1);
+    expect(safeListener).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error in HostCommunication listener:',
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+    service.removeListener(throwingListener);
+    service.removeListener(safeListener);
+  });
 });


### PR DESCRIPTION
# Description

add end-to-end user journey e2e playwright tests

Creates Playwright test coverage verifying navigation to the gallery page, dynamic component selection, properties table
rendering, preview iframe mounting, and copy-to-clipboard.

This is the last in a series of PRs which culminates in a dynamically generated page to show the components of the current catalog: 
<img width="1586" height="961" alt="image" src="https://github.com/user-attachments/assets/1fd0b818-8c81-4a9e-a926-3d0057551944" />

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
