### PR TITLE
refactor: rename Monaco editor component to a2ui-composer-monaco-edit…

### DIFF
--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -135,8 +135,7 @@ test.describe('Components Gallery User Journey', () => {
           const createSurface = cmd1['createSurface'] as Record<string, unknown> | undefined;
           const updateComponents = cmd2['updateComponents'] as Record<string, unknown> | undefined;
           const components = updateComponents?.['components'] as
-            | Array<Record<string, unknown>>
-            | undefined;
+            Array<Record<string, unknown>> | undefined;
           const hasComponent =
             Array.isArray(components) &&
             components.some(c => c['component'] === firstComponentName);

--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -135,7 +135,8 @@ test.describe('Components Gallery User Journey', () => {
           const createSurface = cmd1['createSurface'] as Record<string, unknown> | undefined;
           const updateComponents = cmd2['updateComponents'] as Record<string, unknown> | undefined;
           const components = updateComponents?.['components'] as
-            Array<Record<string, unknown>> | undefined;
+            | Array<Record<string, unknown>>
+            | undefined;
           const hasComponent =
             Array.isArray(components) &&
             components.some(c => c['component'] === firstComponentName);

--- a/shell/src/app/preview/raw/raw-frame.ng.html
+++ b/shell/src/app/preview/raw/raw-frame.ng.html
@@ -26,5 +26,5 @@
     [value]="layoutJson()"
     [readOnly]="isLocked()"
     (valueChange)="onLayoutChange($event)"
-  ></a2ui-composer-monaco-editor>
+  />
 </div>

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -54,7 +54,11 @@ const {createMock, mockEditor, mockModel, undoStack, redoStack} = vi.hoisted(() 
     onDidChangeModelContent: vi.fn(() => ({dispose: () => {}})),
     updateOptions: vi.fn(),
     dispose: vi.fn(),
-    getModel: vi.fn(() => mockModel),
+    getModel: vi.fn(() => ({
+      getFullModelRange: vi.fn(() => ({})),
+    })),
+    pushUndoStop: vi.fn(),
+    executeEdits: vi.fn(),
   };
 
   const create = vi.fn(

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -20,47 +20,35 @@ import {
   signal,
   DestroyRef,
   effect,
-  computed,
   untracked,
   WritableSignal,
-  ElementRef,
-  viewChild,
-  AfterViewInit,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {Subject} from 'rxjs';
 import {debounceTime, filter, map} from 'rxjs/operators';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import loader from '@monaco-editor/loader';
-import type * as monaco from 'monaco-editor';
 import {IS_EXTENSION_MODE} from '../../shell/environment-tokens/environment-tokens';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState} from '../../chat/chat-state/chat-state';
-import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
+import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
 
 /**
  * Hosts the raw JSON view of active surface models, allowing direct source editing
  * and displaying real-time parsing error indicators.
  */
-const LAYOUT_MODEL_URI = 'a2ui://layout.json';
-
 @Component({
   selector: 'a2ui-composer-raw-frame',
   standalone: true,
-  imports: [],
+  imports: [MonacoEditor],
   templateUrl: './raw-frame.ng.html',
   styleUrl: './raw-frame.scss',
 })
-export class RawFrame implements AfterViewInit {
+export class RawFrame {
   protected readonly isExtensionMode = inject(IS_EXTENSION_MODE);
   protected readonly layoutJson: WritableSignal<string>;
-
-  readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editorContainer');
-  private editor?: monaco.editor.IStandaloneCodeEditor;
-  private readonly monacoInstance = signal<typeof monaco | null>(null);
-  private destroyed = false;
+  protected readonly isJsonInvalid: WritableSignal<boolean> = signal(false);
 
   readonly TEST_ONLY = {
     layoutJson: () => this.layoutJson,
@@ -70,23 +58,14 @@ export class RawFrame implements AfterViewInit {
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly stateSync = inject(StateSync);
   private readonly chatState = inject(ChatState);
-  private readonly configProvider = inject(AppConfigProvider);
   private readonly destroyRef = inject(DestroyRef);
   private readonly snackBar = inject(MatSnackBar);
   private readonly layoutInput$ = new Subject<string>();
 
   /** Public lock indicator preventing typing deadlocks during generative LLM stream turns. */
   protected readonly isLocked = this.chatState.isProgrammaticStreamActive;
-  protected readonly isDarkTheme = computed(() => this.configProvider.themePreference() === 'dark');
 
   constructor() {
-    this.destroyRef.onDestroy(() => {
-      this.destroyed = true;
-      if (this.editor) {
-        this.editor.dispose();
-      }
-    });
-
     // Initialize backing editor layout state Signal dynamically from the volatile session cache
     this.layoutJson = signal(this.stateSync.hydrateActiveDraft());
     effect(() => {
@@ -104,75 +83,6 @@ export class RawFrame implements AfterViewInit {
       }
     });
 
-    effect(() => {
-      const catalog = this.catalogManagement.activeCatalog();
-      const monacoInstance = this.monacoInstance();
-
-      if (!catalog || !monacoInstance) {
-        return;
-      }
-
-      // The active catalog provides schemas for individual UI components (e.g. Text, Button).
-      // However, the JSON payload in the editor is an array of A2UI messages (e.g. createSurface,
-      // updateComponents). We dynamically synthesize a root schema here that describes this payload
-      // structure, injecting the catalog's component schemas into the `updateComponents` block
-      // so Monaco can fully validate the entire JSON tree structure and its component properties.
-      const layoutSchema = {
-        ...catalog,
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            version: {type: 'string'},
-            createSurface: {
-              type: 'object',
-              properties: {
-                surfaceId: {type: 'string'},
-                catalogId: {type: 'string'},
-                sendDataModel: {type: 'boolean'},
-              },
-              required: ['surfaceId', 'catalogId'],
-            },
-            updateComponents: {
-              type: 'object',
-              properties: {
-                surfaceId: {type: 'string'},
-                components: {
-                  type: 'array',
-                  items: {
-                    anyOf: Object.values(catalog.components || {}),
-                  },
-                },
-              },
-              required: ['surfaceId', 'components'],
-            },
-            updateDataModel: {
-              type: 'object',
-              properties: {
-                surfaceId: {type: 'string'},
-                path: {type: 'string'},
-                value: {},
-              },
-              required: ['surfaceId'],
-            },
-          },
-          additionalProperties: false,
-        },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (monacoInstance.languages as any).json.jsonDefaults.setDiagnosticsOptions({
-        validate: true,
-        schemas: [
-          {
-            uri: 'a2ui-catalog-schema',
-            fileMatch: [LAYOUT_MODEL_URI],
-            schema: layoutSchema,
-          },
-        ],
-      });
-    });
-
     // Sync back changes in StateSync activeDraft to editor layoutJson (e.g. from LLM stream completed updates)
     effect(() => {
       const activeDraftVal = this.stateSync.activeDraft();
@@ -180,7 +90,6 @@ export class RawFrame implements AfterViewInit {
         if (this.layoutJson() !== activeDraftVal) {
           queueMicrotask(() => {
             this.layoutJson.set(activeDraftVal);
-            this.updateEditorContent(activeDraftVal);
 
             // Run live render updating matching activeDraft commits
             try {
@@ -194,24 +103,6 @@ export class RawFrame implements AfterViewInit {
               this.showJsonSyntaxError();
             }
           });
-        }
-      });
-    });
-
-    effect(() => {
-      const locked = this.isLocked();
-      untracked(() => {
-        if (this.editor) {
-          this.editor.updateOptions({readOnly: locked});
-        }
-      });
-    });
-
-    effect(() => {
-      const isDark = this.isDarkTheme();
-      untracked(() => {
-        if (this.editor) {
-          this.editor.updateOptions({theme: isDark ? 'vs-dark' : 'vs-light'});
         }
       });
     });
@@ -241,85 +132,12 @@ export class RawFrame implements AfterViewInit {
       });
   }
 
-  ngAfterViewInit() {
-    // Configure Monaco loader to use the local assets copy
-    loader.config({paths: {vs: 'assets/monaco/vs'}});
-
-    loader.init().then(monacoInstance => {
-      if (this.destroyed) {
-        return;
-      }
-      this.monacoInstance.set(monacoInstance);
-
-      const modelUri = monacoInstance.Uri.parse(LAYOUT_MODEL_URI);
-      let model = monacoInstance.editor.getModel(modelUri);
-      if (model) {
-        model.setValue(this.layoutJson());
-      } else {
-        model = monacoInstance.editor.createModel(this.layoutJson(), 'json', modelUri);
-      }
-
-      const editor = monacoInstance.editor.create(this.editorContainer().nativeElement, {
-        model: model,
-        theme: this.isDarkTheme() ? 'vs-dark' : 'vs-light',
-        automaticLayout: true,
-        minimap: {enabled: false},
-        readOnly: this.isLocked(),
-        scrollBeyondLastLine: false,
-        lineNumbers: 'on',
-        folding: true,
-        wordWrap: 'on',
-        ariaLabel: 'Raw layout JSON',
-      });
-      this.editor = editor;
-
-      editor.onDidChangeModelContent(() => {
-        const val = editor.getValue();
-        if (val !== this.layoutJson()) {
-          this.onLayoutChange(val);
-        }
-      });
-    });
-  }
-
   protected onLayoutChange(value: string): void {
     this.layoutJson.set(value);
     this.layoutInput$.next(value);
     this.stateSync.updateDraft(value);
   }
 
-  /**
-   * Updates the Monaco editor's content while preserving its undo/redo history stack.
-   * If a model exists on the editor, it executes an edit operation; otherwise it falls back to setValue.
-   *
-   * @param value The new text content to set in the editor.
-   */
-  private updateEditorContent(value: string): void {
-    if (!this.editor || this.editor.getValue() === value) {
-      return;
-    }
-    const model = this.editor.getModel();
-    if (model) {
-      const isLocked = this.isLocked();
-      if (isLocked) {
-        this.editor.updateOptions({readOnly: false});
-      }
-      this.editor.pushUndoStop();
-      this.editor.executeEdits('state-sync', [
-        {
-          range: model.getFullModelRange(),
-          text: value,
-          forceMoveMarkers: true,
-        },
-      ]);
-      this.editor.pushUndoStop();
-      if (isLocked) {
-        this.editor.updateOptions({readOnly: true});
-      }
-    } else {
-      this.editor.setValue(value);
-    }
-  }
 
   /**
    * Parses the raw layout configuration string into an array of message objects.

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -138,7 +138,6 @@ export class RawFrame {
     this.stateSync.updateDraft(value);
   }
 
-
   /**
    * Parses the raw layout configuration string into an array of message objects.
    *

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ng.html
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ng.html
@@ -13,18 +13,4 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<div
-  class="raw-frame-container"
-  [class.is-collapsed]="isExtensionMode()"
-  [class.is-locked]="isLocked()"
->
-  @if (isJsonInvalid()) {
-    <div class="invalid-json-badge">Invalid JSON syntax</div>
-  }
-
-  <a2ui-composer-monaco-editor
-    [value]="layoutJson()"
-    [readOnly]="isLocked()"
-    (valueChange)="onLayoutChange($event)"
-  ></a2ui-composer-monaco-editor>
-</div>
+<div #editorContainer class="monaco-editor-container"></div>

--- a/shell/src/app/shared/monaco-editor/monaco-editor.scss
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.scss
@@ -15,37 +15,17 @@
  */
 
 :host {
-  flex: 1;
   display: block;
   width: 100%;
   height: 100%;
 }
 
-.raw-frame-container {
-  display: flex;
-  flex-direction: column;
-  padding: 0;
+.monaco-editor-container {
+  width: 100%;
   height: 100%;
-  box-sizing: border-box;
-  transition: all 0.3s ease;
-
-  &.is-locked {
-    opacity: 0.55;
-    pointer-events: none;
-    cursor: not-allowed;
-  }
-
-  a2ui-composer-monaco-editor {
-    width: 100%;
-    height: 100%;
-    flex: 1 1 auto;
-    display: block;
-    overflow: hidden;
-  }
-
-  &.is-collapsed {
-    a2ui-composer-monaco-editor {
-      font-size: 12px;
-    }
-  }
+  flex: 1 1 auto;
+  display: block;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  overflow: hidden;
 }

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -132,7 +132,13 @@ export class MonacoEditor {
         },
       };
 
-      // The AMD loader exports jsonDefaults under languages.json despite the ESM types
+      // In the modern @types/monaco-editor (ESM), `monaco.languages.json` is marked as deprecated
+      // in favor of a top-level `monaco.json` module. However, because we dynamically load Monaco
+      // via the AMD loader (@monaco-editor/loader), the runtime object still attaches the JSON
+      // API to `monaco.languages.json`.
+      // It is completely safe to cast this here because the runtime object structure matches the
+      // ESM `monaco.json` type definitions. There are no alternative interfaces exposed by the AMD
+      // runtime to access `jsonDefaults`.
       const jsonContrib = (monacoInstance.languages as unknown as {json: typeof monaco.json}).json;
       jsonContrib.jsonDefaults.setDiagnosticsOptions({
         validate: true,

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  AfterViewInit,
+  OnDestroy,
+  input,
+  Output,
+  EventEmitter,
+  inject,
+  effect,
+  signal,
+  untracked,
+  computed,
+} from '@angular/core';
+import loader from '@monaco-editor/loader';
+import type * as monaco from 'monaco-editor';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
+
+const LAYOUT_MODEL_URI = 'a2ui://layout.json';
+
+@Component({
+  selector: 'a2ui-composer-monaco-editor',
+  standalone: true,
+  templateUrl: './monaco-editor.ng.html',
+  styleUrl: './monaco-editor.scss',
+})
+export class MonacoEditor implements AfterViewInit, OnDestroy {
+  @ViewChild('editorContainer') editorContainer!: ElementRef<HTMLDivElement>;
+
+  readonly value = input<string>('');
+  readonly readOnly = input<boolean>(false);
+
+  @Output() valueChange = new EventEmitter<string>();
+
+  private editor?: monaco.editor.IStandaloneCodeEditor;
+  private readonly monacoInstance = signal<typeof monaco | null>(null);
+  private destroyed = false;
+
+  private readonly catalogManagement = inject(CatalogManagement);
+  private readonly configProvider = inject(AppConfigProvider);
+
+  protected readonly isDarkTheme = computed(() => this.configProvider.themePreference() === 'dark');
+
+  constructor() {
+    effect(() => {
+      const val = this.value();
+      untracked(() => {
+        if (this.editor && this.editor.getValue() !== val) {
+          this.updateEditorContent(val);
+        }
+      });
+    });
+
+    effect(() => {
+      const val = this.readOnly();
+      untracked(() => {
+        if (this.editor) {
+          this.editor.updateOptions({readOnly: val});
+        }
+      });
+    });
+
+    effect(() => {
+      const catalog = this.catalogManagement.activeCatalog();
+      const monacoInstance = this.monacoInstance();
+
+      if (!catalog || !monacoInstance) {
+        return;
+      }
+
+      const layoutSchema = {
+        ...catalog,
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            version: {type: 'string'},
+            createSurface: {
+              type: 'object',
+              properties: {
+                surfaceId: {type: 'string'},
+                catalogId: {type: 'string'},
+                sendDataModel: {type: 'boolean'},
+              },
+              required: ['surfaceId', 'catalogId'],
+            },
+            updateComponents: {
+              type: 'object',
+              properties: {
+                surfaceId: {type: 'string'},
+                components: {
+                  type: 'array',
+                  items: {
+                    anyOf: Object.values(catalog.components || {}),
+                  },
+                },
+              },
+              required: ['surfaceId', 'components'],
+            },
+            updateDataModel: {
+              type: 'object',
+              properties: {
+                surfaceId: {type: 'string'},
+                path: {type: 'string'},
+                value: {},
+              },
+              required: ['surfaceId'],
+            },
+          },
+          additionalProperties: false,
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (monacoInstance.languages as any).json.jsonDefaults.setDiagnosticsOptions({
+        validate: true,
+        schemas: [
+          {
+            uri: 'a2ui-catalog-schema',
+            fileMatch: [LAYOUT_MODEL_URI],
+            schema: layoutSchema,
+          },
+        ],
+      });
+    });
+
+    effect(() => {
+      const isDark = this.isDarkTheme();
+      untracked(() => {
+        if (this.editor) {
+          this.editor.updateOptions({theme: isDark ? 'vs-dark' : 'vs-light'});
+        }
+      });
+    });
+  }
+
+  ngAfterViewInit() {
+    loader.config({paths: {vs: 'assets/monaco/vs'}});
+
+    loader.init().then(monacoInstance => {
+      if (this.destroyed) {
+        return;
+      }
+      this.monacoInstance.set(monacoInstance);
+
+      const modelUri = monacoInstance.Uri.parse(LAYOUT_MODEL_URI);
+      let model = monacoInstance.editor.getModel(modelUri);
+      if (model) {
+        model.setValue(this.value());
+      } else {
+        model = monacoInstance.editor.createModel(this.value(), 'json', modelUri);
+      }
+
+      const editor = monacoInstance.editor.create(this.editorContainer.nativeElement, {
+        model: model,
+        theme: this.isDarkTheme() ? 'vs-dark' : 'vs-light',
+        automaticLayout: true,
+        minimap: {enabled: false},
+        readOnly: this.readOnly(),
+        scrollBeyondLastLine: false,
+        lineNumbers: 'on',
+        folding: true,
+        wordWrap: 'on',
+        ariaLabel: 'Raw layout JSON',
+      });
+      this.editor = editor;
+
+      editor.onDidChangeModelContent(() => {
+        const val = editor.getValue();
+        if (val !== this.value()) {
+          this.valueChange.emit(val);
+        }
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroyed = true;
+    if (this.editor) {
+      this.editor.dispose();
+    }
+  }
+
+  private updateEditorContent(value: string): void {
+    if (!this.editor || this.editor.getValue() === value) {
+      return;
+    }
+    const model = this.editor.getModel();
+    if (model) {
+      const isLocked = this.readOnly();
+      if (isLocked) {
+        this.editor.updateOptions({readOnly: false});
+      }
+      this.editor.pushUndoStop();
+      this.editor.executeEdits('state-sync', [
+        {
+          range: model.getFullModelRange(),
+          text: value,
+          forceMoveMarkers: true,
+        },
+      ]);
+      this.editor.pushUndoStop();
+      if (isLocked) {
+        this.editor.updateOptions({readOnly: true});
+      }
+    } else {
+      this.editor.setValue(value);
+    }
+  }
+}

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -132,8 +132,8 @@ export class MonacoEditor {
         },
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (monacoInstance.languages as any).json.jsonDefaults.setDiagnosticsOptions({
+      // @ts-expect-error monaco.languages.json is deprecated in types but required at runtime
+      monacoInstance.languages.json.jsonDefaults.setDiagnosticsOptions({
         validate: true,
         schemas: [
           {

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -18,8 +18,7 @@ import {
   Component,
   ElementRef,
   input,
-  Output,
-  EventEmitter,
+  output,
   inject,
   effect,
   signal,
@@ -47,8 +46,7 @@ export class MonacoEditor {
 
   readonly value = input<string>('');
   readonly readOnly = input<boolean>(false);
-
-  @Output() valueChange = new EventEmitter<string>();
+  readonly valueChange = output<string>();
 
   private editor?: monaco.editor.IStandaloneCodeEditor;
   private readonly monacoInstance = signal<typeof monaco | null>(null);

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -132,8 +132,9 @@ export class MonacoEditor {
         },
       };
 
-      // @ts-expect-error monaco.languages.json is deprecated in types but required at runtime
-      monacoInstance.languages.json.jsonDefaults.setDiagnosticsOptions({
+      // The AMD loader exports jsonDefaults under languages.json despite the ESM types
+      const jsonContrib = (monacoInstance.languages as unknown as {json: typeof monaco.json}).json;
+      jsonContrib.jsonDefaults.setDiagnosticsOptions({
         validate: true,
         schemas: [
           {

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -17,9 +17,6 @@
 import {
   Component,
   ElementRef,
-  ViewChild,
-  AfterViewInit,
-  OnDestroy,
   input,
   Output,
   EventEmitter,
@@ -28,6 +25,9 @@ import {
   signal,
   untracked,
   computed,
+  viewChild,
+  afterNextRender,
+  DestroyRef,
 } from '@angular/core';
 import loader from '@monaco-editor/loader';
 import type * as monaco from 'monaco-editor';
@@ -42,8 +42,8 @@ const LAYOUT_MODEL_URI = 'a2ui://layout.json';
   templateUrl: './monaco-editor.ng.html',
   styleUrl: './monaco-editor.scss',
 })
-export class MonacoEditor implements AfterViewInit, OnDestroy {
-  @ViewChild('editorContainer') editorContainer!: ElementRef<HTMLDivElement>;
+export class MonacoEditor {
+  readonly editorContainer = viewChild.required<ElementRef<HTMLDivElement>>('editorContainer');
 
   readonly value = input<string>('');
   readonly readOnly = input<boolean>(false);
@@ -52,14 +52,16 @@ export class MonacoEditor implements AfterViewInit, OnDestroy {
 
   private editor?: monaco.editor.IStandaloneCodeEditor;
   private readonly monacoInstance = signal<typeof monaco | null>(null);
-  private destroyed = false;
 
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly configProvider = inject(AppConfigProvider);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly isDarkTheme = computed(() => this.configProvider.themePreference() === 'dark');
 
   constructor() {
+    // Synchronize external value changes into the Monaco editor instance
+    // when the value signal is updated from outside.
     effect(() => {
       const val = this.value();
       untracked(() => {
@@ -69,6 +71,7 @@ export class MonacoEditor implements AfterViewInit, OnDestroy {
       });
     });
 
+    // Toggle the editor's read-only state when the corresponding input signal changes.
     effect(() => {
       const val = this.readOnly();
       untracked(() => {
@@ -78,6 +81,8 @@ export class MonacoEditor implements AfterViewInit, OnDestroy {
       });
     });
 
+    // Dynamically register and update the JSON schema validation for Monaco
+    // based on the currently active A2UI catalog to provide real-time linting.
     effect(() => {
       const catalog = this.catalogManagement.activeCatalog();
       const monacoInstance = this.monacoInstance();
@@ -142,6 +147,8 @@ export class MonacoEditor implements AfterViewInit, OnDestroy {
       });
     });
 
+    // Update the editor's theme (dark vs. light mode) in response to
+    // application-level theme preference changes.
     effect(() => {
       const isDark = this.isDarkTheme();
       untracked(() => {
@@ -150,53 +157,54 @@ export class MonacoEditor implements AfterViewInit, OnDestroy {
         }
       });
     });
-  }
 
-  ngAfterViewInit() {
-    loader.config({paths: {vs: 'assets/monaco/vs'}});
-
-    loader.init().then(monacoInstance => {
-      if (this.destroyed) {
-        return;
+    let destroyed = false;
+    this.destroyRef.onDestroy(() => {
+      destroyed = true;
+      if (this.editor) {
+        this.editor.dispose();
       }
-      this.monacoInstance.set(monacoInstance);
+    });
 
-      const modelUri = monacoInstance.Uri.parse(LAYOUT_MODEL_URI);
-      let model = monacoInstance.editor.getModel(modelUri);
-      if (model) {
-        model.setValue(this.value());
-      } else {
-        model = monacoInstance.editor.createModel(this.value(), 'json', modelUri);
-      }
+    afterNextRender(() => {
+      loader.config({paths: {vs: 'assets/monaco/vs'}});
 
-      const editor = monacoInstance.editor.create(this.editorContainer.nativeElement, {
-        model: model,
-        theme: this.isDarkTheme() ? 'vs-dark' : 'vs-light',
-        automaticLayout: true,
-        minimap: {enabled: false},
-        readOnly: this.readOnly(),
-        scrollBeyondLastLine: false,
-        lineNumbers: 'on',
-        folding: true,
-        wordWrap: 'on',
-        ariaLabel: 'Raw layout JSON',
-      });
-      this.editor = editor;
-
-      editor.onDidChangeModelContent(() => {
-        const val = editor.getValue();
-        if (val !== this.value()) {
-          this.valueChange.emit(val);
+      loader.init().then(monacoInstance => {
+        if (destroyed) {
+          return;
         }
+        this.monacoInstance.set(monacoInstance);
+
+        const modelUri = monacoInstance.Uri.parse(LAYOUT_MODEL_URI);
+        let model = monacoInstance.editor.getModel(modelUri);
+        if (model) {
+          model.setValue(this.value());
+        } else {
+          model = monacoInstance.editor.createModel(this.value(), 'json', modelUri);
+        }
+
+        const editor = monacoInstance.editor.create(this.editorContainer().nativeElement, {
+          model: model,
+          theme: this.isDarkTheme() ? 'vs-dark' : 'vs-light',
+          automaticLayout: true,
+          minimap: {enabled: false},
+          readOnly: this.readOnly(),
+          scrollBeyondLastLine: false,
+          lineNumbers: 'on',
+          folding: true,
+          wordWrap: 'on',
+          ariaLabel: 'Raw layout JSON',
+        });
+        this.editor = editor;
+
+        editor.onDidChangeModelContent(() => {
+          const val = editor.getValue();
+          if (val !== this.value()) {
+            this.valueChange.emit(val);
+          }
+        });
       });
     });
-  }
-
-  ngOnDestroy() {
-    this.destroyed = true;
-    if (this.editor) {
-      this.editor.dispose();
-    }
   }
 
   private updateEditorContent(value: string): void {

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -137,8 +137,9 @@ export class MonacoEditor {
       // via the AMD loader (@monaco-editor/loader), the runtime object still attaches the JSON
       // API to `monaco.languages.json`.
       // It is completely safe to cast this here because the runtime object structure matches the
-      // ESM `monaco.json` type definitions. There are no alternative interfaces exposed by the AMD
-      // runtime to access `jsonDefaults`.
+      // ESM `monaco.json` type definitions. We cast through `unknown` first because TypeScript
+      // considers the deprecated type and the ESM type as non-overlapping. There are no alternative
+      // interfaces exposed by the AMD runtime to access `jsonDefaults`.
       const jsonContrib = (monacoInstance.languages as unknown as {json: typeof monaco.json}).json;
       jsonContrib.jsonDefaults.setDiagnosticsOptions({
         validate: true,

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -56,6 +56,7 @@ export class MonacoEditor {
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly isDarkTheme = computed(() => this.configProvider.themePreference() === 'dark');
+  protected readonly monacoTheme = computed(() => (this.isDarkTheme() ? 'vs-dark' : 'vs-light'));
 
   constructor() {
     // Synchronize external value changes into the Monaco editor instance
@@ -132,14 +133,10 @@ export class MonacoEditor {
         },
       };
 
-      // In the modern @types/monaco-editor (ESM), `monaco.languages.json` is marked as deprecated
-      // in favor of a top-level `monaco.json` module. However, because we dynamically load Monaco
-      // via the AMD loader (@monaco-editor/loader), the runtime object still attaches the JSON
-      // API to `monaco.languages.json`.
-      // It is completely safe to cast this here because the runtime object structure matches the
-      // ESM `monaco.json` type definitions. We cast through `unknown` first because TypeScript
-      // considers the deprecated type and the ESM type as non-overlapping. There are no alternative
-      // interfaces exposed by the AMD runtime to access `jsonDefaults`.
+      // @types/monaco-editor deprecates `monaco.languages.json` in favor of `monaco.json`,
+      // but our AMD loader still attaches the JSON API to `monaco.languages.json`.
+      // We safely cast through `unknown` to the modern ESM type, as the runtime structures
+      // match and no alternative AMD interfaces exist for `jsonDefaults`.
       const jsonContrib = (monacoInstance.languages as unknown as {json: typeof monaco.json}).json;
       jsonContrib.jsonDefaults.setDiagnosticsOptions({
         validate: true,
@@ -156,10 +153,10 @@ export class MonacoEditor {
     // Update the editor's theme (dark vs. light mode) in response to
     // application-level theme preference changes.
     effect(() => {
-      const isDark = this.isDarkTheme();
+      const theme = this.monacoTheme();
       untracked(() => {
         if (this.editor) {
-          this.editor.updateOptions({theme: isDark ? 'vs-dark' : 'vs-light'});
+          this.editor.updateOptions({theme});
         }
       });
     });
@@ -191,7 +188,7 @@ export class MonacoEditor {
 
         const editor = monacoInstance.editor.create(this.editorContainer().nativeElement, {
           model: model,
-          theme: this.isDarkTheme() ? 'vs-dark' : 'vs-light',
+          theme: this.monacoTheme(),
           automaticLayout: true,
           minimap: {enabled: false},
           readOnly: this.readOnly(),


### PR DESCRIPTION
…or and clean up redundant editor logic in raw-frame

# Description

Refactor the JSON Editor to split out Monaco-editor so that editor configuration can be encapsulated better. 

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
