### PR TITLE
Restyle Dockview tabs to Angular Material 3 design

### DIFF
--- a/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
@@ -17,7 +17,7 @@
 <div class="workspace-container" [class.extension-mode]="isExtension()">
   <div
     #dockviewRoot
-    class="dockview-root"
+    class="dockview-root mat-m3-dockview-tabs"
     [class.dockview-theme-dark]="isDarkTheme()"
     [class.dockview-theme-light]="!isDarkTheme()"
   ></div>

--- a/shell/src/app/shell/composer-workspace/composer-workspace.scss
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.scss
@@ -37,21 +37,101 @@
 }
 
 :host ::ng-deep .dockview-root {
-  --dv-group-view-background-color: var(--mat-sys-surface-container);
-  --dv-tabs-and-actions-container-background-color: var(--mat-sys-surface-container-high);
-  --dv-activegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-activegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container-high);
-  --dv-inactivegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-inactivegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container-high);
-  --dv-tab-divider-color: var(--mat-sys-surface-container);
-  --dv-activegroup-visiblepanel-tab-color: var(--mat-sys-on-surface);
+  --dv-activegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container);
   --dv-activegroup-hiddenpanel-tab-color: var(--mat-sys-on-surface-variant);
+  --dv-activegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
+  --dv-activegroup-visiblepanel-tab-color: var(--mat-sys-primary);
+  --dv-group-view-background-color: var(--mat-sys-surface);
+  --dv-inactivegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container);
+  --dv-inactivegroup-hiddenpanel-tab-color: var(--mat-sys-on-surface-variant);
+  --dv-inactivegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
   --dv-inactivegroup-visiblepanel-tab-color: var(--mat-sys-on-surface-variant);
-  --dv-inactivegroup-hiddenpanel-tab-color: var(--mat-sys-outline);
-  --dv-separator-border: var(--mat-sys-outline-variant);
   --dv-paneview-header-border-color: var(--mat-sys-outline-variant);
+  --dv-separator-border: var(--mat-sys-outline-variant);
+  --dv-tab-divider-color: var(--mat-sys-outline-variant);
+  --dv-tabs-and-actions-container-background-color: var(--mat-sys-surface-container);
+
+  .dv-tabs-and-actions-container {
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+  }
 
   .dv-default-tab-action {
     display: none;
+  }
+
+  &:not(.has-tab-overflow) .dv-right-actions-container {
+    display: none;
+  }
+
+  .dv-tab {
+    height: var(--dv-tabs-and-actions-container-height, 48px);
+    padding: 0 16px 0 26px;
+    font-family: var(--mat-sys-title-small-font, Roboto, sans-serif);
+    font-size: var(--mat-sys-title-small-size, 14px);
+    font-weight: var(--mat-sys-title-small-weight, 500);
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    &:hover:not(.dv-tab--dragging) {
+      z-index: 10;
+
+      .dv-default-tab::before {
+        visibility: visible;
+        opacity: 0.85;
+        color: var(--mat-sys-on-surface-variant);
+      }
+    }
+
+    .dv-default-tab {
+      position: relative;
+
+      &::before {
+        content: '\e945';
+        font-family: 'Material Icons', 'Material Symbols Outlined', sans-serif;
+        font-size: 18px;
+        position: absolute;
+        left: -20px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 18px;
+        height: 18px;
+        line-height: 18px;
+        visibility: hidden;
+        opacity: 0;
+        z-index: 10;
+        transition: opacity 0.2s ease;
+        // Prevent intercepting pointerdown/dragstart events handled by Dockview
+        // drag-and-drop.
+        pointer-events: none;
+      }
+    }
+
+    &.dv-active-tab,
+    &.dv-active-tab:focus,
+    &.dv-active-tab:focus-within,
+    &[aria-selected='true'],
+    &[aria-selected='true']:focus,
+    &[aria-selected='true']:focus-within {
+      box-sizing: border-box;
+      box-shadow: none;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: auto;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: auto;
+        height: 3px;
+        outline: none;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        background: var(--mat-sys-primary);
+        z-index: 100;
+        pointer-events: none;
+      }
+    }
   }
 }

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -362,5 +362,43 @@ describe('ComposerWorkspace Dashboard', () => {
 
       expect(rootEl.classList.contains('has-tab-overflow')).toBe(false);
     });
