### PR TITLE
Improvements for generating A2UI component usage.

### DIFF
--- a/shell/src/app/gallery/gallery.scss
+++ b/shell/src/app/gallery/gallery.scss
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+:host {
+  display: block;
+  height: 100%;
+}
+
 .gallery-container {
   height: 100%;
   width: 100%;
@@ -82,6 +87,8 @@
 }
 
 .gallery-content {
+  box-sizing: border-box;
+  height: 100%;
   padding: 24px;
   background-color: var(--mat-sys-background, #fafafa);
   overflow-y: auto;

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -222,7 +222,7 @@ describe('Gallery Component', () => {
 
     const expectedPayload =
       `{"version":"v0.9","createSurface":{"surfaceId":"gallery-preview","catalogId":"https://a2ui.org/custom_catalog.json"}}\n` +
-      `{"version":"v0.9","updateComponents":{"surfaceId":"gallery-preview","components":[{"id":"target","component":"Text"}]}}`;
+      `{"version":"v0.9","updateComponents":{"surfaceId":"gallery-preview","components":[{"id":"root","component":"Text"}]}}`;
 
     expect(writeTextSpy).toHaveBeenCalledWith(expectedPayload);
   });
@@ -416,7 +416,13 @@ describe('Gallery Component', () => {
         updateComponents: {
           surfaceId: 'gallery-preview',
           components: [
-            {id: 'root', component: 'Column', children: ['target']},
+            {
+              id: 'root',
+              component: 'Column',
+              align: 'center',
+              justify: 'center',
+              children: ['target'],
+            },
             {id: 'target', component: 'Text'},
           ],
         },
@@ -447,7 +453,7 @@ describe('Gallery Component', () => {
         version: 'v0.9',
         updateComponents: {
           surfaceId: 'gallery-preview',
-          components: [{id: 'target', component: 'Text'}],
+          components: [{id: 'root', component: 'Text'}],
         },
       },
     ]);
@@ -499,7 +505,13 @@ describe('Gallery Component', () => {
         updateComponents: {
           surfaceId: 'gallery-preview',
           components: [
-            {id: 'root', component: 'coLuMn', children: ['target']},
+            {
+              id: 'root',
+              component: 'coLuMn',
+              align: 'center',
+              justify: 'center',
+              children: ['target'],
+            },
             {id: 'target', component: 'Text'},
           ],
         },
@@ -550,21 +562,6 @@ describe('Gallery Component', () => {
       catalogId: 'mock-id',
     });
     catalogServiceMock.selectedComponentKey.set('Text');
-    expect(
-      (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
-    ).toBe('');
-  });
-
-  it('selectedComponentDescription returns empty string if active catalog is null and key is truthy', () => {
-    catalogManagementMock.activeCatalog.set(null);
-    catalogServiceMock.selectedComponentKey.set('Text');
-    expect(
-      (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
-    ).toBe('');
-  });
-
-  it('selectedComponentDescription returns empty string if selectedComponentKey is null', () => {
-    catalogServiceMock.selectedComponentKey.set(null);
     expect(
       (fixture.componentInstance as unknown as TestFriendlyGallery).selectedComponentDescription(),
     ).toBe('');
@@ -649,7 +646,16 @@ describe('Gallery Component', () => {
       version: 'v0.9',
       updateComponents: {
         surfaceId: 'gallery-preview',
-        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageText],
+        components: [
+          {
+            id: 'root',
+            component: 'Column',
+            align: 'center',
+            justify: 'center',
+            children: ['target'],
+          },
+          ...usageText,
+        ],
       },
     };
     const expectedTextPayload = [expectedTextLine1, expectedTextLine2];
@@ -666,7 +672,16 @@ describe('Gallery Component', () => {
       version: 'v0.9',
       updateComponents: {
         surfaceId: 'gallery-preview',
-        components: [{id: 'root', component: 'Column', children: ['target']}, ...usageButton],
+        components: [
+          {
+            id: 'root',
+            component: 'Column',
+            align: 'center',
+            justify: 'center',
+            children: ['target'],
+          },
+          ...usageButton,
+        ],
       },
     };
     const expectedButtonPayload = [expectedTextLine1, expectedButtonLine2];

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -53,9 +53,6 @@ export class Gallery {
   protected readonly catalogManagement = inject(CatalogManagement);
   private readonly hostCommunication = inject(HostCommunication);
 
-  private static readonly A2UI_v09 = 'v0.9';
-  private static readonly DEMO_SURFACE_ID = 'gallery-preview';
-
   constructor() {
     effect(() => {
       const usageString = this.selectedComponentUsage();
@@ -70,41 +67,21 @@ export class Gallery {
         const catalogId = this.catalogId();
         if (!catalog || !catalogId) return;
 
-        // To visually anchor and center the selected component within the sandboxed preview frame,
-        // we wrap it in a 'Column' container. This prevents individual components (like buttons)
-        // from stretching to fill the entire screen, ensuring a more realistic preview.
-        // We perform a case-insensitive lookup (e.g., matching 'Column' or 'column') to support
-        // different naming conventions that different catalogs might use. If no such column layout
-        // component is found in the catalog, we fall back to rendering the target component directly
-        // as the root.
-        const componentKeys = Object.keys(catalog['components'] || {});
-        const columnKey = componentKeys.find(k => k.toLowerCase() === 'column');
+        const componentsPayload = this.getComponentsPayload(componentsArray);
 
-        let componentsPayload: unknown[];
-        if (columnKey) {
-          componentsPayload = [
-            {id: 'root', component: columnKey, children: ['target']},
-            ...componentsArray,
-          ];
-        } else {
-          componentsPayload = componentsArray;
-        }
-
-        /* prettier-ignore */
         const cmd1 = {
-          'version': Gallery.A2UI_v09,
-          'createSurface': {
-            'surfaceId': Gallery.DEMO_SURFACE_ID,
-            'catalogId': catalogId,
+          version: 'v0.9',
+          createSurface: {
+            surfaceId: 'gallery-preview',
+            catalogId: catalogId,
           },
         };
 
-        /* prettier-ignore */
         const cmd2 = {
-          'version': Gallery.A2UI_v09,
-          'updateComponents': {
-            'surfaceId': Gallery.DEMO_SURFACE_ID,
-            'components': componentsPayload,
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 'gallery-preview',
+            components: componentsPayload,
           },
         };
 
@@ -131,7 +108,7 @@ export class Gallery {
   protected readonly catalogId = computed<string | null>(() => {
     const catalog = this.catalogManagement.activeCatalog();
     if (!catalog) return null;
-    return (catalog['catalogId'] || catalog['$id']) ?? null;
+    return (catalog.catalogId || catalog.$id) ?? null;
   });
 
   /** The table column names mapped by MatTable. */
@@ -146,9 +123,8 @@ export class Gallery {
   /** The resolved schema description for the selected component. */
   protected readonly selectedComponentDescription = computed<string>(() => {
     const key = this.selectedComponentKey();
-    if (!key) return '';
     const catalog = this.catalogManagement.activeCatalog();
-    const comp = catalog?.['components']?.[key];
+    const comp = key ? catalog?.components?.[key] : null;
     return comp && typeof comp['description'] === 'string' ? comp['description'] : '';
   });
 
@@ -159,6 +135,44 @@ export class Gallery {
    */
   protected selectComponent(key: string | null): void {
     this.catalogService.selectComponent(key);
+  }
+
+  private getComponentsPayload(componentsArray: unknown[]): unknown[] {
+    const catalog = this.catalogManagement.activeCatalog();
+    if (!catalog) {
+      return componentsArray;
+    }
+
+    const componentKeys = Object.keys(catalog.components || {});
+    // Support prefixed columns by checking if exactly 'column' or ends with 'column' (case-insensitive).
+    // Prioritize exact match.
+    let columnKey = componentKeys.find(k => k.toLowerCase() === 'column');
+    if (!columnKey) {
+      columnKey = componentKeys.find(k => k.toLowerCase().endsWith('column'));
+    }
+
+    if (columnKey) {
+      return [
+        {
+          id: 'root',
+          component: columnKey,
+          align: 'center',
+          justify: 'center',
+          children: ['target'],
+        },
+        ...componentsArray,
+      ];
+    }
+
+    return componentsArray.map(comp => {
+      if (comp && typeof comp === 'object') {
+        const obj = comp as Record<string, unknown>;
+        if (obj['id'] === 'target') {
+          return {...obj, id: 'root'};
+        }
+      }
+      return comp;
+    });
   }
 
   /**
@@ -181,21 +195,21 @@ export class Gallery {
         return;
       }
 
-      /* prettier-ignore */
       const createSurfaceLine = JSON.stringify({
-        'version': 'v0.9',
-        'createSurface': {
-          'surfaceId': 'gallery-preview',
-          'catalogId': catalogId,
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId,
         },
       });
 
-      /* prettier-ignore */
+      const componentsPayload = this.getComponentsPayload(components as unknown[]);
+
       const updateComponentsLine = JSON.stringify({
-        'version': 'v0.9',
-        'updateComponents': {
-          'surfaceId': 'gallery-preview',
-          'components': components,
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: componentsPayload,
         },
       });
 

--- a/shell/src/app/gallery/schema/catalog-schema-resolver.spec.ts
+++ b/shell/src/app/gallery/schema/catalog-schema-resolver.spec.ts
@@ -958,4 +958,141 @@ describe('CatalogSchemaResolver', () => {
       },
     ]);
   });
+
+  it('resolves common_types.json references from embedded schema when missing locally', () => {
+    const mockSchema = {
+      components: {
+        Component: {
+          type: 'object',
+          properties: {
+            childList: {
+              $ref: 'common_types.json#/$defs/ChildList',
+            },
+          },
+        },
+      },
+    };
+
+    const resolver = new CatalogSchemaResolver(mockSchema);
+    const properties = resolver.resolveComponentProperties('Component');
+
+    expect(properties).toEqual([
+      {
+        name: 'childList',
+        description: '',
+        type: 'array | object',
+        required: false,
+      },
+    ]);
+  });
+
+  it('recursively resolves $ref pointers inside array items', () => {
+    const mockSchema = {
+      components: {
+        ArrayComponent: {
+          type: 'object',
+          properties: {
+            list: {
+              type: 'array',
+              items: {
+                $ref: '#/$defs/ItemType',
+              },
+            },
+          },
+        },
+      },
+      $defs: {
+        ItemType: {
+          type: 'object',
+          properties: {
+            id: {
+              $ref: '#/$defs/IdType',
+            },
+          },
+        },
+        IdType: {
+          type: 'string',
+        },
+      },
+    };
+
+    const resolver = new CatalogSchemaResolver(mockSchema);
+    const propertiesSchema = resolver.resolveComponentPropertiesSchema('ArrayComponent');
+
+    expect(propertiesSchema['list']).toEqual({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+        },
+      },
+    });
+  });
+
+  it('recursively resolves $ref pointers inside object properties', () => {
+    const mockSchema = {
+      components: {
+        ObjectComponent: {
+          type: 'object',
+          properties: {
+            nested: {
+              type: 'object',
+              properties: {
+                value: {
+                  $ref: '#/$defs/ValueType',
+                },
+              },
+            },
+          },
+        },
+      },
+      $defs: {
+        ValueType: {
+          type: 'number',
+        },
+      },
+    };
+
+    const resolver = new CatalogSchemaResolver(mockSchema);
+    const propertiesSchema = resolver.resolveComponentPropertiesSchema('ObjectComponent');
+
+    expect(propertiesSchema['nested']).toEqual({
+      type: 'object',
+      properties: {
+        value: {
+          type: 'number',
+        },
+      },
+    });
+  });
+
+  it('falls back to undecoded key when URI decoding fails on malformed pointer', () => {
+    const mockSchema = {
+      components: {
+        Component: {
+          properties: {
+            text: {$ref: '#/$defs/%E0%A4%A'},
+          },
+        },
+      },
+      $defs: {
+        '%E0%A4%A': {
+          type: 'string',
+          description: 'Fallback key match',
+        },
+      },
+    };
+    const resolver = new CatalogSchemaResolver(mockSchema);
+    expect(resolver.resolveComponentProperties('Component')).toEqual([
+      {
+        name: 'text',
+        description: 'Fallback key match',
+        type: 'string',
+        required: false,
+      },
+    ]);
+  });
 });

--- a/shell/src/app/gallery/schema/catalog-schema-resolver.ts
+++ b/shell/src/app/gallery/schema/catalog-schema-resolver.ts
@@ -15,6 +15,7 @@
  */
 
 import {Catalog, CatalogComponentSchema} from '../../storage/models/catalog-storage.model';
+import {COMMON_TYPES_SCHEMA} from './common-types-schema';
 
 /**
  * Represents a parsed property definition extracted from the catalog schema.
@@ -65,7 +66,7 @@ export class CatalogSchemaResolver {
     }
 
     const componentSchema = componentsDict[componentName];
-    const resolved = this.resolveSchema(componentSchema, root, new Set());
+    const resolved = this.resolveInheritedDefinitions(componentSchema, root, new Set());
 
     const parsedProperties: ParsedProperty[] = [];
     for (const [name, propRawSchema] of Object.entries(resolved.properties)) {
@@ -97,7 +98,53 @@ export class CatalogSchemaResolver {
     return parsedProperties;
   }
 
-  private resolveSchema(
+  /**
+   * Resolves and returns the fully resolved schemas for all properties of the specified component.
+   *
+   * @param componentName The name of the component.
+   * @returns A dictionary of property name to resolved schema.
+   */
+  resolveComponentPropertiesSchema(componentName: string): Record<string, CatalogComponentSchema> {
+    if (this.schema == null || typeof this.schema !== 'object') {
+      return {};
+    }
+    const root = this.schema;
+    const components = root['components'];
+    if (components == null || typeof components !== 'object' || Array.isArray(components)) {
+      return {};
+    }
+    const componentsDict = components;
+    if (!Object.prototype.hasOwnProperty.call(componentsDict, componentName)) {
+      return {};
+    }
+
+    const componentSchema = componentsDict[componentName];
+    const resolved = this.resolveInheritedDefinitions(componentSchema, root, new Set());
+
+    const result: Record<string, CatalogComponentSchema> = {};
+    for (const [name, propRawSchema] of Object.entries(resolved.properties)) {
+      const resolvedProp = this.resolvePropertySchema(
+        propRawSchema as CatalogComponentSchema,
+        root,
+        new Set(),
+      );
+      result[name] = resolvedProp;
+    }
+    return result;
+  }
+
+  /**
+   * Recursively resolving inherited definitions.
+   *
+   * Why: JSON Schemas often use `$ref` inheritance or `allOf` compositions to share
+   * fields. This method resolves those paths recursively to merge inherited properties into
+   * a single flattened representation containing all available fields for the component.
+   *
+   * @param schemaObj The schema object to resolve.
+   * @param rootSchema The root catalog schema.
+   * @param visitedRefs Tracked references to prevent infinite loops.
+   */
+  private resolveInheritedDefinitions(
     schemaObj: CatalogComponentSchema | null | undefined,
     rootSchema: Catalog,
     visitedRefs: Set<string>,
@@ -112,36 +159,8 @@ export class CatalogSchemaResolver {
     }
 
     const obj = schemaObj;
-
-    if (typeof obj['$ref'] === 'string') {
-      const ref = obj['$ref'];
-      if (!visitedRefs.has(ref)) {
-        const resolved = this.resolveJsonPointer(rootSchema, ref);
-        if (resolved) {
-          const nextVisited = new Set(visitedRefs);
-          nextVisited.add(ref);
-          const inherited = this.resolveSchema(
-            resolved as CatalogComponentSchema,
-            rootSchema,
-            nextVisited,
-          );
-          this.mergeResolvedSchemas(result, inherited);
-        } else {
-          console.warn(`Failed to resolve schema reference: "${ref}"`);
-        }
-      }
-    }
-
-    if (Array.isArray(obj['allOf'])) {
-      for (const subSchema of obj['allOf']) {
-        const inherited = this.resolveSchema(
-          subSchema as CatalogComponentSchema,
-          rootSchema,
-          visitedRefs,
-        );
-        this.mergeResolvedSchemas(result, inherited);
-      }
-    }
+    this.resolveRef(obj, visitedRefs, rootSchema, result);
+    this.resolveAllOf(obj, rootSchema, visitedRefs, result);
 
     if (
       obj['properties'] &&
@@ -169,6 +188,62 @@ export class CatalogSchemaResolver {
     return result;
   }
 
+  private resolveRef(
+    obj: CatalogComponentSchema,
+    visitedRefs: Set<string>,
+    rootSchema: Catalog,
+    result: ResolvedSchema,
+  ) {
+    if (typeof obj['$ref'] === 'string') {
+      const ref = obj['$ref'];
+      if (!visitedRefs.has(ref)) {
+        const resolved = this.resolveJsonPointer(rootSchema, ref);
+        if (resolved) {
+          const nextVisited = new Set(visitedRefs);
+          nextVisited.add(ref);
+          const inherited = this.resolveInheritedDefinitions(
+            resolved as CatalogComponentSchema,
+            rootSchema,
+            nextVisited,
+          );
+          this.mergeResolvedSchemas(result, inherited);
+        } else {
+          console.warn(`Failed to resolve schema reference: "${ref}"`);
+        }
+      }
+    }
+  }
+
+  private resolveAllOf(
+    obj: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+    result: ResolvedSchema,
+  ) {
+    if (Array.isArray(obj['allOf'])) {
+      for (const subSchema of obj['allOf']) {
+        const inherited = this.resolveInheritedDefinitions(
+          subSchema as CatalogComponentSchema,
+          rootSchema,
+          visitedRefs,
+        );
+        this.mergeResolvedSchemas(result, inherited);
+      }
+    }
+  }
+
+  /**
+   * Recursively resolves references and nested structure of a property schema.
+   *
+   * Why: This is the central coordinator for resolving property schemas. It delegates
+   * specific keywords like reference, array items, and object properties to helper methods,
+   * making the resolution process easier to understand and maintain.
+   *
+   * @param propSchema The schema definition of the property to resolve.
+   * @param rootSchema The root catalog schema containing definitions for references.
+   * @param visitedRefs Set of references visited in the current path to detect and prevent circular resolution loops.
+   * @returns A fully resolved component schema with references inline and sub-schemas normalized.
+   */
   private resolvePropertySchema(
     propSchema: CatalogComponentSchema | null | undefined,
     rootSchema: Catalog,
@@ -178,68 +253,180 @@ export class CatalogSchemaResolver {
       return {};
     }
 
-    const obj = propSchema;
-    let merged: CatalogComponentSchema = {...obj};
+    const original = propSchema;
+    let merged: CatalogComponentSchema = {...original};
 
-    if (typeof obj['$ref'] === 'string') {
-      const ref = obj['$ref'];
-      if (!visitedRefs.has(ref)) {
-        const resolved = this.resolveJsonPointer(rootSchema, ref);
-        if (resolved) {
-          const nextVisited = new Set(visitedRefs);
-          nextVisited.add(ref);
-          const resolvedProp = this.resolvePropertySchema(
-            resolved as CatalogComponentSchema,
-            rootSchema,
-            nextVisited,
-          );
-          const {$ref: _$ref, ...rest} = merged;
-          merged = {...resolvedProp, ...rest};
-        } else {
-          console.warn(`Failed to resolve property schema reference: "${ref}"`);
-        }
-      }
-    }
-
-    if (Array.isArray(obj['allOf'])) {
-      let allOfMerged: CatalogComponentSchema = {};
-      for (const sub of obj['allOf']) {
-        const resolvedSub = this.resolvePropertySchema(
-          sub as CatalogComponentSchema,
-          rootSchema,
-          visitedRefs,
-        );
-        allOfMerged = {...allOfMerged, ...resolvedSub};
-      }
-      const {allOf: _allOf, ...rest} = merged;
-      merged = {...allOfMerged, ...rest};
-    }
-
-    if (Array.isArray(obj['oneOf'])) {
-      merged['oneOf'] = (obj['oneOf'] as unknown[]).map(sub =>
-        this.resolvePropertySchema(sub as CatalogComponentSchema, rootSchema, visitedRefs),
-      );
-    }
-    if (Array.isArray(obj['anyOf'])) {
-      merged['anyOf'] = (obj['anyOf'] as unknown[]).map(sub =>
-        this.resolvePropertySchema(sub as CatalogComponentSchema, rootSchema, visitedRefs),
-      );
-    }
+    merged = this.resolveReferenceSchema(merged, original, rootSchema, visitedRefs);
+    merged = this.resolveAllOfSchema(merged, original, rootSchema, visitedRefs);
+    merged = this.resolveUnionSchemas(merged, original, rootSchema, visitedRefs);
+    merged = this.resolveArrayItemsSchema(merged, original, rootSchema, visitedRefs);
+    merged = this.resolveObjectPropertiesSchema(merged, original, rootSchema, visitedRefs);
 
     return merged;
   }
 
-  private resolveJsonPointer(schema: Catalog, pointer: string): unknown {
-    let relativePointer = pointer;
-    const hashIndex = pointer.indexOf('#');
-    if (hashIndex !== -1) {
-      relativePointer = pointer.slice(hashIndex);
+  /**
+   * Resolves `$ref` references in a schema, preventing circular loops using visitedRefs.
+   *
+   * Why: JSON Schema references ($ref) must be resolved to merge the referenced
+   * definition properties into the current property's schema.
+   */
+  private resolveReferenceSchema(
+    merged: CatalogComponentSchema,
+    original: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+  ): CatalogComponentSchema {
+    if (typeof original['$ref'] !== 'string') {
+      return merged;
     }
+
+    const ref = original['$ref'];
+    // Avoid re-entering reference resolution if it's already in our visited path.
+    if (visitedRefs.has(ref)) {
+      return merged;
+    }
+
+    const resolved = this.resolveJsonPointer(rootSchema, ref);
+    if (!resolved) {
+      console.warn(`Failed to resolve property schema reference: "${ref}"`);
+      return merged;
+    }
+
+    // Capture reference in visited path for downstream recursion.
+    const nextVisited = new Set(visitedRefs);
+    nextVisited.add(ref);
+    const resolvedProp = this.resolvePropertySchema(
+      resolved as CatalogComponentSchema,
+      rootSchema,
+      nextVisited,
+    );
+
+    // Strip the $ref tag to prevent infinite attempts to re-resolve it.
+    const {$ref: _$ref, ...rest} = merged;
+    return {...resolvedProp, ...rest};
+  }
+
+  /**
+   * Merges multiple sub-schemas from an `allOf` array into a single schema.
+   *
+   * Why: 'allOf' represents an intersection of schemas. We flatten them by merging their properties
+   * to provide a simplified view of the final object fields.
+   */
+  private resolveAllOfSchema(
+    merged: CatalogComponentSchema,
+    original: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+  ): CatalogComponentSchema {
+    if (!Array.isArray(original['allOf'])) {
+      return merged;
+    }
+
+    let allOfMerged: CatalogComponentSchema = {};
+    for (const sub of original['allOf']) {
+      const resolvedSub = this.resolvePropertySchema(
+        sub as CatalogComponentSchema,
+        rootSchema,
+        visitedRefs,
+      );
+      allOfMerged = {...allOfMerged, ...resolvedSub};
+    }
+
+    // Strip allOf list so we don't try to process it again.
+    const {allOf: _allOf, ...rest} = merged;
+    return {...allOfMerged, ...rest};
+  }
+
+  /**
+   * Resolves schemas within union types (`oneOf` and `anyOf`).
+   *
+   * Why: Union types specify alternative schemas for a property. We recursively resolve
+   * each alternative so the UI generator can inspect the full options.
+   */
+  private resolveUnionSchemas(
+    merged: CatalogComponentSchema,
+    original: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+  ): CatalogComponentSchema {
+    const result = {...merged};
+    if (Array.isArray(original['oneOf'])) {
+      result['oneOf'] = (original['oneOf'] as unknown[]).map(sub =>
+        this.resolvePropertySchema(sub as CatalogComponentSchema, rootSchema, visitedRefs),
+      );
+    }
+    if (Array.isArray(original['anyOf'])) {
+      result['anyOf'] = (original['anyOf'] as unknown[]).map(sub =>
+        this.resolvePropertySchema(sub as CatalogComponentSchema, rootSchema, visitedRefs),
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Resolves the schema of items within an array property.
+   *
+   * Why: Array schemas define the structure of their items. We recursively resolve
+   * the 'items' schema to handle nested lists or objects inside arrays.
+   */
+  private resolveArrayItemsSchema(
+    merged: CatalogComponentSchema,
+    original: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+  ): CatalogComponentSchema {
+    if (!original['items'] || typeof original['items'] !== 'object') {
+      return merged;
+    }
+    const result = {...merged};
+    result['items'] = this.resolvePropertySchema(
+      original['items'] as CatalogComponentSchema,
+      rootSchema,
+      visitedRefs,
+    );
+    return result;
+  }
+
+  /**
+   * Resolves schemas for nested properties of an object schema.
+   *
+   * Why: Object schemas contain definitions for their properties. We recursively resolve
+   * each property schema to build a fully resolved nested object tree.
+   */
+  private resolveObjectPropertiesSchema(
+    merged: CatalogComponentSchema,
+    original: CatalogComponentSchema,
+    rootSchema: Catalog,
+    visitedRefs: Set<string>,
+  ): CatalogComponentSchema {
+    if (
+      !original['properties'] ||
+      typeof original['properties'] !== 'object' ||
+      Array.isArray(original['properties'])
+    ) {
+      return merged;
+    }
+
+    const result = {...merged};
+    const resolvedProps = {...((result['properties'] as Record<string, unknown>) || {})};
+    for (const [name, prop] of Object.entries(original['properties'] as Record<string, unknown>)) {
+      resolvedProps[name] = this.resolvePropertySchema(
+        prop as CatalogComponentSchema,
+        rootSchema,
+        visitedRefs,
+      );
+    }
+    result['properties'] = resolvedProps;
+    return result;
+  }
+
+  private resolveJsonPointerBase(targetSchema: unknown, relativePointer: string): unknown {
     if (!relativePointer.startsWith('#/')) {
       return undefined;
     }
     const parts = relativePointer.slice(2).split('/');
-    let current: unknown = schema;
+    let current: unknown = targetSchema;
     for (const part of parts) {
       if (current == null || typeof current !== 'object') {
         return undefined;
@@ -250,12 +437,50 @@ export class CatalogSchemaResolver {
       } catch {
         // Fallback to undecoded key if URI decoding fails.
       }
+      // Security check: Block __proto__, constructor, and prototype to prevent prototype pollution attacks.
       if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         return undefined;
       }
       current = (current as CatalogComponentSchema)[key];
     }
     return current;
+  }
+
+  /**
+   * Resolves a JSON pointer against the root schema, fallback to embedded schemas if needed.
+   *
+   * Why: Schema references ($ref) point to internal definitions (e.g. '#/$defs/Icon')
+   * or common schemas (e.g. 'common_types.json#/$defs/Color'). This method resolves the path
+   * against the catalog or our embedded common types schema to retrieve the referenced definition.
+   *
+   * @param schema The root catalog schema.
+   * @param pointer The JSON pointer to resolve.
+   */
+  private resolveJsonPointer(schema: Catalog, pointer: string): unknown {
+    let relativePointer = pointer;
+    const hashIndex = pointer.indexOf('#');
+    if (hashIndex !== -1) {
+      relativePointer = pointer.slice(hashIndex);
+    }
+
+    if (pointer.includes('common_types.json')) {
+      const localResolved = this.resolveJsonPointerBase(schema, relativePointer);
+      if (localResolved !== undefined) {
+        return localResolved;
+      }
+      return this.resolveJsonPointerBase(COMMON_TYPES_SCHEMA, relativePointer);
+    }
+
+    const resolved = this.resolveJsonPointerBase(schema, relativePointer);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+
+    if (relativePointer.startsWith('#/$defs/')) {
+      return this.resolveJsonPointerBase(COMMON_TYPES_SCHEMA, relativePointer);
+    }
+
+    return undefined;
   }
 
   private mergeResolvedSchemas(target: ResolvedSchema, source: ResolvedSchema): void {

--- a/shell/src/app/gallery/schema/common-types-schema.ts
+++ b/shell/src/app/gallery/schema/common-types-schema.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const COMMON_TYPES_SCHEMA: Record<string, unknown> = {
+  $defs: {
+    ComponentId: {
+      type: 'string',
+    },
+    ChildList: {
+      oneOf: [
+        {
+          type: 'array',
+          items: {
+            $ref: '#/$defs/ComponentId',
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            componentId: {
+              $ref: '#/$defs/ComponentId',
+            },
+            path: {
+              type: 'string',
+            },
+          },
+          required: ['componentId', 'path'],
+          additionalProperties: false,
+        },
+      ],
+    },
+    DataBinding: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+        },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    },
+    FunctionCall: {
+      type: 'object',
+      properties: {
+        call: {
+          type: 'string',
+        },
+        args: {
+          type: 'object',
+        },
+        returnType: {
+          type: 'string',
+          enum: ['string', 'number', 'boolean', 'array', 'object', 'any', 'void'],
+          default: 'boolean',
+        },
+      },
+      required: ['call'],
+    },
+    DynamicString: {
+      oneOf: [
+        {
+          type: 'string',
+        },
+        {
+          $ref: '#/$defs/DataBinding',
+        },
+        {
+          $ref: '#/$defs/FunctionCall',
+        },
+      ],
+    },
+    DynamicBoolean: {
+      oneOf: [
+        {
+          type: 'boolean',
+        },
+        {
+          $ref: '#/$defs/DataBinding',
+        },
+        {
+          $ref: '#/$defs/FunctionCall',
+        },
+      ],
+    },
+    DynamicNumber: {
+      oneOf: [
+        {
+          type: 'number',
+        },
+        {
+          $ref: '#/$defs/DataBinding',
+        },
+        {
+          $ref: '#/$defs/FunctionCall',
+        },
+      ],
+    },
+    DynamicValue: {
+      oneOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'number',
+        },
+        {
+          type: 'boolean',
+        },
+        {
+          type: 'array',
+        },
+        {
+          $ref: '#/$defs/DataBinding',
+        },
+        {
+          $ref: '#/$defs/FunctionCall',
+        },
+      ],
+    },
+    Action: {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            event: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+                context: {
+                  type: 'object',
+                  additionalProperties: {
+                    $ref: '#/$defs/DynamicValue',
+                  },
+                },
+              },
+              required: ['name'],
+              additionalProperties: false,
+            },
+          },
+          required: ['event'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            functionCall: {
+              $ref: '#/$defs/FunctionCall',
+            },
+          },
+          required: ['functionCall'],
+          additionalProperties: false,
+        },
+      ],
+    },
+  },
+};

--- a/shell/src/app/gallery/services/default-presets.ts
+++ b/shell/src/app/gallery/services/default-presets.ts
@@ -27,25 +27,52 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       description: 'Audio Clip',
     },
   ],
+  Badge: [
+    {
+      id: 'target',
+      component: 'Badge',
+      text: '3',
+      children: ['BadgeChild'],
+    },
+    {
+      id: 'BadgeChild',
+      component: 'Icon',
+      icon: 'notifications',
+    },
+  ],
   Button: [
     {
       id: 'target',
       component: 'Button',
       child: 'ButtonLabel',
-      event: {
-        name: 'submit',
-        context: [
-          {
-            key: 'formId',
-            value: 'contact-form',
-          },
-        ],
+      action: {
+        event: {
+          name: 'submit',
+          context: [
+            {
+              key: 'formId',
+              value: 'contact-form',
+            },
+          ],
+        },
       },
     },
     {
       id: 'ButtonLabel',
       component: 'Text',
       text: 'Click Me',
+    },
+  ],
+  ButtonToggle: [
+    {
+      id: 'target',
+      component: 'ButtonToggle',
+      options: [
+        {label: 'Left', value: 'left'},
+        {label: 'Center', value: 'center'},
+        {label: 'Right', value: 'right'},
+      ],
+      value: 'center',
     },
   ],
   Card: [
@@ -108,6 +135,34 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       enableTime: true,
     },
   ],
+  Dialog: [
+    {
+      id: 'target',
+      component: 'Column',
+      children: ['DialogTriggerButton', 'DialogComponent'],
+    },
+    {
+      id: 'DialogTriggerButton',
+      component: 'Button',
+      child: 'DialogTriggerLabel',
+    },
+    {
+      id: 'DialogTriggerLabel',
+      component: 'Text',
+      text: 'Open Dialog',
+    },
+    {
+      id: 'DialogComponent',
+      component: 'Dialog',
+      title: 'Modal Title',
+      children: ['DialogContent'],
+    },
+    {
+      id: 'DialogContent',
+      component: 'Text',
+      text: 'This is the modal content.',
+    },
+  ],
   Divider: [
     {
       id: 'target',
@@ -115,18 +170,32 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       axis: 'horizontal',
     },
   ],
+  ExpansionPanel: [
+    {
+      id: 'target',
+      component: 'ExpansionPanel',
+      title: 'Details',
+      description: 'Click to expand summary info',
+      children: ['PanelContent'],
+    },
+    {
+      id: 'PanelContent',
+      component: 'Text',
+      text: 'This is the expandable content inside the panel.',
+    },
+  ],
   Icon: [
     {
       id: 'target',
       component: 'Icon',
-      name: 'home',
+      icon: 'home',
     },
   ],
   Image: [
     {
       id: 'target',
       component: 'Image',
-      url: 'https://images.unsplash.com/photo-1579783900882-c0d3dad7b119',
+      url: 'https://gstatic.com/images/branding/googlelogo/svg/googlelogo_clr_74x24px.svg',
       description: 'Visual Artwork',
     },
   ],
@@ -145,6 +214,35 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       id: 'list-item-2',
       component: 'Text',
       text: 'List Item Two',
+    },
+  ],
+  Menu: [
+    {
+      id: 'target',
+      component: 'Menu',
+      label: 'Options',
+      icon: 'more_vert',
+      options: [
+        {label: 'Edit', value: 'edit'},
+        {label: 'Share', value: 'share'},
+        {label: 'Delete', value: 'delete'},
+      ],
+    },
+  ],
+  ProgressBar: [
+    {
+      id: 'target',
+      component: 'ProgressBar',
+      mode: 'determinate',
+      value: 70,
+    },
+  ],
+  ProgressSpinner: [
+    {
+      id: 'target',
+      component: 'ProgressSpinner',
+      mode: 'determinate',
+      value: 40,
     },
   ],
   Row: [
@@ -174,6 +272,22 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       value: 50,
     },
   ],
+  Table: [
+    {
+      id: 'target',
+      component: 'Table',
+      columns: [
+        {header: 'Name', field: 'name'},
+        {header: 'Age', field: 'age'},
+        {header: 'Role', field: 'role'},
+      ],
+      rows: [
+        {name: 'Alice', age: '30', role: 'Engineer'},
+        {name: 'Bob', age: '25', role: 'Designer'},
+        {name: 'Charlie', age: '35', role: 'Manager'},
+      ],
+    },
+  ],
   Tabs: [
     {
       id: 'target',
@@ -199,7 +313,7 @@ export const DEFAULT_PRESETS: Record<string, unknown> = {
       id: 'target',
       component: 'Text',
       text: 'Headline Large (H1)',
-      variant: 'h1',
+      usageHint: 'h1',
     },
   ],
   TextField: [

--- a/shell/src/app/gallery/services/gallery-catalog.spec.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.spec.ts
@@ -110,7 +110,7 @@ describe('GalleryCatalog', () => {
           type: 'object',
           properties: {
             text: {type: 'string'},
-            variant: {type: 'string'},
+            usageHint: {type: 'string'},
           },
         },
       },
@@ -124,7 +124,7 @@ describe('GalleryCatalog', () => {
         id: 'target',
         component: 'Text',
         text: 'Headline Large (H1)',
-        variant: 'h1',
+        usageHint: 'h1',
       },
     ]);
   });
@@ -180,6 +180,140 @@ describe('GalleryCatalog', () => {
     ]);
   });
 
+  it('handles schemas with array type and extracts the first valid string type', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        CustomComp: {
+          type: 'object',
+          properties: {
+            reqNullableStr: {type: ['string', 'null'] as unknown as string},
+            reqNullableBool: {type: ['boolean', 'null'] as unknown as string},
+          },
+          required: ['reqNullableStr', 'reqNullableBool'],
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('CustomComp');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'CustomComp',
+        reqNullableStr: '',
+        reqNullableBool: false,
+      },
+    ]);
+  });
+
+  it('safely handles invalid or non-object schemas in union types', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        CustomComp: {
+          type: 'object',
+          properties: {
+            reqUnionBad: {
+              oneOf: [null, {type: 'string'}] as unknown as CatalogComponentSchema[],
+            } as unknown as CatalogComponentSchema,
+          },
+          required: ['reqUnionBad'],
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('CustomComp');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'CustomComp',
+        reqUnionBad: null,
+      },
+    ]);
+  });
+
+  it('recursively generates fallbacks for complex required object and array properties, populating high-value fields and safe image URLs', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        ComplexImageContainer: {
+          type: 'object',
+          properties: {
+            imageSource: {
+              type: 'object',
+              properties: {
+                url: {type: 'string'},
+                title: {type: 'string'},
+                description: {type: 'string'},
+              },
+              required: ['url'],
+            },
+            options: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  label: {type: 'string'},
+                  value: {type: 'number'},
+                  metadata: {
+                    type: 'object',
+                    properties: {
+                      placeholder: {type: 'string'},
+                      tooltip: {type: 'string'},
+                    },
+                  },
+                },
+                required: ['value', 'metadata'],
+              },
+            },
+          },
+          required: ['imageSource', 'options'],
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('ComplexImageContainer');
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'ComplexImageContainer',
+        imageSource: {
+          url: 'https://gstatic.com/images/branding/googlelogo/svg/googlelogo_clr_74x24px.svg',
+          title: 'Sample Title',
+        },
+        options: [
+          {
+            label: 'Sample Label 1',
+            value: 0,
+            metadata: {
+              placeholder: 'Enter text... 1',
+              tooltip: 'Sample Tooltip 1',
+            },
+          },
+          {
+            label: 'Sample Label 2',
+            value: 0,
+            metadata: {
+              placeholder: 'Enter text... 2',
+              tooltip: 'Sample Tooltip 2',
+            },
+          },
+          {
+            label: 'Sample Label 3',
+            value: 0,
+            metadata: {
+              placeholder: 'Enter text... 3',
+              tooltip: 'Sample Tooltip 3',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('delivers a deep copy of the visual preset to prevent global mutation', () => {
     const mockCatalog: Catalog = {
       components: {
@@ -187,7 +321,7 @@ describe('GalleryCatalog', () => {
           type: 'object',
           properties: {
             text: {type: 'string'},
-            variant: {type: 'string'},
+            usageHint: {type: 'string'},
           },
         },
         Column: {type: 'object'},
@@ -295,7 +429,7 @@ describe('GalleryCatalog', () => {
           type: 'object',
           properties: {
             text: {type: 'string'},
-            variant: {type: 'string'},
+            usageHint: {type: 'string'},
           },
         },
       },
@@ -311,7 +445,7 @@ describe('GalleryCatalog', () => {
         id: 'target',
         component: 'Text',
         text: 'Headline Large (H1)',
-        variant: 'h1',
+        usageHint: 'h1',
       },
     ]);
   });
@@ -373,7 +507,7 @@ describe('GalleryCatalog', () => {
           type: 'object',
           properties: {
             text: {type: 'string'},
-            variant: {type: 'string'},
+            usageHint: {type: 'string'},
           },
         },
       },
@@ -387,7 +521,7 @@ describe('GalleryCatalog', () => {
         id: 'target',
         component: 'MaterialText',
         text: 'Headline Large (H1)',
-        variant: 'h1',
+        usageHint: 'h1',
       },
     ]);
   });
@@ -721,6 +855,353 @@ describe('GalleryCatalog', () => {
       expect(preset[0]['tabs']).toBeUndefined();
     } finally {
       delete DEFAULT_PRESETS['TestBadTabs'];
+    }
+  });
+
+  it('adapts child to children when component schema supports children but not child', () => {
+    DEFAULT_PRESETS['TestChildToChildren'] = [
+      {
+        id: 'target',
+        component: 'TestChildToChildren',
+        child: 'child-1',
+      },
+      {
+        id: 'child-1',
+        component: 'Text',
+        text: 'Hello',
+      },
+    ];
+
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          TestChildToChildren: {
+            type: 'object',
+            properties: {
+              children: {type: 'array', items: {type: 'string'}},
+            },
+          },
+          Text: {
+            type: 'object',
+            properties: {
+              text: {type: 'string'},
+            },
+          },
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('TestChildToChildren');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset();
+      expect(preset).toEqual([
+        {
+          id: 'target',
+          component: 'TestChildToChildren',
+          children: ['child-1'],
+        },
+        {
+          id: 'child-1',
+          component: 'Text',
+          text: 'Hello',
+        },
+      ]);
+    } finally {
+      delete DEFAULT_PRESETS['TestChildToChildren'];
+    }
+  });
+
+  it('adapts child to label when component schema supports label but not child, and child is Text', () => {
+    DEFAULT_PRESETS['TestChildToLabel'] = [
+      {
+        id: 'target',
+        component: 'TestChildToLabel',
+        child: 'child-1',
+      },
+      {
+        id: 'child-1',
+        component: 'Text',
+        text: 'Hello Label',
+      },
+    ];
+
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          TestChildToLabel: {
+            type: 'object',
+            properties: {
+              label: {type: 'string'},
+            },
+          },
+          Text: {
+            type: 'object',
+            properties: {
+              text: {type: 'string'},
+            },
+          },
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('TestChildToLabel');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset();
+      expect(preset).toEqual([
+        {
+          id: 'target',
+          component: 'TestChildToLabel',
+          label: 'Hello Label',
+        },
+      ]);
+    } finally {
+      delete DEFAULT_PRESETS['TestChildToLabel'];
+    }
+  });
+
+  it('adapts tabs items (title -> label, child -> content) for non-basic Tabs component', () => {
+    DEFAULT_PRESETS['MaterialTabs'] = [
+      {
+        id: 'target',
+        component: 'MaterialTabs',
+        tabs: [{title: 'Tab 1', child: 'tab-content-1'}],
+      },
+      {
+        id: 'tab-content-1',
+        component: 'Text',
+        text: 'Content 1',
+      },
+    ];
+
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          MaterialTabs: {
+            type: 'object',
+            properties: {
+              tabs: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: {type: 'string'},
+                    content: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+          Text: {
+            type: 'object',
+            properties: {
+              text: {type: 'string'},
+            },
+          },
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('MaterialTabs');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset();
+      expect(preset).toEqual([
+        {
+          id: 'target',
+          component: 'MaterialTabs',
+          tabs: [{label: 'Tab 1', content: 'tab-content-1'}],
+        },
+        {
+          id: 'tab-content-1',
+          component: 'Text',
+          text: 'Content 1',
+        },
+      ]);
+    } finally {
+      delete DEFAULT_PRESETS['MaterialTabs'];
+    }
+  });
+
+  it('does NOT adapt tabs items for basic Tabs component', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        Tabs: {
+          type: 'object',
+          properties: {
+            tabs: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  title: {type: 'string'},
+                  child: {type: 'string'},
+                },
+              },
+            },
+          },
+        },
+        Text: {
+          type: 'object',
+          properties: {
+            text: {type: 'string'},
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('Tabs');
+    TestBed.flushEffects();
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'Tabs',
+        tabs: [
+          {title: 'Tab One', child: 'tab-content-1'},
+          {title: 'Tab Two', child: 'tab-content-2'},
+        ],
+      },
+      {
+        id: 'tab-content-1',
+        component: 'Text',
+        text: 'Content of Tab One',
+      },
+      {
+        id: 'tab-content-2',
+        component: 'Text',
+        text: 'Content of Tab Two',
+      },
+    ]);
+  });
+
+  it('resolves union types from anyOf schema for component properties', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        UnionComponent: {
+          type: 'object',
+          properties: {
+            unionField: {
+              anyOf: [{type: 'string'}, {type: 'number'}],
+            },
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('UnionComponent');
+    TestBed.flushEffects();
+
+    const props = service.selectedComponentProperties();
+    expect(props).toEqual([
+      {
+        name: 'unionField',
+        description: '',
+        type: 'string | number',
+        required: false,
+      },
+    ]);
+  });
+
+  it('spawns a child Text component when component has required child property in dynamic fallback generator', () => {
+    const mockCatalog: Catalog = {
+      components: {
+        ParentComponent: {
+          type: 'object',
+          properties: {
+            child: {
+              type: 'string',
+            },
+          },
+          required: ['child'],
+        },
+        Text: {
+          type: 'object',
+          properties: {
+            text: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    };
+    catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.selectComponent('ParentComponent');
+    TestBed.flushEffects();
+
+    const preset = service.selectedComponentPreset();
+    expect(preset).toEqual([
+      {
+        id: 'target',
+        component: 'ParentComponent',
+        child: 'target-child-0',
+      },
+      {
+        id: 'target-child-0',
+        component: 'Text',
+        text: 'Child Element',
+      },
+    ]);
+  });
+
+  it('passes invalid tab items through without crashing', () => {
+    DEFAULT_PRESETS['CustomTabs'] = [
+      {
+        id: 'target',
+        component: 'CustomTabs',
+        tabs: [null, 'invalid-tab-string', {title: 'Valid Tab', child: 'tab-content-1'}],
+      },
+      {
+        id: 'tab-content-1',
+        component: 'Text',
+        text: 'Content 1',
+      },
+    ];
+
+    try {
+      const mockCatalog: Catalog = {
+        components: {
+          CustomTabs: {
+            type: 'object',
+            properties: {
+              tabs: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    label: {type: 'string'},
+                    content: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+          Text: {
+            type: 'object',
+            properties: {
+              text: {type: 'string'},
+            },
+          },
+        },
+      };
+      catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.selectComponent('CustomTabs');
+      TestBed.flushEffects();
+
+      const preset = service.selectedComponentPreset();
+      expect(preset).toEqual([
+        {
+          id: 'target',
+          component: 'CustomTabs',
+          tabs: [null, 'invalid-tab-string', {label: 'Valid Tab', content: 'tab-content-1'}],
+        },
+        {
+          id: 'tab-content-1',
+          component: 'Text',
+          text: 'Content 1',
+        },
+      ]);
+    } finally {
+      delete DEFAULT_PRESETS['CustomTabs'];
     }
   });
 });

--- a/shell/src/app/gallery/services/gallery-catalog.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.ts
@@ -17,7 +17,31 @@
 import {Injectable, inject, signal, computed} from '@angular/core';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {CatalogSchemaResolver, ParsedProperty} from '../schema/catalog-schema-resolver';
+import {CatalogComponentSchema} from '../../storage/models/catalog-storage.model';
 import {DEFAULT_PRESETS} from './default-presets';
+
+const HIGH_VALUE_FIELDS = new Set([
+  'label',
+  'text',
+  'title',
+  'header',
+  'tooltip',
+  'placeholder',
+  'children',
+  'child',
+]);
+
+const DEFAULT_TEXT_FOR_FIELD: Record<string, string> = {
+  label: 'Sample Label',
+  text: 'Sample Text',
+  title: 'Sample Title',
+  header: 'Sample Header',
+  tooltip: 'Sample Tooltip',
+  placeholder: 'Enter text...',
+  icon: 'search',
+  name: 'action',
+  value: 'option',
+};
 
 /**
  * Represents components grouped under a specific category name.
@@ -139,6 +163,13 @@ function getCategoryForComponent(key: string): string {
   return 'Other';
 }
 
+interface FallbackPresetContext {
+  readonly componentKey: string;
+  readonly prefix: string;
+  readonly additionalItems: Record<string, unknown>[];
+  childCounter: number;
+}
+
 /**
  * Coordinates visual gallery state including component categories, selections,
  * schema property resolutions, visual presets, and usage snippet generations.
@@ -201,6 +232,14 @@ export class GalleryCatalog {
     return resolver.resolveComponentProperties(key);
   });
 
+  /**
+   * The active visual preset representing the UI layout for the selected component.
+   *
+   * Why: Visual presets define how components are structured, styled, and populated with children
+   * to showcase them in the gallery. This computed property fetches a predefined static preset,
+   * falls back to dynamic generation, adapts structural slots like children/tabs, and validates
+   * properties against the schema so the preview remains consistent.
+   */
   readonly selectedComponentPreset = computed<Record<string, unknown>[] | null>(() => {
     const key = this.selectedComponentKey();
     if (!key) {
@@ -213,7 +252,8 @@ export class GalleryCatalog {
       preset = this.generateFallbackPreset(key, prefix);
     }
 
-    return this.validateAndPrunePreset(preset);
+    const adaptedPreset = this.adaptPreset(preset, key);
+    return this.validateAndPrunePreset(adaptedPreset);
   });
 
   /**
@@ -251,12 +291,17 @@ export class GalleryCatalog {
     prefix: string,
     normalizedKey: string,
   ): Record<string, unknown>[] | null {
-    if (!DEFAULT_PRESETS[normalizedKey]) {
+    const presetKey = Object.prototype.hasOwnProperty.call(DEFAULT_PRESETS, key)
+      ? key
+      : Object.prototype.hasOwnProperty.call(DEFAULT_PRESETS, normalizedKey)
+        ? normalizedKey
+        : null;
+    if (!presetKey) {
       return null;
     }
 
     // We clone the preset to avoid mutating the shared DEFAULT_PRESETS object.
-    const preset = structuredClone(DEFAULT_PRESETS[normalizedKey]) as Record<string, unknown>[];
+    const preset = structuredClone(DEFAULT_PRESETS[presetKey]) as Record<string, unknown>[];
 
     // Prefix propagation: static presets in DEFAULT_PRESETS use prefix-less component names
     // for children to remain library-agnostic. We must restore the active prefix here
@@ -265,7 +310,9 @@ export class GalleryCatalog {
       if (item['id'] === 'target') {
         item['component'] = key;
       } else if (typeof item['component'] === 'string') {
-        item['component'] = `${prefix}${item['component']}`;
+        if (presetKey === normalizedKey) {
+          item['component'] = `${prefix}${item['component']}`;
+        }
       }
     }
     return preset;
@@ -278,55 +325,344 @@ export class GalleryCatalog {
    * @param prefix The library prefix.
    * @returns A generated preset with required properties populated and default children linked if supported.
    */
+  /**
+   * Generates a fallback preset when no static preset is defined.
+   *
+   * Why: If a component has no predefined presets, we dynamically generate
+   * a minimal working configuration so the user can still see and interact
+   * with it in the gallery.
+   *
+   * @param key The selected component key.
+   * @param prefix The library prefix.
+   * @returns A generated preset with required properties populated and default children linked if supported.
+   */
   private generateFallbackPreset(key: string, prefix: string): Record<string, unknown>[] {
-    const props = this.selectedComponentProperties();
-    const fallback: Record<string, unknown> = {
+    const resolver = this.catalogSchemaResolver();
+    if (!resolver) {
+      return [{id: 'target', component: key}];
+    }
+
+    const propSchemas = resolver.resolveComponentPropertiesSchema(key);
+    const targetItem: Record<string, unknown> = {
       id: 'target',
       component: key,
     };
 
-    let hasChildren = false;
-    let childrenPropType = '';
+    const ctx: FallbackPresetContext = {
+      componentKey: key,
+      prefix,
+      additionalItems: [],
+      childCounter: 0,
+    };
 
-    // Inspect schema to find required properties and check if it accepts children.
-    for (const prop of props) {
-      if (prop.name === 'children') {
-        hasChildren = true;
-        childrenPropType = prop.type;
+    const requiredProps = new Set(
+      resolver
+        .resolveComponentProperties(key)
+        .filter(p => p.required)
+        .map(p => p.name),
+    );
+    for (const [propName, propSchema] of Object.entries(propSchemas)) {
+      if (propName === 'component' || propName === 'id') {
+        continue;
       }
-      if (
-        prop.required &&
-        prop.name !== 'component' &&
-        prop.name !== 'children' &&
-        prop.name !== 'id'
-      ) {
-        fallback[prop.name] = this.getDefaultValueForType(prop.type);
+      const isRequired = requiredProps.has(propName);
+
+      const val = this.generatePropertyValue(propName, propSchema, isRequired, 1, ctx);
+      if (val !== undefined) {
+        targetItem[propName] = val;
       }
     }
 
-    // If the component accepts a children array, we link a default child component.
-    // This provides a better out-of-the-box visual representation in the gallery.
-    if (hasChildren && childrenPropType.includes('array')) {
-      const textComponent = `${prefix}Text`;
-      const catalog = this.catalogManagement.activeCatalog();
-      const textComponentExists = !!(
-        catalog?.components &&
-        Object.prototype.hasOwnProperty.call(catalog.components, textComponent)
+    return [targetItem, ...ctx.additionalItems];
+  }
+
+  /**
+   * Main entry point to generate a fallback value for a specific property schema.
+   *
+   * Why: Coordinates fallback value generation per property, mapping types to specialized helpers.
+   *
+   * @param propName The name of the property.
+   * @param schema The schema definition of the property.
+   * @param isRequired True if the property is required.
+   * @param depth The current recursion depth (capped at 5).
+   * @param ctx The execution context holding generator state.
+   * @returns The generated value, or undefined if the value should not be populated.
+   */
+  private generatePropertyValue(
+    propName: string,
+    schema: CatalogComponentSchema,
+    isRequired: boolean,
+    depth: number,
+    ctx: FallbackPresetContext,
+    itemIndex?: number,
+  ): unknown {
+    if (depth > 5) {
+      return null;
+    }
+
+    if (!schema || typeof schema !== 'object') {
+      return undefined;
+    }
+
+    // Special case: fallback placeholder image for Image component url/src fields.
+    const isImageComponent = ctx.componentKey.toLowerCase().includes('image');
+    const isUrlField = propName === 'url' || propName === 'src';
+    if (isImageComponent && isUrlField) {
+      return 'https://gstatic.com/images/branding/googlelogo/svg/googlelogo_clr_74x24px.svg';
+    }
+
+    const activeSchema = this.resolveActiveSchema(schema);
+    let typeString = '';
+    if (typeof activeSchema['type'] === 'string') {
+      typeString = activeSchema['type'];
+    } else if (Array.isArray(activeSchema['type'])) {
+      typeString = activeSchema['type'].find(t => typeof t === 'string') || '';
+    }
+    const primaryType = typeString.split('|')[0].trim();
+
+    // High-value fields should have a default text even if not required, to make mock visually pleasing.
+    if (!isRequired && HIGH_VALUE_FIELDS.has(propName)) {
+      if (primaryType === 'string' || !primaryType) {
+        return this.generateStringValue(propName, ctx, itemIndex, 'Sample');
+      }
+    }
+
+    if (!isRequired && !HIGH_VALUE_FIELDS.has(propName)) {
+      return undefined;
+    }
+
+    switch (primaryType) {
+      case 'string':
+        return this.generateStringValue(propName, ctx, itemIndex);
+      case 'number':
+      case 'integer':
+        return this.generateNumberValue();
+      case 'boolean':
+        return this.generateBooleanValue();
+      case 'array':
+        return this.generateArrayValue(propName, activeSchema, depth, ctx);
+      case 'object':
+        return this.generateObjectValue(activeSchema, depth, ctx, itemIndex);
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Selects the active schema from a union schema, defaulting to the first option.
+   *
+   * Why: Union types (oneOf/anyOf) specify multiple possible shapes. We pick the first one
+   * as a representative to generate a fallback preset.
+   */
+  private resolveActiveSchema(schema: CatalogComponentSchema): CatalogComponentSchema {
+    if (!schema || typeof schema !== 'object') {
+      return {} as CatalogComponentSchema;
+    }
+    if (Array.isArray(schema['oneOf']) && schema['oneOf'].length > 0) {
+      const first = schema['oneOf'][0];
+      return (first && typeof first === 'object' ? first : {}) as CatalogComponentSchema;
+    }
+    if (Array.isArray(schema['anyOf']) && schema['anyOf'].length > 0) {
+      const first = schema['anyOf'][0];
+      return (first && typeof first === 'object' ? first : {}) as CatalogComponentSchema;
+    }
+    return schema;
+  }
+
+  /**
+   * Generates a fallback string value. Handles special mapping of 'child' property to a Text component.
+   *
+   * Why: Generates default strings or links sub-components if the field represents a child slot.
+   */
+  private generateStringValue(
+    propName: string,
+    ctx: FallbackPresetContext,
+    itemIndex?: number,
+    fallback = '',
+  ): unknown {
+    if (propName === 'child') {
+      return this.generateChildTextComponent(ctx);
+    }
+    const baseText = DEFAULT_TEXT_FOR_FIELD[propName] || fallback;
+    if (itemIndex !== undefined) {
+      return `${baseText} ${itemIndex + 1}`;
+    }
+    return baseText;
+  }
+
+  /**
+   * Generates a fallback number/integer value.
+   *
+   * Why: Default fallback for numeric properties.
+   */
+  private generateNumberValue(): number {
+    return 0;
+  }
+
+  /**
+   * Generates a fallback boolean value.
+   *
+   * Why: Default fallback for boolean properties.
+   */
+  private generateBooleanValue(): boolean {
+    return false;
+  }
+
+  /**
+   * Generates a fallback array value. Handles special mapping of 'children'/'child' properties to Text components.
+   *
+   * Why: Populates array slots, linking child text items for layout slots or resolving item schemas recursively.
+   */
+  private generateArrayValue(
+    propName: string,
+    activeSchema: CatalogComponentSchema,
+    depth: number,
+    ctx: FallbackPresetContext,
+  ): unknown {
+    if (propName === 'children' || propName === 'child') {
+      const childId = this.generateChildTextComponent(ctx);
+      if (childId !== undefined) {
+        return propName === 'children' ? [childId] : childId;
+      }
+      return undefined;
+    }
+
+    const itemsSchema = activeSchema['items'] as CatalogComponentSchema | undefined;
+    if (itemsSchema && typeof itemsSchema === 'object') {
+      const isOptions = propName.toLowerCase().includes('options');
+      const count = isOptions ? 3 : 1;
+      const items: unknown[] = [];
+      for (let i = 0; i < count; i++) {
+        const item = this.generatePropertyValue(
+          propName + 'Item',
+          itemsSchema,
+          true,
+          depth + 1,
+          ctx,
+          isOptions ? i : undefined,
+        );
+        if (item !== undefined) {
+          items.push(item);
+        }
+      }
+      return items;
+    }
+    return [];
+  }
+
+  /**
+   * Generates a fallback object value by recursively generating values for its required sub-properties.
+   *
+   * Why: Recursively generates nested object structures up to the maximum depth.
+   */
+  private generateObjectValue(
+    activeSchema: CatalogComponentSchema,
+    depth: number,
+    ctx: FallbackPresetContext,
+    itemIndex?: number,
+  ): Record<string, unknown> {
+    const properties = activeSchema['properties'] as Record<string, unknown> | undefined;
+    if (properties && typeof properties === 'object') {
+      const objVal: Record<string, unknown> = {};
+      const requiredProps = new Set<string>(
+        Array.isArray(activeSchema['required']) ? (activeSchema['required'] as string[]) : [],
       );
+      for (const [subPropName, subPropSchema] of Object.entries(properties)) {
+        const subIsRequired = requiredProps.has(subPropName);
+        const val = this.generatePropertyValue(
+          subPropName,
+          subPropSchema as CatalogComponentSchema,
+          subIsRequired,
+          depth + 1,
+          ctx,
+          itemIndex,
+        );
+        if (val !== undefined) {
+          objVal[subPropName] = val;
+        }
+      }
+      return objVal;
+    }
+    return {};
+  }
 
-      if (textComponentExists) {
-        const childId = 'target-child-0';
-        const childFallback: Record<string, unknown> = {
-          id: childId,
-          component: textComponent,
-          text: 'Child Element',
-        };
-        fallback['children'] = [childId];
-        return [fallback, childFallback];
+  /**
+   * Generates a fallback Text child component and adds it to the additional items list.
+   *
+   * Why: Common utility to link standard Text child elements when components support children.
+   *
+   * @returns The generated child element ID, or undefined if the Text component doesn't exist in the catalog.
+   */
+  private generateChildTextComponent(ctx: FallbackPresetContext): string | undefined {
+    const textComponent = `${ctx.prefix}Text`;
+    const catalog = this.catalogManagement.activeCatalog();
+    const textComponentExists = !!(
+      catalog?.components && Object.prototype.hasOwnProperty.call(catalog.components, textComponent)
+    );
+
+    if (textComponentExists) {
+      const childId = `target-child-${ctx.childCounter++}`;
+      const childItem = {
+        id: childId,
+        component: textComponent,
+        text: 'Child Element',
+      };
+      ctx.additionalItems.push(childItem);
+      return childId;
+    }
+    return undefined;
+  }
+
+  private adaptPreset(preset: Record<string, unknown>[], key: string): Record<string, unknown>[] {
+    const targetItem = preset.find(item => item['id'] === 'target');
+    if (!targetItem) {
+      return preset;
+    }
+
+    const validProps = new Set(this.selectedComponentProperties().map(p => p.name));
+
+    // 1. Map 'child' to 'children' if 'children' is valid but 'child' is not.
+    if ('child' in targetItem && !validProps.has('child') && validProps.has('children')) {
+      targetItem['children'] = [targetItem['child']];
+      delete targetItem['child'];
+    }
+
+    // 2. Map 'child' to 'label' if 'label' is valid but 'child' is not.
+    if ('child' in targetItem && !validProps.has('child') && validProps.has('label')) {
+      const childId = targetItem['child'];
+      if (typeof childId === 'string') {
+        const childItem = preset.find(item => item['id'] === childId);
+        if (childItem && typeof childItem['text'] === 'string') {
+          targetItem['label'] = childItem['text'];
+        }
       }
     }
 
-    return [fallback];
+    // 3. Map 'tabs' array items (title -> label, child -> content) if target is not basic 'Tabs' and component expects 'tabs'.
+    if (
+      key !== 'Tabs' &&
+      'tabs' in targetItem &&
+      Array.isArray(targetItem['tabs']) &&
+      validProps.has('tabs')
+    ) {
+      targetItem['tabs'] = targetItem['tabs'].map(tab => {
+        if (tab && typeof tab === 'object') {
+          const adaptedTab = {...tab} as Record<string, unknown>;
+          if ('title' in adaptedTab) {
+            adaptedTab['label'] = adaptedTab['title'];
+            delete adaptedTab['title'];
+          }
+          if ('child' in adaptedTab) {
+            adaptedTab['content'] = adaptedTab['child'];
+            delete adaptedTab['child'];
+          }
+          return adaptedTab;
+        }
+        return tab;
+      });
+    }
+
+    return preset;
   }
 
   /**
@@ -370,13 +706,11 @@ export class GalleryCatalog {
         childIdsToPrune.add(targetItem['child']);
       } else if (key === 'tabs' && Array.isArray(targetItem['tabs'])) {
         for (const tab of targetItem['tabs']) {
-          if (
-            tab &&
-            typeof tab === 'object' &&
-            'child' in tab &&
-            typeof (tab as Record<string, unknown>)['child'] === 'string'
-          ) {
-            childIdsToPrune.add((tab as Record<string, unknown>)['child'] as string);
+          if (tab && typeof tab === 'object') {
+            const tabRecord = tab as Record<string, unknown>;
+            if (typeof tabRecord['child'] === 'string') {
+              childIdsToPrune.add(tabRecord['child']);
+            }
           }
         }
       }
@@ -395,31 +729,5 @@ export class GalleryCatalog {
     const prefix = match ? match[0] : '';
     const normalizedName = name.slice(prefix.length);
     return {prefix, normalizedName};
-  }
-
-  /**
-   * Resolves a default value for a given schema type string.
-   * Handles union types by taking the first type in the union.
-   *
-   * @param type The schema type (e.g., 'string', 'number', 'string | number').
-   * @returns A default value matching the type, or null if unsupported.
-   */
-  private getDefaultValueForType(type: string): unknown {
-    const primaryType = type.split('|')[0].trim();
-    switch (primaryType) {
-      case 'string':
-        return '';
-      case 'number':
-      case 'integer':
-        return 0;
-      case 'boolean':
-        return false;
-      case 'array':
-        return [];
-      case 'object':
-        return {};
-      default:
-        return null;
-    }
   }
 }

--- a/shell/src/test-setup.ts
+++ b/shell/src/test-setup.ts
@@ -17,6 +17,7 @@
 import {getTestBed} from '@angular/core/testing';
 import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {webcrypto} from 'node:crypto';
+import {beforeEach} from 'vitest';
 
 if (typeof window !== 'undefined' && (!window.crypto || !window.crypto.subtle)) {
   Object.defineProperty(window, 'crypto', {
@@ -29,7 +30,6 @@ if (!getTestBed().platform) {
   getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting());
 }
 
-import {beforeEach} from 'vitest';
 beforeEach(() => {
   getTestBed().resetTestingModule();
 });


### PR DESCRIPTION
# Description

Add improvements for how we dynamically generate component previews for the gallery.

NOTE: A subsequent PR will make this code less likely to be invoked (we'll allow the renderer application to provide the specific A2UI JSON for each component's example), but it's still necessary.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
