### PR TITLE
Make Gemini API Key optional for 3P use case

### DIFF
--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -80,7 +80,7 @@ test.describe('Settings and Client Configuration', () => {
       expect(rendererVal).toBe('http://locked-renderer.com');
     });
 
-    test('verifies 1P vs 3P environment detection and automatic redirection on missing API keys', async ({
+    test('verifies 1P vs 3P environment detection and disables chat panel on missing API keys', async ({
       page,
     }) => {
       await page.goto('/?renderer=http://localhost:3000');
@@ -91,8 +91,11 @@ test.describe('Settings and Client Configuration', () => {
         } catch (e) {}
       });
       await page.reload();
-      await page.waitForURL('**/settings');
-      await expect(page.getByLabel('Gemini API Key')).toBeVisible();
+      await page.waitForURL(url => url.pathname === '/');
+      await expect(page.locator('.disabled-chat-panel')).toBeVisible();
+      await expect(page.locator('.disabled-notice-text')).toContainText(
+        'This feature is only available with a valid Gemini API key.',
+      );
     });
 
     test('verifies forced 3P authentication mode toggle and API key provisioning panel visibility', async ({
@@ -115,7 +118,8 @@ test.describe('Settings and Client Configuration', () => {
         name: 'Force External Third-Party Authentication Mode',
       });
       await force3pSwitch.click();
-      await page.waitForURL('**/settings');
+      await page.waitForURL(url => url.pathname === '/');
+      await page.goto('/settings');
 
       const isForce3p = await page.evaluate(() => localStorage.getItem('a2ui_composer_force_3p'));
       expect(isForce3p).toBe('true');

--- a/shell/e2e/user-journey.e2e.ts
+++ b/shell/e2e/user-journey.e2e.ts
@@ -52,7 +52,8 @@ test.describe('E2E Workspace User Journey', () => {
       name: 'Force External Third-Party Authentication Mode',
     });
     await force3pSwitch.click();
-    await page.waitForURL('**/settings');
+    await page.waitForURL(url => url.pathname === '/');
+    await page.goto('/settings');
 
     const isForce3p = await page.evaluate(() => localStorage.getItem('a2ui_composer_force_3p'));
     expect(isForce3p).toBe('true');
@@ -68,6 +69,7 @@ test.describe('E2E Workspace User Journey', () => {
     );
     expect(isForce3pAfter).toBeNull();
 
+    await page.goto('/settings');
     await expect(page.getByText('Gemini API Provisioning')).not.toBeVisible();
 
     // 6. Switch back to Workspace

--- a/shell/e2e/workspace-routing-bootstrapping.e2e.ts
+++ b/shell/e2e/workspace-routing-bootstrapping.e2e.ts
@@ -23,11 +23,31 @@ test.beforeEach(async ({page}) => {
 });
 
 test.describe('Startup Resolution & Redirection', () => {
-  test('redirects unconfigured boot at root to settings page with card layout', async ({page}) => {
+  test('redirects unconfigured boot (missing renderer URL) at root to settings page with card layout', async ({
+    page,
+  }) => {
+    await page.route('**/config.json', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          allowOverrides: true,
+          // no defaultRendererUrl
+        }),
+      });
+    });
     await page.goto('/');
     await page.waitForURL('**/settings');
     await expect(page.locator('.settings-container')).toBeVisible();
     await expect(page.locator('.settings-card')).toBeVisible();
+  });
+
+  test('does not redirect if default renderer URL is present but API key is missing', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.waitForURL(url => url.pathname === '/');
+    await expect(page.locator('.workspace-container')).toBeVisible();
+    await expect(page.locator('.disabled-chat-panel')).toBeVisible();
   });
 });
 

--- a/shell/src/app/chat/chat-panel/chat-panel.ng.html
+++ b/shell/src/app/chat/chat-panel/chat-panel.ng.html
@@ -40,83 +40,95 @@
     <span class="panel-title-text">Gemini Assistant</span>
   </div>
 
-  <div class="frame-body chat-history-log">
-    @if (visibleChatHistory().length === 0) {
-      <div class="empty-state-notice">
-        <span class="empty-state-icon">💬</span>
-        <p class="empty-state-text">
-          Ask Gemini to shape your layout interfaces or generate dynamic mock configurations
-          schemas. Let's get started!
-        </p>
-      </div>
-    } @else {
-      @for (turn of visibleChatHistory(); track $index) {
-        <div class="chat-bubble-container" [class]="getBubbleClass(turn)">
-          <div class="bubble-header-bar">
-            @if (turn.role === 'user') {
-              <span class="bubble-author-name">{{
-                turn.isSnapshot ? 'Canvas Revision Snapshot' : 'You'
-              }}</span>
-            } @else if (turn.role === 'model') {
-              <span class="bubble-author-name">Gemini AI</span>
-            } @else if (turn.role === 'error') {
-              <span class="bubble-author-name error-label">Gateway Exception Diagnostic</span>
-            }
-          </div>
-
-          <div class="bubble-body">
-            @if (turn.isSnapshot) {
-              <p class="bubble-text-content">A2UI JSON: {{ turn.componentCount }} components</p>
-            } @else {
-              <p class="bubble-text-content">{{ turn.content }}</p>
-              @if (turn.isRetryable) {
-                <div class="retry-action-container">
-                  <button
-                    mat-stroked-button
-                    color="primary"
-                    class="retry-button"
-                    [disabled]="isLocked()"
-                    (click)="retryPrompt(turn.originalPrompt || '')"
-                  >
-                    <mat-icon aria-hidden="true">refresh</mat-icon>
-                    Retry Request
-                  </button>
-                </div>
-              }
-            }
-          </div>
-        </div>
-      }
-    }
-  </div>
-
-  <!-- Footer Prompts textareas and lockout submits controls block -->
-  <div class="chat-controllers-panel">
-    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="prompt-form-field">
-      <textarea
-        matInput
-        aria-label="Chat prompt"
-        [ngModel]="userPrompt()"
-        (ngModelChange)="userPrompt.set($event)"
-        [disabled]="isLocked()"
-        (keydown)="onKeyDown($event)"
-        placeholder="Type instruction to shape your screen (e.g. 'Add a checkbox column')..."
-        rows="2"
-      ></textarea>
-    </mat-form-field>
-    <div class="submit-action-bar">
-      <button mat-button class="system-instructions-link" (click)="showSystemInstructions()">
-        Show system instructions
-      </button>
-      <button
-        mat-raised-button
-        color="primary"
-        class="submit-button"
-        [disabled]="isLocked() || !isHandshakeComplete() || !userPrompt().trim()"
-        (click)="submitPrompt()"
-      >
-        Send
-      </button>
+  @if (isChatDisabled()) {
+    <div class="disabled-chat-panel">
+      <mat-icon class="disabled-key-icon" aria-hidden="true">vpn_key</mat-icon>
+      <p class="disabled-notice-text">
+        This feature is only available with a valid Gemini API key.
+      </p>
+      <a mat-flat-button color="primary" routerLink="/settings" class="add-key-button">
+        Add Gemini API key
+      </a>
     </div>
-  </div>
+  } @else {
+    <div class="frame-body chat-history-log">
+      @if (visibleChatHistory().length === 0) {
+        <div class="empty-state-notice">
+          <span class="empty-state-icon">💬</span>
+          <p class="empty-state-text">
+            Ask Gemini to shape your layout interfaces or generate dynamic mock configurations
+            schemas. Let's get started!
+          </p>
+        </div>
+      } @else {
+        @for (turn of visibleChatHistory(); track $index) {
+          <div class="chat-bubble-container" [class]="getBubbleClass(turn)">
+            <div class="bubble-header-bar">
+              @if (turn.role === 'user') {
+                <span class="bubble-author-name">{{
+                  turn.isSnapshot ? 'Canvas Revision Snapshot' : 'You'
+                }}</span>
+              } @else if (turn.role === 'model') {
+                <span class="bubble-author-name">Gemini AI</span>
+              } @else if (turn.role === 'error') {
+                <span class="bubble-author-name error-label">Gateway Exception Diagnostic</span>
+              }
+            </div>
+
+            <div class="bubble-body">
+              @if (turn.isSnapshot) {
+                <p class="bubble-text-content">A2UI JSON: {{ turn.componentCount }} components</p>
+              } @else {
+                <p class="bubble-text-content">{{ turn.content }}</p>
+                @if (turn.isRetryable) {
+                  <div class="retry-action-container">
+                    <button
+                      mat-stroked-button
+                      color="primary"
+                      class="retry-button"
+                      [disabled]="isLocked()"
+                      (click)="retryPrompt(turn.originalPrompt || '')"
+                    >
+                      <mat-icon aria-hidden="true">refresh</mat-icon>
+                      Retry Request
+                    </button>
+                  </div>
+                }
+              }
+            </div>
+          </div>
+        }
+      }
+    </div>
+
+    <!-- Footer Prompts textareas and lockout submits controls block -->
+    <div class="chat-controllers-panel">
+      <mat-form-field appearance="outline" subscriptSizing="dynamic" class="prompt-form-field">
+        <textarea
+          matInput
+          aria-label="Chat prompt"
+          [ngModel]="userPrompt()"
+          (ngModelChange)="userPrompt.set($event)"
+          [disabled]="isLocked()"
+          (keydown)="onKeyDown($event)"
+          placeholder="Type instruction to shape your screen (e.g. 'Add a checkbox column')..."
+          rows="2"
+        ></textarea>
+      </mat-form-field>
+      <div class="submit-action-bar">
+        <button mat-button class="system-instructions-link" (click)="showSystemInstructions()">
+          Show system instructions
+        </button>
+        <button
+          mat-raised-button
+          color="primary"
+          class="submit-button"
+          [disabled]="isLocked() || !isHandshakeComplete() || !userPrompt().trim()"
+          (click)="submitPrompt()"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  }
 </div>

--- a/shell/src/app/chat/chat-panel/chat-panel.scss
+++ b/shell/src/app/chat/chat-panel/chat-panel.scss
@@ -479,3 +479,31 @@
     font-size: 12px;
   }
 }
