### PR TITLE
Explain why we're stripping out the prefix before reading the JSON.

### DIFF
--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -53,6 +53,12 @@ export class StartupResolution {
     try {
       const response = await fetch('config.json', {signal: controller.signal});
       if (response.ok) {
+        // Although we *expect* JSON, it's possible that the response includes
+        // a JSON Vulnerability Protection prefixes (often referred to as an
+        // XSSI - Cross-Site Script Inclusion prefix).
+        // To prevent attacks, Google APIs and frameworks (like Angular) prefix
+        // JSON payloads with a non-executable, syntactically invalid JavaScript
+        // prefix—most commonly )]}' followed by a newline.
         const text = await response.text();
         const cleanText = text.replace(/^\)]}'\s*/, '');
         staticConfig = JSON.parse(cleanText);


### PR DESCRIPTION
# Description

Comment on the hard-to-read regex when reading the config.json file.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