+
+    it('coalesces pending animation frames on multiple rapid calls to checkTabOverflow()', () => {
+      const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+      let nextId = 100;
+      const requestSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(() => ++nextId);
+
+      const component = fixture.componentInstance as unknown as {
+        checkTabOverflow: () => void;
+        animationFrameId?: number;
+      };
+      component.animationFrameId = undefined;
+
+      component.checkTabOverflow();
+      component.checkTabOverflow();
+
+      expect(cancelSpy).toHaveBeenCalledWith(101);
+      requestSpy.mockRestore();
+      cancelSpy.mockRestore();
+    });
+
+    it('cancels any pending animation frame when the component is destroyed', () => {
+      const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+      const requestSpy = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(999);
+
+      const component = fixture.componentInstance as unknown as {
+        checkTabOverflow: () => void;
+        animationFrameId?: number;
+      };
+      component.checkTabOverflow();
+
+      fixture.destroy();
+
+      expect(cancelSpy).toHaveBeenCalledWith(999);
+      requestSpy.mockRestore();
+      cancelSpy.mockRestore();
+    });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -334,5 +334,33 @@ describe('ComposerWorkspace Dashboard', () => {
       expect(apiSpy).toHaveBeenCalled();
       apiSpy.mockRestore();
     });
+
+    it('applies Material M3 tab styling class hook to the Dockview root element', () => {
+      const rootEl = fixture.nativeElement.querySelector('.dockview-root');
+      expect(rootEl.classList.contains('mat-m3-dockview-tabs')).toBe(true);
+    });
+
+    it('toggles has-tab-overflow on the #dockviewRoot element when .dv-tabs-container has scrollWidth > clientWidth + 2', async () => {
+      const rootEl: HTMLElement = fixture.nativeElement.querySelector('.dockview-root');
+      const tabsContainer = document.createElement('div');
+      tabsContainer.className = 'dv-tabs-container';
+      rootEl.appendChild(tabsContainer);
+
+      Object.defineProperty(tabsContainer, 'scrollWidth', {value: 200, configurable: true});
+      Object.defineProperty(tabsContainer, 'clientWidth', {value: 100, configurable: true});
+
+      (fixture.componentInstance as unknown as {checkTabOverflow: () => void}).checkTabOverflow();
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      expect(rootEl.classList.contains('has-tab-overflow')).toBe(true);
+
+      Object.defineProperty(tabsContainer, 'scrollWidth', {value: 102, configurable: true});
+      Object.defineProperty(tabsContainer, 'clientWidth', {value: 100, configurable: true});
+
+      (fixture.componentInstance as unknown as {checkTabOverflow: () => void}).checkTabOverflow();
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      expect(rootEl.classList.contains('has-tab-overflow')).toBe(false);
+    });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -98,8 +98,11 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private eventsInstance?: Events;
   private errorsInstance?: Errors;
 
+  private resizeObserver?: ResizeObserver;
+
   constructor() {
     this.destroyRef.onDestroy(() => {
+      this.resizeObserver?.disconnect();
       this.dockviewApi?.dispose();
       this.componentRefs.forEach(ref => ref.destroy());
     });
@@ -261,6 +264,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       } else if (panel?.id === ComposerPanelId.Errors) {
         untracked(() => this.unreadErrorsCount.set(0));
       }
+      this.checkTabOverflow();
     });
 
     const savedLayout = localStorage.getItem('composer_dockview_layout');