+
+.disabled-chat-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  text-align: center;
+  padding: 32px;
+  background-color: var(--mat-sys-surface-container-low);
+  box-sizing: border-box;
+
+  .disabled-key-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    margin-bottom: 16px;
+    color: var(--mat-sys-outline);
+  }
+
+  .disabled-notice-text {
+    font-size: var(--mat-sys-body-medium-size);
+    line-height: 1.5;
+    margin: 0 0 24px 0;
+    max-width: 260px;
+    color: var(--mat-sys-on-surface-variant);
+  }
+}

--- a/shell/src/app/chat/chat-panel/chat-panel.spec.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.spec.ts
@@ -19,7 +19,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ChatPanel} from './chat-panel';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ChatPanelHarness} from './test/chat-panel.harness';
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {ChatCoordinator} from '../chat-service/chat-coordinator';
 import {ChatState, LlmLogEntry, LlmLogType} from '../chat-state/chat-state';
 import {signal, inject} from '@angular/core';
@@ -27,8 +27,11 @@ import {LlmMessage} from '../llm-client/llm-client';
 import {MessageRole} from '../llm-client/llm-client';
 import {PipelineStatus} from '../pipeline-status/pipeline-status';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
+import {provideRouter} from '@angular/router';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {MatDialogHarness} from '@angular/material/dialog/testing';
+import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {Catalog} from '../../storage/models/catalog-storage.model';
 
