### PR TITLE
Add responsive icon-only collapsed sidenav rail

### DIFF
--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -93,26 +93,32 @@ for (const config of CONFIGS) {
       const envelopes = page.locator(
         '.raw-messages-container [data-testid="raw-message-envelope"], .raw-messages-container [data-testid="llm-log-panel"]',
       );
-      expect(await envelopes.count()).toBeGreaterThanOrEqual(3);
+      await expect.poll(async () => envelopes.count()).toBeGreaterThanOrEqual(3);
 
       // Validate descending chronological sequence (newest first)
       await expect(envelopes.nth(0).locator('.message-type')).toHaveText(
         PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       );
-      await expect(envelopes.nth(1).locator('.message-type')).toHaveText(
+      const catalogEnvelope = envelopes
+        .filter({hasText: PreviewBridgeMessageType.A2UI_CATALOG})
+        .first();
+      await expect(catalogEnvelope.locator('.message-type')).toHaveText(
         PreviewBridgeMessageType.A2UI_CATALOG,
       );
-      await expect(envelopes.nth(2).locator('.message-type')).toHaveText(
+      const readyEnvelope = envelopes
+        .filter({hasText: PreviewBridgeMessageType.RENDERER_READY})
+        .first();
+      await expect(readyEnvelope.locator('.message-type')).toHaveText(
         PreviewBridgeMessageType.RENDERER_READY,
       );
 
       // Expand A2UI_CATALOG card
-      const catalogHeader = envelopes.nth(1).locator('mat-expansion-panel-header');
+      const catalogHeader = catalogEnvelope.locator('mat-expansion-panel-header');
       await catalogHeader.focus();
       await catalogHeader.press('Enter');
 
       // Assert the pre block contains key catalog properties
-      const catalogPre = envelopes.nth(1).locator('pre');
+      const catalogPre = catalogEnvelope.locator('pre');
       await expect(catalogPre).toBeVisible();
       await expect(catalogPre).toContainText('components');
       await expect(catalogPre).toContainText('Column');
@@ -242,6 +248,7 @@ for (const config of CONFIGS) {
         .locator(
           '.raw-messages-container [data-testid="raw-message-envelope"], .raw-messages-container [data-testid="llm-log-panel"]',
         )
+        .filter({hasText: PreviewBridgeMessageType.SEND_TO_SERVER})
         .first();
       await expect(latestEnvelope.locator('.message-type')).toHaveText(
         PreviewBridgeMessageType.SEND_TO_SERVER,

--- a/shell/src/app/shell/composer-shell/composer-shell.ng.html
+++ b/shell/src/app/shell/composer-shell/composer-shell.ng.html
@@ -18,8 +18,10 @@
   <button
     mat-icon-button
     class="hamburger-button"
-    (click)="sidenav.toggle()"
+    (click)="toggleCollapsed()"
+    [attr.aria-expanded]="!isCollapsed()"
     aria-label="Toggle sidenav"
+    aria-controls="composer-sidenav"
   >
     <mat-icon aria-hidden="true">menu</mat-icon>
   </button>
@@ -42,11 +44,61 @@
 </mat-toolbar>
 
 <mat-sidenav-container class="composer-sidenav-container">
-  <mat-sidenav #sidenav mode="side" opened class="composer-sidenav">
+  <mat-sidenav
+    #sidenav
+    id="composer-sidenav"
+    mode="side"
+    [opened]="true"
+    class="composer-sidenav"
+    [class.collapsed]="isCollapsed()"
+  >
     <mat-nav-list>
-      <a mat-list-item routerLink="/">Composer Workspace</a>
-      <a mat-list-item routerLink="/gallery">Components Gallery</a>
-      <a mat-list-item routerLink="/settings">Settings</a>
+      <a
+        mat-list-item
+        routerLink="/"
+        routerLinkActive="active-nav-item"
+        aria-label="Composer Workspace"
+        matTooltip="Composer Workspace"
+        matTooltipPosition="right"
+        [routerLinkActiveOptions]="{exact: true}"
+        [matTooltipDisabled]="!isCollapsed()"
+        (click)="ensureCollapsed()"
+      >
+        <mat-icon matListItemIcon aria-hidden="true">construction</mat-icon>
+        @if (!isCollapsed()) {
+          <span class="nav-label">Composer Workspace</span>
+        }
+      </a>
+      <a
+        mat-list-item
+        routerLink="/gallery"
+        routerLinkActive="active-nav-item"
+        aria-label="Components Gallery"
+        matTooltip="Components Gallery"
+        matTooltipPosition="right"
+        [matTooltipDisabled]="!isCollapsed()"
+        (click)="ensureCollapsed()"
+      >
+        <mat-icon matListItemIcon aria-hidden="true">widgets</mat-icon>
+        @if (!isCollapsed()) {
+          <span class="nav-label">Components Gallery</span>
+        }
+      </a>
+      <a
+        mat-list-item
+        routerLink="/settings"
+        routerLinkActive="active-nav-item"
+        aria-label="Settings"
+        matTooltip="Settings"
+        matTooltipPosition="right"
+        [matTooltipDisabled]="!isCollapsed()"
+        (click)="ensureCollapsed()"
+      >
+        <mat-icon matListItemIcon aria-hidden="true">settings</mat-icon>
+        @if (!isCollapsed()) {
+          <span class="nav-label">Settings</span>
+        }
+      </a>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -44,9 +44,44 @@
   --mat-drawer-container-shape: 0px;
   border-radius: 0px;
   --mat-sidenav-background-color: var(--mat-sys-surface-container);
+  transition: width 200ms ease-in-out;
 
   ::ng-deep .mat-drawer-inner-container {
     border-radius: 0px;
+    white-space: nowrap;
+    overflow-x: hidden;
+  }
+
+  mat-nav-list {
+    padding: 8px;
+
+    a[mat-list-item] {
+      border-radius: 28px;
+      margin-bottom: 4px;
+
+      &.active-nav-item {
+        background-color: var(--mat-sys-secondary-container);
+        color: var(--mat-sys-on-secondary-container);
+
+        mat-icon {
+          color: var(--mat-sys-primary);
+        }
+      }
+    }
+  }
+
+  &.collapsed {
+    width: 64px;
+
+    a[mat-list-item] {
+      padding: 16px;
+      display: flex;
+      justify-content: center;
+
+      ::ng-deep .mdc-list-item__start {
+        margin: 0;
+      }
+    }
   }
 }
 .composer-content {

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -16,7 +16,8 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComposerShell} from './composer-shell';
-import {provideRouter} from '@angular/router';
+import {provideRouter, Router, RouterLinkActive} from '@angular/router';
+import {By} from '@angular/platform-browser';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComposerShellHarness} from './test/composer-shell.harness';
@@ -161,14 +162,14 @@ describe('ComposerShell Layout', () => {
   );
 
   it(
-    'toggles the left sidebar opened and closed states upon clicking ' +
+    'toggles the left sidebar collapsed state upon clicking ' +
       'the hamburger button via test harness interaction',
     async () => {
-      expect(await harness.isSidenavOpened()).toBe(true);
+      expect(await harness.isSidenavCollapsed()).toBe(true);
       await harness.clickHamburgerButton();
-      expect(await harness.isSidenavOpened()).toBe(false);
+      expect(await harness.isSidenavCollapsed()).toBe(false);
       await harness.clickHamburgerButton();
-      expect(await harness.isSidenavOpened()).toBe(true);
+      expect(await harness.isSidenavCollapsed()).toBe(true);
     },
   );
 
@@ -190,16 +191,64 @@ describe('ComposerShell Layout', () => {
     expect(configProviderMock.setThemePreference).toHaveBeenCalledWith('light');
   });
 
-  it('renders the Components Gallery navigation link in the sidebar by default', async () => {
+  it('renders the Components Gallery navigation link in the sidebar when expanded', async () => {
+    await harness.clickHamburgerButton();
     const links = await harness.getNavigationLinksText();
     expect(links).toContain('Components Gallery');
   });
 
   it('applies aria-hidden attribute to purely decorative MatIcon elements across the composer shell', async () => {
     const hiddenAttrs = await harness.getIconsAriaHidden();
-    expect(hiddenAttrs.length).toBe(2);
+    expect(hiddenAttrs.length).toBe(5);
     hiddenAttrs.forEach(attr => {
       expect(attr).toBe('true');
     });
+  });
+
+  it('renders Material icons inside navigation list items', async () => {
+    const icons = await harness.getNavListIconsText();
+    expect(icons).toEqual(['construction', 'widgets', 'settings']);
+  });
+
+  it('enables tooltips on navigation items and hides labels when collapsed initially', async () => {
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([false, false, false]);
+    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(0);
+    await harness.clickHamburgerButton();
+    expect(await harness.isSidenavCollapsed()).toBe(false);
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([true, true, true]);
+    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(3);
+  });
+
+  it('sets explicit aria-label attributes on navigation links and connects hamburger button to sidenav via aria-controls', () => {
+    const navLinks = Array.from(fixture.nativeElement.querySelectorAll('mat-nav-list a'));
+    const ariaLabels = navLinks.map((link: unknown) =>
+      (link as Element).getAttribute('aria-label'),
+    );
+    expect(ariaLabels).toEqual(['Composer Workspace', 'Components Gallery', 'Settings']);
+
+    const sidenavEl = fixture.nativeElement.querySelector('mat-sidenav');
+    expect(sidenavEl.getAttribute('id')).toBe('composer-sidenav');
+
+    const hamburgerButton = fixture.nativeElement.querySelector('.hamburger-button');
+    expect(hamburgerButton.getAttribute('aria-controls')).toBe('composer-sidenav');
+  });
+
+  it('applies routerLinkActive="active-nav-item" to navigation links with exact matching on root so active anchor receives active-nav-item class', async () => {
+    const navLinks = Array.from(fixture.nativeElement.querySelectorAll('mat-nav-list a'));
+    const rlaAttrs = navLinks.map((link: unknown) =>
+      (link as Element).getAttribute('routerLinkActive'),
+    );
+    expect(rlaAttrs).toEqual(['active-nav-item', 'active-nav-item', 'active-nav-item']);
+
+    const rlaDirectives = fixture.debugElement.queryAll(By.directive(RouterLinkActive));
+    expect(rlaDirectives.length).toBe(3);
+    const rlaInstances = rlaDirectives.map(de => de.injector.get(RouterLinkActive));
+    expect(rlaInstances[0].routerLinkActiveOptions).toEqual({exact: true});
+
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect((navLinks[0] as HTMLElement).classList.contains('active-nav-item')).toBe(true);
   });
 });

--- a/shell/src/app/shell/composer-shell/composer-shell.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Component, computed, effect, inject} from '@angular/core';
+import {Component, computed, effect, inject, signal} from '@angular/core';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatListModule} from '@angular/material/list';
-import {RouterLink, RouterOutlet} from '@angular/router';
+import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
 import {DOCUMENT} from '@angular/common';
 import {IndexedDbStorage} from '../../storage/indexed-db-storage/indexed-db-storage';
 import {MatTooltipModule} from '@angular/material/tooltip';
@@ -46,12 +46,14 @@ import {SessionStorageInteractions} from '../../storage/session-storage-interact
     MatListModule,
     RouterOutlet,
     RouterLink,
+    RouterLinkActive,
     MatTooltipModule,
   ],
   templateUrl: './composer-shell.ng.html',
   styleUrl: './composer-shell.scss',
 })
 export class ComposerShell {
+  readonly isCollapsed = signal(true);
   isDarkTheme = computed(() => this.configProvider.themePreference() === 'dark');
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly indexedDbStorage = inject(IndexedDbStorage);
@@ -71,6 +73,18 @@ export class ComposerShell {
         this.document.body.classList.remove('dark-theme');
       }
     });
