### PR TITLE
feat: replace textarea with Monaco editor for JSON layout editing

### DIFF
--- a/.github/workflows/enforce-formatting.yml
+++ b/.github/workflows/enforce-formatting.yml
@@ -33,6 +33,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -43,6 +45,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
+
+      - name: Install dependencies
+        run: yarn install --immutable
 
       - name: Run enforce-formatting script
         run: ./scripts/fix_format.sh --check

--- a/shell/angular.json
+++ b/shell/angular.json
@@ -29,6 +29,11 @@
                 "glob": "**/*",
                 "input": "node_modules/ng-basic-catalog/dist/ng-basic-catalog/browser",
                 "output": "samples/ng-basic-catalog"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min/vs",
+                "output": "assets/monaco/vs"
               }
             ],
             "styles": [

--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -16,6 +16,7 @@
 
 import {test, expect, Locator, FrameLocator} from '@playwright/test';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {WindowWithMonaco} from './types';
 
 interface IntegrationConfig {
   name: string;
@@ -165,15 +166,30 @@ for (const config of CONFIGS) {
       await page.goto(`/?renderer=${config.rendererUrl}`);
       await expect(page.locator('.workspace-container')).toBeVisible();
 
-      const rawJsonTextarea = page.locator('.raw-json-field textarea');
-      await expect(rawJsonTextarea).not.toHaveValue(/^$/);
+      const editorLocator = page.locator('.monaco-editor');
+      await expect(editorLocator).toBeVisible();
 
-      const rawJson = await rawJsonTextarea.inputValue();
+      await page.waitForFunction(() => {
+        const monaco = (window as unknown as WindowWithMonaco).monaco;
+        return (monaco?.editor?.getModels()?.length ?? 0) > 0;
+      });
+
+      const rawJson = await page.evaluate(() => {
+        const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
+        return model ? model.getValue() : '';
+      });
+      expect(rawJson).not.toBe('');
+
       const updatedRawJson = rawJson.replace(
         '"text": "Search Cars"',
         '"text": "Search Rental Cars"',
       );
-      await rawJsonTextarea.fill(updatedRawJson);
+      await page.evaluate((val) => {
+        const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
+        if (model) {
+          model.setValue(val);
+        }
+      }, updatedRawJson);
       await page.waitForTimeout(1000);
 
       const iframe = page.frameLocator('iframe.preview-iframe');

--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -184,7 +184,7 @@ for (const config of CONFIGS) {
         '"text": "Search Cars"',
         '"text": "Search Rental Cars"',
       );
-      await page.evaluate((val) => {
+      await page.evaluate(val => {
         const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
         if (model) {
           model.setValue(val);

--- a/shell/e2e/types.ts
+++ b/shell/e2e/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface MonacoModel {
+  getValue(): string;
+  setValue(value: string): void;
+}
+
+export interface WindowWithMonaco extends Window {
+  monaco?: {
+    editor: {
+      getModels(): MonacoModel[];
+    };
+  };
+}

--- a/shell/e2e/user-journey.e2e.ts
+++ b/shell/e2e/user-journey.e2e.ts
@@ -15,6 +15,7 @@
  */
 
 import {test, expect} from '@playwright/test';
+import {WindowWithMonaco} from './types';
 
 test.beforeEach(async ({page}) => {
   page.on('pageerror', err => {
@@ -75,17 +76,34 @@ test.describe('E2E Workspace User Journey', () => {
     // 6. Switch back to Workspace
     await page.getByRole('link', {name: 'Composer Workspace'}).click();
 
-    // 7. Enter malformed JSON in Raw Editor textarea
-    const rawEditor = page.getByPlaceholder('Enter raw JSON here...');
-    await rawEditor.fill('invalid json {');
+    // 7. Wait for Monaco to load and enter malformed JSON
+    const editorLocator = page.locator('.monaco-editor');
+    await expect(editorLocator).toBeVisible();
+
+    await page.waitForFunction(() => {
+      const monaco = (window as unknown as WindowWithMonaco).monaco;
+      return (monaco?.editor?.getModels()?.length ?? 0) > 0;
+    });
+
+    await page.evaluate(() => {
+      const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
+      if (model) {
+        model.setValue('invalid json {');
+      }
+    });
 
     // 8. Assert that warning badge (.invalid-json-badge) appears above textarea
     await expect(page.locator('.invalid-json-badge')).toBeVisible();
 
     // 9. Correct JSON and verify warning badge disappears
-    await rawEditor.fill(
-      '{"version": "v0.9", "createSurface": {"surfaceId": "test", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"}}',
-    );
+    await page.evaluate(() => {
+      const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
+      if (model) {
+        model.setValue(
+          '{"version": "v0.9", "createSurface": {"surfaceId": "test", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"}}',
+        );
+      }
+    });
     await expect(page.locator('.invalid-json-badge')).not.toBeVisible();
   });
 });

--- a/shell/package.json
+++ b/shell/package.json
@@ -27,7 +27,9 @@
     "@angular/platform-browser": "22.0.2",
     "@angular/router": "22.0.2",
     "@google/genai": "2.8.0",
+    "@monaco-editor/loader": "^1.7.0",
     "a2ui-bridge": "0.1.0",
+    "monaco-editor": "^0.55.1",
     "rxjs": "7.8.2",
     "safevalues": "1.2.0",
     "tslib": "2.8.1"

--- a/shell/src/app/preview/raw/raw-frame.ng.html
+++ b/shell/src/app/preview/raw/raw-frame.ng.html
@@ -21,14 +21,5 @@
   @if (isJsonInvalid()) {
     <div class="invalid-json-badge">⚠️ Invalid JSON syntax detected.</div>
   }
-  <mat-form-field appearance="outline" subscriptSizing="dynamic" class="raw-json-field">
-    <textarea
-      matInput
-      aria-label="Raw layout JSON"
-      [ngModel]="layoutJson()"
-      (ngModelChange)="onLayoutChange($event)"
-      [readOnly]="isLocked()"
-      placeholder="Enter raw JSON here..."
-    ></textarea>
-  </mat-form-field>
+  <div #editorContainer class="monaco-editor-container"></div>
 </div>

--- a/shell/src/app/preview/raw/raw-frame.scss
+++ b/shell/src/app/preview/raw/raw-frame.scss
@@ -33,10 +33,6 @@
     opacity: 0.55;
     pointer-events: none;
     cursor: not-allowed;
-
-    textarea {
-      cursor: not-allowed;
-    }
   }
 
   .invalid-json-badge {
@@ -45,56 +41,19 @@
     padding: 8px 0;
   }
 
-  .raw-json-field {
+  .monaco-editor-container {
     width: 100%;
     height: 100%;
     flex: 1 1 auto;
     display: block;
-
-    ::ng-deep .mdc-notched-outline {
-      display: none !important;
-    }
-
-    ::ng-deep .mat-mdc-text-field-wrapper {
-      height: 100%;
-      padding-right: 0;
-    }
-
-    ::ng-deep .mat-mdc-form-field-flex {
-      height: 100%;
-      background-color: transparent;
-      padding: 0;
-    }
-    ::ng-deep .mat-mdc-form-field-infix {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      box-sizing: border-box;
-      padding-top: 0;
-    }
-
-    textarea {
-      font-family: monospace;
-      resize: none;
-      flex: 1 1 auto;
-      height: 100%;
-      width: 100%;
-      box-sizing: border-box;
-      border: none;
-      outline: none;
-      background: transparent;
-    }
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 4px;
+    overflow: hidden;
   }
 
   &.is-collapsed {
-    .raw-json-field {
+    .monaco-editor-container {
       font-size: 12px;
-      ::ng-deep .mat-mdc-form-field-flex {
-        padding: 0;
-      }
-      ::ng-deep .mat-mdc-form-field-infix {
-        padding-top: 0;
-      }
     }
   }
 }

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -18,7 +18,6 @@ import {TestBed} from '@angular/core/testing';
 import {RawFrame} from './raw-frame';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {RawFrameHarness} from './test/raw-frame.harness';
-import {MatInputHarness} from '@angular/material/input/testing';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {IS_EXTENSION_MODE} from '../../shell/environment-tokens/environment-tokens';
@@ -28,6 +27,62 @@ import {CatalogManagement} from '../../storage/catalog-management/catalog-manage
 import {Catalog} from '../../storage/models/catalog-storage.model';
 import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState, LlmLogEntry, LlmLogType} from '../../chat/chat-state/chat-state';
+
+const {createMock, mockEditor} = vi.hoisted(() => {
+  const mockEditor = {
+    getValue: vi.fn(() => ''),
+    setValue: vi.fn(),
+    onDidChangeModelContent: vi.fn(() => ({dispose: () => {}})),
+    updateOptions: vi.fn(),
+    dispose: vi.fn(),
+  };
+
+  const create = vi.fn((container: HTMLElement, options: any) => {
+    const textarea = document.createElement('textarea');
+    textarea.className = 'mock-monaco-textarea';
+    textarea.value = options.value || '';
+    if (options.readOnly) {
+      textarea.readOnly = true;
+    }
+    container.appendChild(textarea);
+
+    mockEditor.getValue.mockImplementation(() => textarea.value);
+    mockEditor.setValue.mockImplementation((val: string) => {
+      textarea.value = val;
+    });
+    mockEditor.onDidChangeModelContent.mockImplementation((cb: any) => {
+      textarea.addEventListener('input', cb);
+      return {
+        dispose: () => textarea.removeEventListener('input', cb),
+      };
+    });
+    mockEditor.updateOptions.mockImplementation((newOpts: any) => {
+      if (newOpts.readOnly !== undefined) {
+        textarea.readOnly = newOpts.readOnly;
+      }
+    });
+    mockEditor.dispose.mockImplementation(() => {
+      textarea.remove();
+    });
+
+    return mockEditor as any;
+  });
+
+  return {createMock: create, mockEditor};
+});
+
+vi.mock('@monaco-editor/loader', () => {
+  return {
+    default: {
+      config: vi.fn(),
+      init: vi.fn().mockResolvedValue({
+        editor: {
+          create: createMock,
+        },
+      }),
+    },
+  };
+});
 
 class MockChatState {
   readonly isProgrammaticStreamActive = signal<boolean>(false);
@@ -66,6 +121,19 @@ describe('RawFrame JSON Source Editor View', () => {
   beforeEach(() => {
     sendRenderA2UIMock = vi.fn();
     mockActiveCatalog = signal<Catalog | null>({title: 'Sample Catalog'});
+
+    mockEditor.getValue.mockClear();
+    mockEditor.setValue.mockClear();
+    mockEditor.onDidChangeModelContent.mockClear();
+    mockEditor.updateOptions.mockClear();
+    mockEditor.dispose.mockClear();
+    createMock.mockClear();
+
+    mockEditor.getValue.mockReturnValue(
+      '{"version": "v0.9", "createSurface": {"surfaceId": "sample-surface", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json", "sendDataModel": true}}\n' +
+        '{"version": "v0.9", "updateComponents": {"surfaceId": "sample-surface", "components": [{"id": "root", "component": "Column", "children": ["title", "location_input", "pickup_input", "dropoff_input", "book_button"], "justify": "start", "align": "stretch"}, {"id": "title", "component": "Text", "text": "Book a Car", "variant": "h1"}, {"id": "location_input", "component": "TextField", "label": "Pick-up Location", "value": {"path": "/booking/location"}, "variant": "shortText"}, {"id": "pickup_input", "component": "DateTimeInput", "label": "Pick-up Date", "value": {"path": "/booking/pickupDate"}, "enableDate": true, "enableTime": false}, {"id": "dropoff_input", "component": "DateTimeInput", "label": "Drop-off Date", "value": {"path": "/booking/dropoffDate"}, "enableDate": true, "enableTime": false}, {"id": "book_button", "component": "Button", "child": "book_button_text", "variant": "primary", "action": {"event": {"name": "searchCars", "context": {"location": {"path": "/booking/location"}, "pickupDate": {"path": "/booking/pickupDate"}, "dropoffDate": {"path": "/booking/dropoffDate"}}}}}, {"id": "book_button_text", "component": "Text", "text": "Search Cars", "variant": "body"}]}}\n' +
+        '{"version": "v0.9", "updateDataModel": {"surfaceId": "sample-surface", "path": "/booking", "value": {"location": "", "pickupDate": "", "dropoffDate": ""}}}',
+    );
   });
 
   afterEach(() => {
@@ -97,12 +165,14 @@ describe('RawFrame JSON Source Editor View', () => {
 
     const fixture = TestBed.createComponent(RawFrame);
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, RawFrameHarness);
     const component = fixture.componentInstance;
     return {fixture, harness, component};
   }
 
-  it('renders the raw JSON layout inside an Angular Material form field', async () => {
+  it('renders the raw JSON layout inside the editor', async () => {
     const {harness} = await setup(false);
     expect(await harness.getJsonText()).toContain('"createSurface"');
   });
@@ -290,7 +360,7 @@ describe('RawFrame JSON Source Editor View', () => {
     expect(stateSyncMock.updateDraft).toHaveBeenCalledWith('{"version": "v0.9"}');
   });
 
-  it('locks textarea inputs forcefully during active streams lockouts periods', async () => {
+  it('locks editor inputs forcefully during active streams lockouts periods', async () => {
     const {fixture, harness} = await setup(false);
     expect(await harness.isReadOnly()).toBe(false);
 
@@ -305,11 +375,10 @@ describe('RawFrame JSON Source Editor View', () => {
     expect(await harness.isReadOnly()).toBe(false);
   });
 
-  it('applies the accessible name "Raw layout JSON" to the raw layout textarea', async () => {
-    const {fixture} = await setup(false);
-    const loader = TestbedHarnessEnvironment.loader(fixture);
-    const input = await loader.getHarness(MatInputHarness);
-    const host = await input.host();
-    expect(await host.getAttribute('aria-label')).toBe('Raw layout JSON');
+  it('applies the accessible name "Raw layout JSON" to the raw layout editor options', async () => {
+    await setup(false);
+    expect(createMock).toHaveBeenCalled();
+    const lastCall = createMock.mock.calls[createMock.mock.calls.length - 1];
+    expect(lastCall[1].ariaLabel).toBe('Raw layout JSON');
   });
 });

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -129,12 +129,6 @@ describe('RawFrame JSON Source Editor View', () => {
     mockEditor.updateOptions.mockClear();
     mockEditor.dispose.mockClear();
     createMock.mockClear();
-
-    mockEditor.getValue.mockReturnValue(
-      '{"version": "v0.9", "createSurface": {"surfaceId": "sample-surface", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json", "sendDataModel": true}}\n' +
-        '{"version": "v0.9", "updateComponents": {"surfaceId": "sample-surface", "components": [{"id": "root", "component": "Column", "children": ["title", "location_input", "pickup_input", "dropoff_input", "book_button"], "justify": "start", "align": "stretch"}, {"id": "title", "component": "Text", "text": "Book a Car", "variant": "h1"}, {"id": "location_input", "component": "TextField", "label": "Pick-up Location", "value": {"path": "/booking/location"}, "variant": "shortText"}, {"id": "pickup_input", "component": "DateTimeInput", "label": "Pick-up Date", "value": {"path": "/booking/pickupDate"}, "enableDate": true, "enableTime": false}, {"id": "dropoff_input", "component": "DateTimeInput", "label": "Drop-off Date", "value": {"path": "/booking/dropoffDate"}, "enableDate": true, "enableTime": false}, {"id": "book_button", "component": "Button", "child": "book_button_text", "variant": "primary", "action": {"event": {"name": "searchCars", "context": {"location": {"path": "/booking/location"}, "pickupDate": {"path": "/booking/pickupDate"}, "dropoffDate": {"path": "/booking/dropoffDate"}}}}}, {"id": "book_button_text", "component": "Text", "text": "Search Cars", "variant": "body"}]}}\n' +
-        '{"version": "v0.9", "updateDataModel": {"surfaceId": "sample-surface", "path": "/booking", "value": {"location": "", "pickupDate": "", "dropoffDate": ""}}}',
-    );
   });
 
   afterEach(() => {

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -38,36 +38,38 @@ const {createMock, mockEditor} = vi.hoisted(() => {
     dispose: vi.fn(),
   };
 
-  const create = vi.fn((container: HTMLElement, options: monaco.editor.IStandaloneEditorConstructionOptions) => {
-    const textarea = document.createElement('textarea');
-    textarea.className = 'mock-monaco-textarea';
-    textarea.value = options.value || '';
-    if (options.readOnly) {
-      textarea.readOnly = true;
-    }
-    container.appendChild(textarea);
-
-    mockEditor.getValue.mockImplementation(() => textarea.value);
-    mockEditor.setValue.mockImplementation((val: string) => {
-      textarea.value = val;
-    });
-    mockEditor.onDidChangeModelContent.mockImplementation((cb: () => void) => {
-      textarea.addEventListener('input', cb);
-      return {
-        dispose: () => textarea.removeEventListener('input', cb),
-      };
-    });
-    mockEditor.updateOptions.mockImplementation((newOpts: monaco.editor.IEditorOptions) => {
-      if (newOpts.readOnly !== undefined) {
-        textarea.readOnly = newOpts.readOnly;
+  const create = vi.fn(
+    (container: HTMLElement, options: monaco.editor.IStandaloneEditorConstructionOptions) => {
+      const textarea = document.createElement('textarea');
+      textarea.className = 'mock-monaco-textarea';
+      textarea.value = options.value || '';
+      if (options.readOnly) {
+        textarea.readOnly = true;
       }
-    });
-    mockEditor.dispose.mockImplementation(() => {
-      textarea.remove();
-    });
+      container.appendChild(textarea);
 
-    return mockEditor as unknown as monaco.editor.IStandaloneCodeEditor;
-  });
+      mockEditor.getValue.mockImplementation(() => textarea.value);
+      mockEditor.setValue.mockImplementation((val: string) => {
+        textarea.value = val;
+      });
+      mockEditor.onDidChangeModelContent.mockImplementation((cb: () => void) => {
+        textarea.addEventListener('input', cb);
+        return {
+          dispose: () => textarea.removeEventListener('input', cb),
+        };
+      });
+      mockEditor.updateOptions.mockImplementation((newOpts: monaco.editor.IEditorOptions) => {
+        if (newOpts.readOnly !== undefined) {
+          textarea.readOnly = newOpts.readOnly;
+        }
+      });
+      mockEditor.dispose.mockImplementation(() => {
+        textarea.remove();
+      });
+
+      return mockEditor as unknown as monaco.editor.IStandaloneCodeEditor;
+    },
+  );
 
   return {createMock: create, mockEditor};
 });

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -27,6 +27,7 @@ import {CatalogManagement} from '../../storage/catalog-management/catalog-manage
 import {Catalog} from '../../storage/models/catalog-storage.model';
 import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState, LlmLogEntry, LlmLogType} from '../../chat/chat-state/chat-state';
+import type * as monaco from 'monaco-editor';
 
 const {createMock, mockEditor} = vi.hoisted(() => {
   const mockEditor = {
@@ -37,7 +38,7 @@ const {createMock, mockEditor} = vi.hoisted(() => {
     dispose: vi.fn(),
   };
 
-  const create = vi.fn((container: HTMLElement, options: any) => {
+  const create = vi.fn((container: HTMLElement, options: monaco.editor.IStandaloneEditorConstructionOptions) => {
     const textarea = document.createElement('textarea');
     textarea.className = 'mock-monaco-textarea';
     textarea.value = options.value || '';
@@ -50,13 +51,13 @@ const {createMock, mockEditor} = vi.hoisted(() => {
     mockEditor.setValue.mockImplementation((val: string) => {
       textarea.value = val;
     });
-    mockEditor.onDidChangeModelContent.mockImplementation((cb: any) => {
+    mockEditor.onDidChangeModelContent.mockImplementation((cb: () => void) => {
       textarea.addEventListener('input', cb);
       return {
         dispose: () => textarea.removeEventListener('input', cb),
       };
     });
-    mockEditor.updateOptions.mockImplementation((newOpts: any) => {
+    mockEditor.updateOptions.mockImplementation((newOpts: monaco.editor.IEditorOptions) => {
       if (newOpts.readOnly !== undefined) {
         textarea.readOnly = newOpts.readOnly;
       }
@@ -65,7 +66,7 @@ const {createMock, mockEditor} = vi.hoisted(() => {
       textarea.remove();
     });
 
-    return mockEditor as any;
+    return mockEditor as unknown as monaco.editor.IStandaloneCodeEditor;
   });
 
   return {createMock: create, mockEditor};

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -22,13 +22,16 @@ import {
   effect,
   untracked,
   WritableSignal,
+  ElementRef,
+  ViewChild,
+  AfterViewInit,
+  OnDestroy,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatInputModule} from '@angular/material/input';
-import {FormsModule} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {debounceTime, filter, map} from 'rxjs/operators';
+import loader from '@monaco-editor/loader';
+import type * as monaco from 'monaco-editor';
 import {IS_EXTENSION_MODE} from '../../shell/environment-tokens/environment-tokens';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
@@ -43,14 +46,16 @@ import {tryParseJsonArray} from '../../utils/json';
 @Component({
   selector: 'a2ui-composer-raw-frame',
   standalone: true,
-  imports: [MatFormFieldModule, MatInputModule, FormsModule],
   templateUrl: './raw-frame.ng.html',
   styleUrl: './raw-frame.scss',
 })
-export class RawFrame {
+export class RawFrame implements AfterViewInit, OnDestroy {
   protected readonly isExtensionMode = inject(IS_EXTENSION_MODE);
   protected readonly layoutJson: WritableSignal<string>;
   protected readonly isJsonInvalid: WritableSignal<boolean> = signal(false);
+
+  @ViewChild('editorContainer') editorContainer!: ElementRef<HTMLDivElement>;
+  private editor?: monaco.editor.IStandaloneCodeEditor;
 
   readonly TEST_ONLY = {
     layoutJson: () => this.layoutJson,
@@ -92,6 +97,9 @@ export class RawFrame {
         if (this.layoutJson() !== activeDraftVal) {
           queueMicrotask(() => {
             this.layoutJson.set(activeDraftVal);
+            if (this.editor && this.editor.getValue() !== activeDraftVal) {
+              this.editor.setValue(activeDraftVal);
+            }
 
             // Run live render updating matching activeDraft commits
             try {
@@ -106,6 +114,15 @@ export class RawFrame {
               this.isJsonInvalid.set(true);
             }
           });
+        }
+      });
+    });
+
+    effect(() => {
+      const locked = this.isLocked();
+      untracked(() => {
+        if (this.editor) {
+          this.editor.updateOptions({readOnly: locked});
         }
       });
     });
@@ -133,6 +150,41 @@ export class RawFrame {
       .subscribe((payload: unknown[]) => {
         this.hostCommunication.sendRenderA2UI(payload);
       });
+  }
+
+  ngAfterViewInit() {
+    // Configure Monaco loader to use the local assets copy
+    loader.config({paths: {vs: '/assets/monaco/vs'}});
+
+    loader.init().then((monacoInstance) => {
+      const editor = monacoInstance.editor.create(this.editorContainer.nativeElement, {
+        value: this.layoutJson(),
+        language: 'json',
+        theme: 'vs-light',
+        automaticLayout: true,
+        minimap: {enabled: false},
+        readOnly: this.isLocked(),
+        scrollBeyondLastLine: false,
+        lineNumbers: 'on',
+        folding: true,
+        wordWrap: 'on',
+        ariaLabel: 'Raw layout JSON',
+      });
+      this.editor = editor;
+
+      editor.onDidChangeModelContent(() => {
+        const val = editor.getValue();
+        if (val !== this.layoutJson()) {
+          this.onLayoutChange(val);
+        }
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.editor) {
+      this.editor.dispose();
+    }
   }
 
   protected onLayoutChange(value: string): void {

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -56,6 +56,7 @@ export class RawFrame implements AfterViewInit, OnDestroy {
 
   @ViewChild('editorContainer') editorContainer!: ElementRef<HTMLDivElement>;
   private editor?: monaco.editor.IStandaloneCodeEditor;
+  private destroyed = false;
 
   readonly TEST_ONLY = {
     layoutJson: () => this.layoutJson,
@@ -154,9 +155,12 @@ export class RawFrame implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit() {
     // Configure Monaco loader to use the local assets copy
-    loader.config({paths: {vs: '/assets/monaco/vs'}});
+    loader.config({paths: {vs: 'assets/monaco/vs'}});
 
     loader.init().then((monacoInstance) => {
+      if (this.destroyed) {
+        return;
+      }
       const editor = monacoInstance.editor.create(this.editorContainer.nativeElement, {
         value: this.layoutJson(),
         language: 'json',
@@ -182,6 +186,7 @@ export class RawFrame implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.destroyed = true;
     if (this.editor) {
       this.editor.dispose();
     }

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -157,7 +157,7 @@ export class RawFrame implements AfterViewInit, OnDestroy {
     // Configure Monaco loader to use the local assets copy
     loader.config({paths: {vs: 'assets/monaco/vs'}});
 
-    loader.init().then((monacoInstance) => {
+    loader.init().then(monacoInstance => {
       if (this.destroyed) {
         return;
       }

--- a/shell/src/app/preview/raw/test/raw-frame.harness.ts
+++ b/shell/src/app/preview/raw/test/raw-frame.harness.ts
@@ -16,7 +16,6 @@
  */
 
 import {ComponentHarness} from '@angular/cdk/testing';
-import {MatInputHarness} from '@angular/material/input/testing';
 
 /**
  * Harness for interacting with the raw-frame preview editor.
@@ -25,7 +24,7 @@ import {MatInputHarness} from '@angular/material/input/testing';
 export class RawFrameHarness extends ComponentHarness {
   static hostSelector = 'a2ui-composer-raw-frame';
 
-  protected getInputHarness = this.locatorFor(MatInputHarness);
+  private readonly textareaLocator = this.locatorFor('textarea.mock-monaco-textarea');
 
   async isCollapsed(): Promise<boolean> {
     const container = await this.locatorFor('.raw-frame-container')();
@@ -33,13 +32,14 @@ export class RawFrameHarness extends ComponentHarness {
   }
 
   async getJsonText(): Promise<string> {
-    const input = await this.getInputHarness();
-    return input.getValue();
+    const textarea = await this.textareaLocator();
+    return textarea.getProperty('value');
   }
 
   async setJsonText(value: string): Promise<void> {
-    const input = await this.getInputHarness();
-    return input.setValue(value);
+    const textarea = await this.textareaLocator();
+    await textarea.setInputValue(value);
+    await textarea.dispatchEvent('input');
   }
 
   async hasInvalidJsonBadge(): Promise<boolean> {
@@ -48,8 +48,7 @@ export class RawFrameHarness extends ComponentHarness {
   }
 
   async isReadOnly(): Promise<boolean> {
-    const input = await this.getInputHarness();
-    const host = await input.host();
-    return !!(await host.getProperty<boolean>('readOnly'));
+    const textarea = await this.textareaLocator();
+    return textarea.getProperty('readOnly');
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3390,6 +3390,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@monaco-editor/loader@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@monaco-editor/loader@npm:1.7.0"
+  dependencies:
+    state-local: "npm:^1.0.6"
+  checksum: 10c0/1fd3579cb09b669493cf553dfc0723a93483140a44353ce9a739827edfa7b2c6541b254024d15c48176ece749ef666b6d16cce6cf0e4396c7fa1c5a48012d08a
+  languageName: node
+  linkType: hard
+
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.4":
   version: 3.0.4
   resolution: "@msgpackr-extract/msgpackr-extract-darwin-arm64@npm:3.0.4"
@@ -5869,6 +5878,7 @@ __metadata:
     "@angular/platform-browser-dynamic": "npm:22.0.2"
     "@angular/router": "npm:22.0.2"
     "@google/genai": "npm:2.8.0"
+    "@monaco-editor/loader": "npm:^1.7.0"
     "@playwright/test": "npm:1.61.0"
     "@types/jsdom": "npm:28.0.3"
     "@vitest/coverage-v8": "npm:4.1.9"
@@ -5876,6 +5886,7 @@ __metadata:
     angular-eslint: "npm:22.0.0"
     eslint: "npm:10.5.0"
     jsdom: "npm:29.1.1"
+    monaco-editor: "npm:^0.55.1"
     ng-basic-catalog: "npm:0.1.0"
     prettier: "npm:3.8.4"
     rxjs: "npm:7.8.2"
@@ -7101,6 +7112,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:3.2.7":
+  version: 3.2.7
+  resolution: "dompurify@npm:3.2.7"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
   languageName: node
   linkType: hard
 
@@ -9510,6 +9533,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:14.0.0":
+  version: 14.0.0
+  resolution: "marked@npm:14.0.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/57a47cb110f7b1a10f398b0a7236f9183aad2dcd5345ee73f2732b6387e585d04cef472bc655d2f84c542296be9728e179aebe3ed7f2f8666b8a0a9dae592876
+  languageName: node
+  linkType: hard
+
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -9781,6 +9813,16 @@ __metadata:
   bin:
     mkdirp: dist/cjs/src/bin.js
   checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
+  languageName: node
+  linkType: hard
+
+"monaco-editor@npm:^0.55.1":
+  version: 0.55.1
+  resolution: "monaco-editor@npm:0.55.1"
+  dependencies:
+    dompurify: "npm:3.2.7"
+    marked: "npm:14.0.0"
+  checksum: 10c0/c1a0cf887657b42c8996518bc5ee96bbd39c977f862d2a2b2018427c45f14b0dd25d1452278202056f6b1ead97981282ccacd7d7ad918d8f0ef084159f974a25
   languageName: node
   linkType: hard
 
@@ -11990,6 +12032,13 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"state-local@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "state-local@npm:1.0.7"
+  checksum: 10c0/8dc7daeac71844452fafb514a6d6b6f40d7e2b33df398309ea1c7b3948d6110c57f112b7196500a10c54fdde40291488c52c875575670fb5c819602deca48bd9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Switch out the A2UI JSON Payload text area from raw textarea element to Monaco Editor to get Syntax highlighting.

https://screenshot.googleplex.com/4KQvV84rzrXKBah


## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