@@ -87,21 +90,37 @@ class MockCatalogManagement {
   readonly activeCatalog = signal<Catalog | null>({}); // non-null by default
 }
 
+class MockStartupResolution {
+  is3PVal = false;
+  isThirdPartyEnvironment() {
+    return this.is3PVal;
+  }
+}
+
+class MockAppConfigProvider {
+  geminiApiKey = signal<string>('AIzaSyValidKey');
+}
+
 describe('ChatPanel Gemini Dialogue Panel Integration', () => {
   let fixture: ComponentFixture<ChatPanel>;
   let harness: ChatPanelHarness;
   let chatServiceMock: MockChatCoordinator;
   let chatStateMock: MockChatState;
   let catalogManagementServiceMock: MockCatalogManagement;
+  let startupResolutionMock: MockStartupResolution;
+  let configProviderMock: MockAppConfigProvider;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ChatPanel],
       providers: [
         provideNoopAnimations(),
+        provideRouter([]),
         {provide: ChatCoordinator, useClass: MockChatCoordinator},
         {provide: ChatState, useClass: MockChatState},
         {provide: CatalogManagement, useClass: MockCatalogManagement},
+        {provide: StartupResolution, useClass: MockStartupResolution},
+        {provide: AppConfigProvider, useClass: MockAppConfigProvider},
       ],
     }).compileComponents();
 
@@ -110,9 +129,17 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     catalogManagementServiceMock = TestBed.inject(
       CatalogManagement,
     ) as unknown as MockCatalogManagement;
