### PR TITLE
feat: expand common schema types with accessibility, dynamic evaluati…

### DIFF
--- a/shell/src/app/gallery/schema/common-types-schema.ts
+++ b/shell/src/app/gallery/schema/common-types-schema.ts
@@ -167,5 +167,92 @@ export const COMMON_TYPES_SCHEMA: Record<string, unknown> = {
         },
       ],
     },
+    AccessibilityAttributes: {
+      type: 'object',
+      description:
+        'Attributes to enhance accessibility when using assistive technologies like screen readers.',
+      properties: {
+        label: {
+          $ref: '#/$defs/DynamicString',
+          description:
+            "A short string, typically 1 to 3 words, used by assistive technologies to convey the purpose or intent of an element. For example, an input field might have an accessible label of 'User ID' or a button might be labeled 'Submit'.",
+        },
+        description: {
+          $ref: '#/$defs/DynamicString',
+          description:
+            "Additional information provided by assistive technologies about an element such as instructions, format requirements, or result of an action. For example, a mute button might have a label of 'Mute' and a description of 'Silences notifications about this conversation'.",
+        },
+      },
+    },
+    ComponentCommon: {
+      type: 'object',
+      properties: {
+        id: {
+          $ref: '#/$defs/ComponentId',
+        },
+        accessibility: {
+          $ref: '#/$defs/AccessibilityAttributes',
+        },
+      },
+      required: ['id'],
+    },
+    DynamicStringList: {
+      description:
+        'Represents a value that can be either a literal array of strings, a path to a string array in the data model, or a function call returning a string array.',
+      oneOf: [
+        {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        {
+          $ref: '#/$defs/DataBinding',
+        },
+        {
+          allOf: [
+            {
+              $ref: '#/$defs/FunctionCall',
+            },
+            {
+              properties: {
+                returnType: {
+                  const: 'array',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    CheckRule: {
+      type: 'object',
+      description: 'A single validation rule applied to an input component.',
+      properties: {
+        condition: {
+          $ref: '#/$defs/DynamicBoolean',
+        },
+        message: {
+          type: 'string',
+          description: 'The error message to display if the check fails.',
+        },
+      },
+      required: ['condition', 'message'],
+      additionalProperties: false,
+    },
+    Checkable: {
+      description: 'Properties for components that support client-side checks.',
+      type: 'object',
+      properties: {
+        checks: {
+          type: 'array',
+          description:
+            'A list of checks to perform. These are function calls that must return a boolean indicating validity.',
+          items: {
+            $ref: '#/$defs/CheckRule',
+          },
+        },
+      },
+    },
   },
 };


### PR DESCRIPTION
…on, and validation rules

# Description

This PR appends several missing type definitions to the A2UI `common-types-schema.ts` definitions. 

The change is inspired by the bug reported in **b/535760468**, where reference gaps were identified when externally provided catalogs are validated. By explicitly defining these missing schema types, we ensure complete schema coverage and prevent validation failures caused by missing `$ref` resolutions when external catalogs are evaluated.

## Changes
The following types have been carefully added to the schema without modifying any of the existing definitions:
- **`AccessibilityAttributes`**: Attributes to enhance accessibility when using assistive technologies.
- **`ComponentCommon`**: Common component properties encompassing `id` and `accessibility`.
- **`DynamicStringList`**: Defines a value that can be a string array, data binding, or a function call returning a string array.
- **`CheckRule`**: A single validation rule applied to an input component.
- **`Checkable`**: Properties for components that support client-side checks.



## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
