### PR TITLE
Update fix_format.sh to use root yarn prettier scripts

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -26,6 +26,7 @@
     "clean": "rm -rf dist",
     "test": "NODE_ENV=test vitest run --coverage",
     "prettier": "prettier --ignore-path ../.prettierignore --write . | grep -v '(unchanged)'",
+    "prettier:check": "prettier --ignore-path ../.prettierignore --check .",
     "lint": "eslint ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "yarn workspaces foreach -A --exclude a2ui-composer-root run test",
     "build": "yarn workspaces foreach -A --topological-dev --exclude a2ui-composer-root run build",
     "prettier": "yarn workspaces foreach -A --exclude a2ui-composer-root run prettier",
+    "prettier:check": "yarn workspaces foreach -A --exclude a2ui-composer-root run prettier:check",
     "tsc": "yarn --cwd shell tsc --noEmit && yarn --cwd bridge tsc --project tsconfig.bridge.json --noEmit",
     "clean": "yarn workspaces foreach -A --exclude a2ui-composer-root run clean",
     "lint": "yarn workspaces foreach -A --exclude a2ui-composer-root run lint"

--- a/samples/lit-basic-catalog/package.json
+++ b/samples/lit-basic-catalog/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "prettier": "prettier --ignore-path ../../.prettierignore --write . | grep -v '(unchanged)'",
+    "prettier:check": "prettier --ignore-path ../../.prettierignore --check .",
     "clean": "rm -rf dist node_modules/.vite",
     "lint": "eslint ."
   },

--- a/samples/ng-basic-catalog/package.json
+++ b/samples/ng-basic-catalog/package.json
@@ -7,6 +7,7 @@
     "build": "yarn lint && ng build",
     "test": "vitest run",
     "prettier": "prettier --ignore-path ../../.prettierignore --write . | grep -v '(unchanged)'",
+    "prettier:check": "prettier --ignore-path ../../.prettierignore --check .",
     "clean": "rm -rf dist .angular node_modules/.vite",
     "lint": "eslint ."
   },

--- a/samples/react-basic-catalog/package.json
+++ b/samples/react-basic-catalog/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "NODE_ENV=test vitest run",
     "prettier": "prettier --ignore-path ../../.prettierignore --write . | grep -v '(unchanged)'",
+    "prettier:check": "prettier --ignore-path ../../.prettierignore --check .",
     "clean": "rm -rf dist node_modules/.vite",
     "lint": "eslint ."
   },

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -15,28 +15,19 @@
 
 set -euo pipefail
 
-CHECK_ONLY="${CHECK_ONLY:-true}"
-
-for arg in "$@"; do
-  case "$arg" in
-    --check)
-      CHECK_ONLY=true
-      ;;
-    --fix|--write)
-      CHECK_ONLY=false
-      ;;
-  esac
-done
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
 
 # Get repo root
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+echo "Running Prettier..."
 if [ "$CHECK_ONLY" = true ]; then
-  echo "Checking Prettier formatting..."
   corepack yarn prettier:check
 else
-  echo "Fixing Prettier formatting..."
   corepack yarn prettier
 fi
 

--- a/scripts/fix_format.sh
+++ b/scripts/fix_format.sh
@@ -15,20 +15,29 @@
 
 set -euo pipefail
 
-CHECK_ONLY=false
-if [[ "${1:-}" == "--check" ]]; then
-  CHECK_ONLY=true
-fi
+CHECK_ONLY="${CHECK_ONLY:-true}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --check)
+      CHECK_ONLY=true
+      ;;
+    --fix|--write)
+      CHECK_ONLY=false
+      ;;
+  esac
+done
 
 # Get repo root
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-echo "Running Prettier..."
 if [ "$CHECK_ONLY" = true ]; then
-  npx -y prettier --config .prettierrc --check .
+  echo "Checking Prettier formatting..."
+  corepack yarn prettier:check
 else
-  npx -y prettier --config .prettierrc --write .
+  echo "Fixing Prettier formatting..."
+  corepack yarn prettier
 fi
 
 echo "Done."

--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -135,8 +135,7 @@ test.describe('Components Gallery User Journey', () => {
           const createSurface = cmd1['createSurface'] as Record<string, unknown> | undefined;
           const updateComponents = cmd2['updateComponents'] as Record<string, unknown> | undefined;
           const components = updateComponents?.['components'] as
-            | Array<Record<string, unknown>>
-            | undefined;
+            Array<Record<string, unknown>> | undefined;
           const hasComponent =
             Array.isArray(components) &&
             components.some(c => c['component'] === firstComponentName);

--- a/shell/package.json
+++ b/shell/package.json
@@ -13,6 +13,7 @@
     "e2e": "playwright test",
     "e2e-headless": "E2E_HEADLESS=true playwright test",
     "prettier": "prettier --ignore-path ../.prettierignore --write . | grep -v '(unchanged)'",
+    "prettier:check": "prettier --ignore-path ../.prettierignore --check .",
     "clean": "rm -rf dist .angular node_modules/.vite",
     "lint": "eslint ."
   },


### PR DESCRIPTION
# Description

Make the fix_format.sh script use the same configuration as the the `yarn prettier` command by *using* that command and a new `yarn prettier:check` command.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