+    startupResolutionMock = TestBed.inject(StartupResolution) as unknown as MockStartupResolution;
+    configProviderMock = TestBed.inject(AppConfigProvider) as unknown as MockAppConfigProvider;
     fixture = TestBed.createComponent(ChatPanel);
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ChatPanelHarness);
+  });
+
+  afterEach(() => {
+    if (fixture) {
+      fixture.destroy();
+    }
   });
 
   it(
@@ -420,5 +447,33 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     hiddenAttrs.forEach(attr => {
       expect(attr).toBe('true');
     });
+  });
+
+  it('disables the chat panel when in a 3P environment and the API key is empty', async () => {
+    startupResolutionMock.is3PVal = true;
+    configProviderMock.geminiApiKey.set('');
+    fixture.detectChanges();
+
+    expect(await harness.isDisabled()).toBe(true);
+    expect(await harness.getDisabledNoticeText()).toContain(
+      'This feature is only available with a valid Gemini API key.',
+    );
+    expect(await harness.hasAddKeyButton()).toBe(true);
+  });
+
+  it('keeps the chat panel active in 1P environment even if API key is empty', async () => {
+    startupResolutionMock.is3PVal = false;
+    configProviderMock.geminiApiKey.set('');
+    fixture.detectChanges();
+
+    expect(await harness.isDisabled()).toBe(false);
+  });
+
+  it('keeps the chat panel active in 3P environment if API key is supplied', async () => {
+    startupResolutionMock.is3PVal = true;
+    configProviderMock.geminiApiKey.set('AIzaSyValidKey');
+    fixture.detectChanges();
+
+    expect(await harness.isDisabled()).toBe(false);
   });
 });

--- a/shell/src/app/chat/chat-panel/chat-panel.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.ts
@@ -30,6 +30,9 @@ import {MatDialogModule, MatDialog} from '@angular/material/dialog';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {SystemInstructionsDialog} from '../system-instructions-dialog/system-instructions-dialog';
 import {tryParseJsonArray} from '../../utils/json';
