### PR TITLE
configure Vitest test pool to threads to fix Node 24 ESM link failures

### DIFF
--- a/shell/vitest.config.ts
+++ b/shell/vitest.config.ts
@@ -20,6 +20,7 @@ import angular from '@analogjs/vite-plugin-angular';
 export default defineConfig({
   plugins: [angular({jit: true, tsconfig: './tsconfig.spec.json'})],
   test: {
+    pool: 'threads',
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.spec.ts'],


### PR DESCRIPTION
# Description

Switch to use `threads` instead of the default `forks` pool. This should eliminate the occasional transient failures seen in running unit tests.

By switching to threads, we reduce the memory and CPU footprint of the test run, which stops the GitHub Actions runner from throttling. It also replaces slower OS-level IPC with low-latency in-process messaging.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