@@ -331,16 +335,37 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
 
     let saveTimeout: ReturnType<typeof setTimeout>;
     this.dockviewApi.onDidLayoutChange(() => {
+      this.checkTabOverflow();
       clearTimeout(saveTimeout);
       saveTimeout = setTimeout(() => {
         localStorage.setItem('composer_dockview_layout', JSON.stringify(this.dockviewApi.toJSON()));
       }, 1000);
     });
+    this.dockviewApi.onDidAddPanel(() => this.checkTabOverflow());
+    this.dockviewApi.onDidRemovePanel(() => this.checkTabOverflow());
+
+    this.resizeObserver = new ResizeObserver(() => this.checkTabOverflow());
+    this.resizeObserver.observe(this.dockviewRoot().nativeElement);
 
     // Force an initial layout pass. In browsers, ResizeObserver handles this,
     // but in jsdom tests with mocked observers, it requires an explicit call.
     this.dockviewApi.layout(1000, 1000);
     this.isDockviewInitialized.set(true);
+    this.checkTabOverflow();
+  }
+
+  private checkTabOverflow(): void {
+    requestAnimationFrame(() => {
+      const rootEl = this.dockviewRoot().nativeElement;
+      const containers = rootEl.querySelectorAll('.dv-tabs-container');
+      let hasOverflow = false;
+      containers.forEach(container => {
+        if (container.scrollWidth > container.clientWidth + 2) {
+          hasOverflow = true;
+        }
+      });
+      rootEl.classList.toggle('has-tab-overflow', hasOverflow);
+    });
   }
 
   clearAllLogs(): void {

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -358,6 +358,12 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
     this.checkTabOverflow();
   }
 
+  /**
+   * If the tabs don't fit in the available space, then we want the dockview
+   * overflow selector to be displayed. Otherwise, it's redundant, so it
+   * should be hidden. Unfortunately, there doesn't seem to be a "native"
+   * mechanism in dockview to support this.
+   */
   private checkTabOverflow(): void {
     if (this.animationFrameId !== undefined) {
       cancelAnimationFrame(this.animationFrameId);

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -99,9 +99,13 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private errorsInstance?: Errors;
 
   private resizeObserver?: ResizeObserver;
+  private animationFrameId?: number;
 
   constructor() {
     this.destroyRef.onDestroy(() => {
+      if (this.animationFrameId !== undefined) {
+        cancelAnimationFrame(this.animationFrameId);
+      }
       this.resizeObserver?.disconnect();
       this.dockviewApi?.dispose();
       this.componentRefs.forEach(ref => ref.destroy());
@@ -355,11 +359,16 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   }
 
   private checkTabOverflow(): void {
-    requestAnimationFrame(() => {
-      const rootEl = this.dockviewRoot().nativeElement;
-      const containers = rootEl.querySelectorAll('.dv-tabs-container');
+    if (this.animationFrameId !== undefined) {
+      cancelAnimationFrame(this.animationFrameId);
+    }
+    this.animationFrameId = requestAnimationFrame(() => {
+      this.animationFrameId = undefined;
+      const rootEl = this.dockviewRoot()?.nativeElement;
+      if (!rootEl) return;
+      const tabContainers = rootEl.querySelectorAll<HTMLElement>('.dv-tabs-container');
       let hasOverflow = false;
-      containers.forEach(container => {
+      tabContainers.forEach(container => {
         if (container.scrollWidth > container.clientWidth + 2) {
           hasOverflow = true;
         }


### PR DESCRIPTION
# Description

Style Dockview tabs using Angular Material 3 design tokens (--mat-sys-*), add active tab primary underline indicator with focus-within over-constraint protection, display drag_indicator icon on hover, and auto-hide right dropdown button when tabs fit.

See 
<img width="1536" height="1192" alt="image" src="https://github.com/user-attachments/assets/b072abe9-e171-4b82-9978-970d4955fc82" />


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