+import {RouterLink} from '@angular/router';
+import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {RenderA2uiItem} from 'a2ui-bridge';
 
 /**
@@ -49,6 +52,7 @@ import {RenderA2uiItem} from 'a2ui-bridge';
     MatProgressSpinnerModule,
     MatIconModule,
     MatDialogModule,
+    RouterLink,
   ],
   templateUrl: './chat-panel.ng.html',
   styleUrl: './chat-panel.scss',
@@ -58,6 +62,8 @@ export class ChatPanel {
   private readonly chatState = inject(ChatState);
   private readonly dialog = inject(MatDialog);
   private readonly catalogManagement = inject(CatalogManagement);
+  private readonly startupResolution = inject(StartupResolution);
+  private readonly configProvider = inject(AppConfigProvider);
 
   /**
    * Reactively computed dynamic system prompt instructions spec viewport
@@ -67,6 +73,11 @@ export class ChatPanel {
   protected readonly isHandshakeComplete = computed(
     () => this.catalogManagement.activeCatalog() !== null,
   );
+  protected readonly isChatDisabled = computed(() => {
+    const is3P = this.startupResolution.isThirdPartyEnvironment();
+    const hasNoKey = !this.configProvider.geminiApiKey();
+    return is3P && hasNoKey;
+  });
 
   /**
    * Exposes the active streaming pipeline execution status point

--- a/shell/src/app/chat/chat-panel/test/chat-panel.harness.ts
+++ b/shell/src/app/chat/chat-panel/test/chat-panel.harness.ts
@@ -185,4 +185,26 @@ export class ChatPanelHarness extends ComponentHarness {
     const icons = await this.locatorForAll('mat-icon')();
     return Promise.all(icons.map(i => i.getAttribute('aria-hidden')));
   }
+
+  async isDisabled(): Promise<boolean> {
+    const panel = await this.locatorForOptional('.disabled-chat-panel')();
+    return panel !== null;
+  }
+
+  async getDisabledNoticeText(): Promise<string | null> {
+    const textNode = await this.locatorForOptional('.disabled-notice-text')();
+    if (!textNode) return null;
+    return textNode.text();
+  }
+
+  async hasAddKeyButton(): Promise<boolean> {
+    const btn = await this.locatorForOptional('.add-key-button')();
+    return btn !== null;
+  }
+
+  async clickAddKeyButton(): Promise<void> {
+    const btn = await this.locatorForOptional('.add-key-button')();
+    if (!btn) throw new Error('Add API key button not found.');
+    await btn.click();
+  }
 }

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -29,7 +29,8 @@ class MockSecureCredentialsStorage {
   private storage = new Map<string, string>();
 
   async getCredential(key: string): Promise<string | null> {
-    return Promise.resolve(this.storage.get(key) || null);
+    const val = this.storage.get(key);
+    return Promise.resolve(val !== undefined ? val : null);
   }
 
   async setCredential(key: string, value: string): Promise<void> {
@@ -103,6 +104,26 @@ describe('LocalStorageAppConfigProvider', () => {
     const provider = setupProvider();
     await provider.initialize();
     expect(provider.geminiApiKey()).toBe('test-key-xyz');
+  });
+
+  it('initializes geminiApiKey with a trimmed stored API key', async () => {
+    await mockSecureStorage.setCredential(SecureCredentialsKey.GEMINI_API_KEY, '  test-key-xyz  ');
+    const provider = setupProvider();
+    await provider.initialize();
+    expect(provider.geminiApiKey()).toBe('test-key-xyz');
+  });
+
+  it('initializes geminiApiKey with an empty string when stored API key is not present', async () => {
+    const provider = setupProvider();
+    await provider.initialize();
+    expect(provider.geminiApiKey()).toBe('');
+  });
+
+  it('initializes geminiApiKey with an empty string when stored API key is empty or whitespace', async () => {
+    await mockSecureStorage.setCredential(SecureCredentialsKey.GEMINI_API_KEY, '   ');
+    const provider = setupProvider();
+    await provider.initialize();
+    expect(provider.geminiApiKey()).toBe('');
   });
 
   it('initializes rendererUrl with stored renderer URL if present', () => {
@@ -192,6 +213,29 @@ describe('LocalStorageAppConfigProvider', () => {
     expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBe(
       'fresh-token',
     );
+  });
+
+  it('trims the API key before persisting and updating signal', async () => {
+    const provider = setupProvider();
+    await provider.setGeminiApiKey('  fresh-token  ');
+    expect(provider.geminiApiKey()).toBe('fresh-token');
+    expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBe(
+      'fresh-token',
+    );
+  });
+
+  it('handles empty string in setGeminiApiKey', async () => {
+    const provider = setupProvider();
+    await provider.setGeminiApiKey('');
+    expect(provider.geminiApiKey()).toBe('');
+    expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBe('');
+  });
+
+  it('handles whitespace-only string in setGeminiApiKey by trimming to empty string', async () => {
+    const provider = setupProvider();
+    await provider.setGeminiApiKey('   ');
+    expect(provider.geminiApiKey()).toBe('');
+    expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBe('');
   });
 
   it('persists updated theme selection to localStorage and updates signal', () => {

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -82,7 +82,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
       const key = await this.secureCredentialsStorage.getCredential(
         SecureCredentialsKey.GEMINI_API_KEY,
       );
-      this._geminiApiKey.set(key || '');
+      this._geminiApiKey.set((key || '').trim());
     } catch (err) {
       console.warn(
         'Failed to resolve credentials from SecureCredentialsStorage during bootstrap',
@@ -146,8 +146,12 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
    */
   override async setGeminiApiKey(key: string): Promise<void> {
     try {
-      await this.secureCredentialsStorage.setCredential(SecureCredentialsKey.GEMINI_API_KEY, key);
-      this._geminiApiKey.set(key);
+      const trimmedKey = key.trim();
+      await this.secureCredentialsStorage.setCredential(
+        SecureCredentialsKey.GEMINI_API_KEY,
+        trimmedKey,
+      );
+      this._geminiApiKey.set(trimmedKey);
     } catch (err) {
       console.warn('Failed to persist Gemini API key to SecureCredentialsStorage', err);
       throw err;

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -77,8 +77,10 @@
                   hideApiKey() ? 'visibility' : 'visibility_off'
                 }}</mat-icon>
               </button>
