### PR TITLE
refactor: replace invalid JSON UI badge with MatSnackBar notification…

### DIFF
--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -135,8 +135,7 @@ test.describe('Components Gallery User Journey', () => {
           const createSurface = cmd1['createSurface'] as Record<string, unknown> | undefined;
           const updateComponents = cmd2['updateComponents'] as Record<string, unknown> | undefined;
           const components = updateComponents?.['components'] as
-            | Array<Record<string, unknown>>
-            | undefined;
+            Array<Record<string, unknown>> | undefined;
           const hasComponent =
             Array.isArray(components) &&
             components.some(c => c['component'] === firstComponentName);

--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -135,7 +135,8 @@ test.describe('Components Gallery User Journey', () => {
           const createSurface = cmd1['createSurface'] as Record<string, unknown> | undefined;
           const updateComponents = cmd2['updateComponents'] as Record<string, unknown> | undefined;
           const components = updateComponents?.['components'] as
-            Array<Record<string, unknown>> | undefined;
+            | Array<Record<string, unknown>>
+            | undefined;
           const hasComponent =
             Array.isArray(components) &&
             components.some(c => c['component'] === firstComponentName);

--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -157,6 +157,9 @@ for (const config of CONFIGS) {
 
       await expect(dataModelTextarea).not.toHaveValue(/^$/);
 
+      // Wait for initial DATA_MODEL_CHANGE sync from iframe to complete to avoid race condition
+      await page.waitForTimeout(1000);
+
       const currentValue = await dataModelTextarea.inputValue();
       const parsedModel = JSON.parse(currentValue);
       parsedModel.booking.location = 'LAX';

--- a/shell/e2e/user-journey.e2e.ts
+++ b/shell/e2e/user-journey.e2e.ts
@@ -66,6 +66,8 @@ test.describe('E2E Workspace User Journey', () => {
       return (monaco?.editor?.getModels()?.length ?? 0) > 0;
     });
 
+    await page.waitForTimeout(500); // Give Monaco time to fully attach event listeners
+
     await page.evaluate(() => {
       const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
       if (model) {
@@ -73,10 +75,11 @@ test.describe('E2E Workspace User Journey', () => {
       }
     });
 
-    // 8. Assert that warning badge (.invalid-json-badge) appears above textarea
-    await expect(page.locator('.invalid-json-badge')).toBeVisible();
+    // 8. Assert that snackbar appears
+    const snackbarLocator = page.locator('.mat-mdc-snack-bar-label').first();
+    await expect(snackbarLocator).toContainText('Invalid JSON syntax detected.');
 
-    // 9. Correct JSON and verify warning badge disappears
+    // 9. Correct JSON and verify snackbar disappears
     await page.evaluate(() => {
       const model = (window as unknown as WindowWithMonaco).monaco?.editor?.getModels()?.[0];
       if (model) {
@@ -85,6 +88,7 @@ test.describe('E2E Workspace User Journey', () => {
         );
       }
     });
-    await expect(page.locator('.invalid-json-badge')).not.toBeVisible();
+    // With dismissal logic, it should disappear immediately
+    await expect(page.locator('.mat-mdc-snack-bar-label')).toHaveCount(0, {timeout: 3000});
   });
 });

--- a/shell/src/app/preview/raw/raw-frame.ng.html
+++ b/shell/src/app/preview/raw/raw-frame.ng.html
@@ -18,8 +18,5 @@
   [class.is-collapsed]="isExtensionMode()"
   [class.is-locked]="isLocked()"
 >
-  @if (isJsonInvalid()) {
-    <div class="invalid-json-badge">⚠️ Invalid JSON syntax detected.</div>
-  }
   <div #editorContainer class="monaco-editor-container"></div>
 </div>

--- a/shell/src/app/preview/raw/raw-frame.scss
+++ b/shell/src/app/preview/raw/raw-frame.scss
@@ -35,12 +35,6 @@
     cursor: not-allowed;
   }
 
-  .invalid-json-badge {
-    color: var(--mat-sys-error);
-    font-weight: bold;
-    padding: 8px 0;
-  }
-
   .monaco-editor-container {
     width: 100%;
     height: 100%;

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -29,6 +29,7 @@ import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState, LlmLogEntry, LlmLogType} from '../../chat/chat-state/chat-state';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import type * as monaco from 'monaco-editor';
+import {MatSnackBar} from '@angular/material/snack-bar';
 
 const {createMock, mockEditor, mockModel, undoStack, redoStack} = vi.hoisted(() => {
   const undoStack: string[] = [];
@@ -266,11 +267,13 @@ describe('RawFrame JSON Source Editor View', () => {
   let mockThemePreference: WritableSignal<string>;
   let stateSyncMock: MockStateSync;
   let chatStateMock: MockChatState;
+  let snackBarMock: {open: ReturnType<typeof vi.fn>};
 
   beforeEach(() => {
     sendRenderA2UIMock = vi.fn();
     mockActiveCatalog = signal<Catalog | null>({title: 'Sample Catalog'});
     mockThemePreference = signal<string>('light');
+    snackBarMock = {open: vi.fn()};
 
     undoStack.length = 0;
     redoStack.length = 0;
@@ -315,6 +318,7 @@ describe('RawFrame JSON Source Editor View', () => {
         },
         {provide: StateSync, useClass: MockStateSync},
         {provide: ChatState, useClass: MockChatState},
+        {provide: MatSnackBar, useValue: snackBarMock},
       ],
     }).compileComponents();
 
@@ -455,8 +459,7 @@ describe('RawFrame JSON Source Editor View', () => {
     expect(sendRenderA2UIMock).toHaveBeenLastCalledWith([
       {version: 'v0.9', createSurface: {surfaceId: 's1', catalogId: 'c1'}},
     ]);
-    expect(fixture.componentInstance.TEST_ONLY.isJsonInvalid()()).toBe(false);
-    expect(await harness.hasInvalidJsonBadge()).toBe(false);
+    expect(snackBarMock.open).not.toHaveBeenCalled();
   });
 
   it('sets isJsonInvalid to true, suppresses sendRenderA2UI, and displays the invalid JSON badge when malformed JSON is typed', async () => {
@@ -469,8 +472,11 @@ describe('RawFrame JSON Source Editor View', () => {
     fixture.detectChanges();
 
     expect(sendRenderA2UIMock).toHaveBeenCalledTimes(1);
-    expect(fixture.componentInstance.TEST_ONLY.isJsonInvalid()()).toBe(true);
-    expect(await harness.hasInvalidJsonBadge()).toBe(true);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      'Invalid JSON syntax detected.',
+      undefined,
+      expect.any(Object),
+    );
   });
 
   it('sets isJsonInvalid to true, suppresses sendRenderA2UI, and displays the invalid JSON badge when a malformed JSON array is typed', async () => {
@@ -483,8 +489,11 @@ describe('RawFrame JSON Source Editor View', () => {
     fixture.detectChanges();
 
     expect(sendRenderA2UIMock).toHaveBeenCalledTimes(1);
-    expect(fixture.componentInstance.TEST_ONLY.isJsonInvalid()()).toBe(true);
-    expect(await harness.hasInvalidJsonBadge()).toBe(true);
+    expect(snackBarMock.open).toHaveBeenCalledWith(
+      'Invalid JSON syntax detected.',
+      undefined,
+      expect.any(Object),
+    );
   });
 
   it('dispatches initial layout dynamically when activeCatalog transitions from null to a valid catalog', async () => {

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -496,6 +496,24 @@ describe('RawFrame JSON Source Editor View', () => {
     );
   });
 
+  it('suppresses the snackbar notification when malformed JSON is typed during an active stream (isLocked is true)', async () => {
+    const {fixture, harness} = await setup(false);
+    vi.useFakeTimers();
+
+    // Lock active stream
+    chatStateMock.isProgrammaticStreamActive.set(true);
+    fixture.detectChanges();
+
+    await harness.setJsonText('{"version": "v0.9", invalid_json...');
+    fixture.detectChanges();
+
+    vi.advanceTimersByTime(300);
+    fixture.detectChanges();
+
+    expect(sendRenderA2UIMock).toHaveBeenCalledTimes(1);
+    expect(snackBarMock.open).not.toHaveBeenCalled();
+  });
+
   it('dispatches initial layout dynamically when activeCatalog transitions from null to a valid catalog', async () => {
     mockActiveCatalog = signal(null);
     const {fixture} = await setup(false);

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -267,13 +267,13 @@ describe('RawFrame JSON Source Editor View', () => {
   let mockThemePreference: WritableSignal<string>;
   let stateSyncMock: MockStateSync;
   let chatStateMock: MockChatState;
-  let snackBarMock: {open: ReturnType<typeof vi.fn>};
+  let snackBarMock: {open: ReturnType<typeof vi.fn>; dismiss: ReturnType<typeof vi.fn>};
 
   beforeEach(() => {
     sendRenderA2UIMock = vi.fn();
     mockActiveCatalog = signal<Catalog | null>({title: 'Sample Catalog'});
     mockThemePreference = signal<string>('light');
-    snackBarMock = {open: vi.fn()};
+    snackBarMock = {open: vi.fn(), dismiss: vi.fn()};
 
     undoStack.length = 0;
     redoStack.length = 0;

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -345,8 +345,11 @@ export class RawFrame implements AfterViewInit {
   }
 
   private showJsonSyntaxError(): void {
+    if (this.isLocked()) {
+      return;
+    }
     this.snackBar.open('Invalid JSON syntax detected.', undefined, {
-      duration: 3000,
+      duration: 5000,
     });
   }
 }

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -30,6 +30,7 @@ import {
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {Subject} from 'rxjs';
 import {debounceTime, filter, map} from 'rxjs/operators';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import loader from '@monaco-editor/loader';
 import type * as monaco from 'monaco-editor';
 import {IS_EXTENSION_MODE} from '../../shell/environment-tokens/environment-tokens';
@@ -55,7 +56,6 @@ const LAYOUT_MODEL_URI = 'a2ui://layout.json';
 export class RawFrame implements AfterViewInit {
   protected readonly isExtensionMode = inject(IS_EXTENSION_MODE);
   protected readonly layoutJson: WritableSignal<string>;
-  protected readonly isJsonInvalid: WritableSignal<boolean> = signal(false);
 
   readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editorContainer');
   private editor?: monaco.editor.IStandaloneCodeEditor;
@@ -64,7 +64,6 @@ export class RawFrame implements AfterViewInit {
 
   readonly TEST_ONLY = {
     layoutJson: () => this.layoutJson,
-    isJsonInvalid: () => this.isJsonInvalid,
   };
 
   private readonly hostCommunication = inject(HostCommunication);
@@ -73,6 +72,7 @@ export class RawFrame implements AfterViewInit {
   private readonly chatState = inject(ChatState);
   private readonly configProvider = inject(AppConfigProvider);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly snackBar = inject(MatSnackBar);
   private readonly layoutInput$ = new Subject<string>();
 
   /** Public lock indicator preventing typing deadlocks during generative LLM stream turns. */
@@ -186,13 +186,12 @@ export class RawFrame implements AfterViewInit {
             try {
               const payload = this.parseLayoutString(activeDraftVal);
               if (payload !== null) {
-                this.isJsonInvalid.set(false);
                 this.hostCommunication.sendRenderA2UI(payload);
               } else {
-                this.isJsonInvalid.set(true);
+                this.showJsonSyntaxError();
               }
             } catch (err) {
-              this.isJsonInvalid.set(true);
+              this.showJsonSyntaxError();
             }
           });
         }
@@ -224,13 +223,12 @@ export class RawFrame implements AfterViewInit {
           try {
             const payload = this.parseLayoutString(value);
             if (payload !== null) {
-              this.isJsonInvalid.set(false);
               return payload;
             }
-            this.isJsonInvalid.set(true);
+            this.showJsonSyntaxError();
             return null;
           } catch (err) {
-            this.isJsonInvalid.set(true);
+            this.showJsonSyntaxError();
             return null;
           }
         }),
@@ -344,5 +342,11 @@ export class RawFrame implements AfterViewInit {
     } catch (err) {
       throw new SyntaxError('Invalid JSON');
     }
+  }
+
+  private showJsonSyntaxError(): void {
+    this.snackBar.open('Invalid JSON syntax detected.', undefined, {
+      duration: 3000,
+    });
   }
 }

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -223,6 +223,7 @@ export class RawFrame implements AfterViewInit {
           try {
             const payload = this.parseLayoutString(value);
             if (payload !== null) {
+              this.snackBar.dismiss();
               return payload;
             }
             this.showJsonSyntaxError();

--- a/shell/src/app/preview/raw/test/raw-frame.harness.ts
+++ b/shell/src/app/preview/raw/test/raw-frame.harness.ts
@@ -42,11 +42,6 @@ export class RawFrameHarness extends ComponentHarness {
     await textarea.dispatchEvent('input');
   }
 
-  async hasInvalidJsonBadge(): Promise<boolean> {
-    const badge = await this.locatorForOptional('.invalid-json-badge')();
-    return badge !== null;
-  }
-
   async isReadOnly(): Promise<boolean> {
     const textarea = await this.textareaLocator();
     return textarea.getProperty('readOnly');


### PR DESCRIPTION
… in RawFrame

# Description

Change how the JSON Syntax error is displayed to user. It now uses the snackbar to be less obstructive to the ongoing workflow. 

https://screencast.googleplex.com/cast/NjMzOTUxODI4NTIxNzc5MnxmMjdmYjMwZC0zOA

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