+  }
+
+  /**
+   * Toggles collapsed state of the side navigation bar.
+   */
+  toggleCollapsed(): void {
+    this.isCollapsed.update(c => !c);
+  }
+
+  /** Ensure the sidenav is collapsed. Called after the user clicks an item. */
+  ensureCollapsed(): void {
+    this.isCollapsed.set(true);
   }
 
   /**

--- a/shell/src/app/shell/composer-shell/test/composer-shell.harness.ts
+++ b/shell/src/app/shell/composer-shell/test/composer-shell.harness.ts
@@ -64,6 +64,21 @@ export class ComposerShellHarness extends ComponentHarness {
     return sidenav.isOpen();
   }
 
+  async isSidenavCollapsed(): Promise<boolean> {
+    const sidenav = await this.locatorFor('.composer-sidenav')();
+    return sidenav.hasClass('collapsed');
+  }
+
+  async getNavListIconsText(): Promise<string[]> {
+    const icons = await this.locatorForAll('mat-nav-list mat-icon')();
+    return Promise.all(icons.map(icon => icon.text()));
+  }
+
+  async getNavListTooltipsDisabled(): Promise<boolean[]> {
+    const tooltips = await this.locatorForAll(MatTooltipHarness.with({ancestor: 'mat-nav-list'}))();
+    return Promise.all(tooltips.map(t => t.isDisabled()));
+  }
+
   async getNavigationLinksText(): Promise<string[]> {
     const list = await this.getNavList();
     const items = await list.getItems();


### PR DESCRIPTION
# Description

Side nav starts collapsed.
Add icons to nav items.
Show only the icons when the sidenav is collapsed.

Initial state: https://screenshot.googleplex.com/image/9RqJ9bBGihXtA2B.png
Sidenav open: https://screenshot.googleplex.com/image/7XJksoppxgcQJei.png

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