-              @if (settingsForm.controls.apiKey.hasError('required')) {
-                <mat-error>Gemini API key is required in external environments.</mat-error>
+              @if (!settingsForm.controls.apiKey.value) {
+                <mat-hint class="warning-hint"
+                  >Gemini Assistant feature will be disabled without a valid API key.</mat-hint
+                >
               }
               @if (settingsForm.controls.apiKey.hasError('pattern')) {
                 <mat-error>API key cannot be empty whitespace.</mat-error>

--- a/shell/src/app/settings/settings-view/settings.scss
+++ b/shell/src/app/settings/settings-view/settings.scss
@@ -44,8 +44,8 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  background-color: #fff3e0;
-  color: #e65100;
+  background-color: var(--mat-sys-error-container);
+  color: var(--mat-sys-on-error-container);
   border-radius: 6px;
   margin-bottom: 16px;
   font-size: 13px;
@@ -93,4 +93,10 @@
     line-height: 1.4 !important;
     color: var(--mat-sys-on-surface) !important;
   }
+}
+
+.warning-hint {
+  color: var(--mat-sys-on-surface-variant);
+  display: block;
+  margin-top: 4px;
 }

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -184,12 +184,13 @@ describe('Settings', () => {
     expect(reloadSpy).toHaveBeenCalled();
   });
 
-  it('enforces apiKey requirement in 3P mode and rejects empty whitespace keys', async () => {
+  it('rejects empty whitespace keys in 3P mode but permits missing keys', async () => {
     mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
     const {component, harness} = await setupComponent();
 
     expect(component.isThirdParty()).toBe(true);
-    expect(component.settingsForm.controls.apiKey.errors?.['required']).toBeTruthy();
+    expect(component.settingsForm.controls.apiKey.errors?.['required']).toBeFalsy();
+    expect(component.settingsForm.valid).toBe(true);
 
     await harness.setRendererUrlValue('http://new-url.com');
     await harness.setGeminiApiKeyValue('   ');
@@ -305,9 +306,8 @@ describe('Settings', () => {
     fixture.detectChanges();
 
     const errors = await harness.getErrorsText();
-    expect(errors.length).toBe(2);
+    expect(errors.length).toBe(1);
     expect(errors[0]).toContain('Renderer URL is required');
-    expect(errors[1]).toContain('Gemini API key is required');
 
     await harness.setRendererUrlValue('invalid-url');
     await harness.setGeminiApiKeyValue('valid-key');

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -106,7 +106,7 @@ export class Settings implements OnInit {
 
     if (is3P) {
       const apiKeyControl = this.settingsForm.controls.apiKey;
-      apiKeyControl.setValidators([Validators.required, Validators.pattern(/\S/)]);
+      apiKeyControl.setValidators([Validators.pattern(/\S/)]);
       apiKeyControl.updateValueAndValidity();
     }
   }

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -20,6 +20,7 @@ import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComposerWorkspaceHarness} from './test/composer-workspace.harness';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
+import {provideRouter} from '@angular/router';
 import {HostCommunication} from '../host-communication/host-communication';
 import {StartupResolution} from '../startup-resolution/startup-resolution';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
@@ -111,6 +112,7 @@ describe('ComposerWorkspace Dashboard', () => {
       imports: [ComposerWorkspace],
       providers: [
         provideNoopAnimations(),
+        provideRouter([]),
         {provide: ChatState, useClass: MockChatState},
         {provide: ChatCoordinator, useClass: MockChatCoordinator},
         {provide: StateSync, useClass: MockStateSync},

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -161,9 +161,9 @@ describe('StartupResolution Task 2.6', () => {
 
     vi.spyOn(service, 'getWindowHostname').mockReturnValue('localhost');
 
-    // Scenario 1: URL resolved, but 3P missing API key -> invalid
+    // Scenario 1: URL resolved, and 3P missing API key -> valid
     await service.resolveStartupConfiguration();
-    expect(await service.isEnvironmentValid()).toBe(false);
+    expect(await service.isEnvironmentValid()).toBe(true);
 
     // Scenario 2: URL resolved, and 3P has API key -> valid
     mockConfigProvider.geminiApiKey.set('AIzaSyValidKey');

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -127,15 +127,7 @@ export class StartupResolution {
 
   async isEnvironmentValid(): Promise<boolean> {
     const resolvedUrl = this.getResolvedRendererUrl();
-    const is3P = this.isThirdPartyEnvironment();
-    let hasApiKey = false;
-
-    try {
-      const configProvider = this.injector.get(AppConfigProvider);
-      hasApiKey = !!configProvider.geminiApiKey();
-    } catch (err) {}
-
-    return !!resolvedUrl && (!is3P || hasApiKey);
+    return !!resolvedUrl;
   }
 
   isExtensionMode(): boolean {


### PR DESCRIPTION
# Description

Use of a Gemini API key is now optional. If not provided, the chat panel won't be available, but everything else works.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
