### PR TITLE
feat(workspace): panel-preset switcher over Dockview

### DIFF
--- a/shell/src/app/shell/composer-shell/composer-shell.ng.html
+++ b/shell/src/app/shell/composer-shell/composer-shell.ng.html
@@ -32,6 +32,19 @@
   <button mat-button class="reset-session-button" color="primary" (click)="resetSession()">
     New Session
   </button>
+  @if (layout.isActive()) {
+    <button
+      type="button"
+      class="layout-cycle-button"
+      (click)="layout.cycle()"
+      [matTooltip]="'Switch to ' + layout.nextPresetMeta().label"
+      aria-label="Switch workspace layout"
+    >
+      <mat-icon aria-hidden="true">{{ layout.activePresetMeta().icon }}</mat-icon>
+      <span class="layout-cycle-label">{{ layout.activePresetMeta().label }}</span>
+      <mat-icon class="layout-cycle-caret" aria-hidden="true">unfold_more</mat-icon>
+    </button>
+  }
   <button
     mat-icon-button
     class="theme-toggle-button"

--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -116,3 +116,53 @@
 .theme-toggle-button {
   margin-left: 8px;
 }
+
+// Single IDE-style layout toggle: shows the active workspace layout and cycles
+// to the next on click (Chat -> Chat + Preview -> Code & Engine -> Chat).
+.layout-cycle-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  margin-left: 8px;
+  padding: 0 8px 0 12px;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 18px;
+  background: transparent;
+  color: var(--mat-sys-on-surface);
+  font-family: inherit;
+  font-size: var(--mat-sys-label-large-size, 14px);
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    background: var(--mat-sys-surface-container-high);
+    border-color: var(--mat-sys-outline);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--mat-sys-primary);
+    outline-offset: 2px;
+  }
+
+  .layout-cycle-label {
+    white-space: nowrap;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  .layout-cycle-caret {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: var(--mat-sys-on-surface-variant);
+  }
+}

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -33,6 +33,7 @@ import {signal, WritableSignal} from '@angular/core';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {SessionStorageInteractions} from '../../storage/session-storage-interactions/session-storage-interactions';
+import {WorkspaceLayout} from '../workspace-layout/workspace-layout';
 
 describe('ComposerShell Layout', () => {
   let fixture: ComponentFixture<ComposerShell>;
@@ -216,6 +217,27 @@ describe('ComposerShell Layout', () => {
     hiddenAttrs.forEach(attr => {
       expect(attr).toBe('true');
     });
+  });
+
+  it('shows the header layout-cycle toggle only while a workspace is active and cycles it on click', () => {
+    const layout = TestBed.inject(WorkspaceLayout);
+
+    // Hidden until a workspace registers itself.
+    expect(fixture.nativeElement.querySelector('.layout-cycle-button')).toBeNull();
+
+    layout.register(() => {});
+    layout.apply('chat-preview');
+    fixture.detectChanges();
+
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('.layout-cycle-button');
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain('Chat + Preview');
+
+    button.click();
+    fixture.detectChanges();
+
+    expect(layout.activePreset()).toBe('full');
+    expect(button.textContent).toContain('Code & Engine');
   });
 
   it('renders Material icons inside navigation list items', async () => {

--- a/shell/src/app/shell/composer-shell/composer-shell.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.ts
@@ -32,6 +32,7 @@ import {
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {SessionStorageInteractions} from '../../storage/session-storage-interactions/session-storage-interactions';
+import {WorkspaceLayout} from '../workspace-layout/workspace-layout';
 
 /**
  * The primary layout container for the A2UI Composer.
@@ -57,6 +58,8 @@ import {SessionStorageInteractions} from '../../storage/session-storage-interact
 })
 export class ComposerShell {
   readonly isCollapsed = signal(true);
+  /** Drives the header's single layout-cycle toggle over the routed workspace. */
+  readonly layout = inject(WorkspaceLayout);
   isDarkTheme = computed(() => this.configProvider.themePreference() === ThemePreference.DARK);
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly indexedDbStorage = inject(IndexedDbStorage);

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
@@ -15,6 +15,31 @@
 -->
 
 <div class="workspace-container" [class.extension-mode]="isExtension()">
+  <div class="workspace-toolbar">
+    <mat-button-toggle-group
+      class="preset-switcher"
+      [value]="activePreset()"
+      (change)="applyPreset($event.value)"
+      aria-label="Workspace layout preset"
+      hideSingleSelectionIndicator
+    >
+      <mat-button-toggle value="chat" matTooltip="Chat only">
+        <mat-icon aria-hidden="true">forum</mat-icon>
+        <span class="preset-label">Chat</span>
+      </mat-button-toggle>
+      <mat-button-toggle value="chat-preview" matTooltip="Chat + live preview">
+        <mat-icon aria-hidden="true">preview</mat-icon>
+        <span class="preset-label">Chat + Preview</span>
+      </mat-button-toggle>
+      <mat-button-toggle
+        value="full"
+        matTooltip="Chat, preview, JSON editor + data/engine panels"
+      >
+        <mat-icon aria-hidden="true">dashboard</mat-icon>
+        <span class="preset-label">Code &amp; Engine</span>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
   <div
     #dockviewRoot
     class="dockview-root mat-m3-dockview-tabs"

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
@@ -15,31 +15,6 @@
 -->
 
 <div class="workspace-container" [class.extension-mode]="isExtension()">
-  <div class="workspace-toolbar">
-    <mat-button-toggle-group
-      class="preset-switcher"
-      [value]="activePreset()"
-      (change)="applyPreset($event.value)"
-      aria-label="Workspace layout preset"
-      hideSingleSelectionIndicator
-    >
-      <mat-button-toggle value="chat" matTooltip="Chat only">
-        <mat-icon aria-hidden="true">forum</mat-icon>
-        <span class="preset-label">Chat</span>
-      </mat-button-toggle>
-      <mat-button-toggle value="chat-preview" matTooltip="Chat + live preview">
-        <mat-icon aria-hidden="true">preview</mat-icon>
-        <span class="preset-label">Chat + Preview</span>
-      </mat-button-toggle>
-      <mat-button-toggle
-        value="full"
-        matTooltip="Chat, preview, JSON editor + data/engine panels"
-      >
-        <mat-icon aria-hidden="true">dashboard</mat-icon>
-        <span class="preset-label">Code &amp; Engine</span>
-      </mat-button-toggle>
-    </mat-button-toggle-group>
-  </div>
   <div
     #dockviewRoot
     class="dockview-root mat-m3-dockview-tabs"

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ng.html
@@ -14,7 +14,7 @@
  limitations under the License.
 -->
 
-<div class="workspace-container" [class.extension-mode]="isExtension()">
+<div class="workspace-container">
   <div
     #dockviewRoot
     class="dockview-root mat-m3-dockview-tabs"

--- a/shell/src/app/shell/composer-workspace/composer-workspace.scss
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.scss
@@ -28,45 +28,6 @@
   overflow: hidden;
 }
 
-.workspace-toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: var(--cpk-space-3);
-  padding: var(--cpk-space-2) var(--cpk-space-3);
-}
-
-.preset-switcher {
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-pill);
-  overflow: hidden;
-  background: var(--cpk-surface-elevated);
-  font-family: var(--cpk-font-body);
-
-  ::ng-deep .mat-button-toggle-label-content {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--cpk-space-2);
-    line-height: 34px;
-    padding: 0 var(--cpk-space-3);
-  }
-
-  ::ng-deep .mat-button-toggle {
-    color: var(--cpk-text-secondary);
-  }
-
-  ::ng-deep .mat-button-toggle-checked {
-    background: var(--cpk-accent-bg);
-    color: var(--cpk-accent);
-  }
-
-  ::ng-deep mat-icon {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-  }
-}
-
 .dockview-root {
   width: 100%;
   flex: 1 1 auto;

--- a/shell/src/app/shell/composer-workspace/composer-workspace.scss
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.scss
@@ -22,36 +22,75 @@
 
 .workspace-container {
   display: flex;
+  flex-direction: column;
   height: 100%;
   box-sizing: border-box;
   overflow: hidden;
+}
 
-  &.extension-mode {
-    flex-direction: column;
+.workspace-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--cpk-space-3);
+  padding: var(--cpk-space-2) var(--cpk-space-3);
+}
+
+.preset-switcher {
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-pill);
+  overflow: hidden;
+  background: var(--cpk-surface-elevated);
+  font-family: var(--cpk-font-body);
+
+  ::ng-deep .mat-button-toggle-label-content {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cpk-space-2);
+    line-height: 34px;
+    padding: 0 var(--cpk-space-3);
+  }
+
+  ::ng-deep .mat-button-toggle {
+    color: var(--cpk-text-secondary);
+  }
+
+  ::ng-deep .mat-button-toggle-checked {
+    background: var(--cpk-accent-bg);
+    color: var(--cpk-accent);
+  }
+
+  ::ng-deep mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
   }
 }
 
 .dockview-root {
   width: 100%;
-  height: 100%;
+  flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
 }
 
 :host ::ng-deep .dockview-root {
-  --dv-activegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-activegroup-hiddenpanel-tab-color: var(--mat-sys-on-surface-variant);
-  --dv-activegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-activegroup-visiblepanel-tab-color: var(--mat-sys-primary);
-  --dv-group-view-background-color: var(--mat-sys-surface);
-  --dv-inactivegroup-hiddenpanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-inactivegroup-hiddenpanel-tab-color: var(--mat-sys-on-surface-variant);
-  --dv-inactivegroup-visiblepanel-tab-background-color: var(--mat-sys-surface-container);
-  --dv-inactivegroup-visiblepanel-tab-color: var(--mat-sys-on-surface-variant);
-  --dv-paneview-header-border-color: var(--mat-sys-outline-variant);
-  --dv-separator-border: var(--mat-sys-outline-variant);
-  --dv-tab-divider-color: var(--mat-sys-outline-variant);
-  --dv-tabs-and-actions-container-background-color: var(--mat-sys-surface-container);
+  // Retinted onto the CopilotKit token palette so the workspace chrome matches
+  // the shell. Panel bodies stay solid (--cpk-surface-elevated) for legibility
+  // over Monaco/preview; the tab strip takes the page tone.
+  --dv-activegroup-hiddenpanel-tab-background-color: transparent;
+  --dv-activegroup-hiddenpanel-tab-color: var(--cpk-text-secondary);
+  --dv-activegroup-visiblepanel-tab-background-color: var(--cpk-surface-elevated);
+  --dv-activegroup-visiblepanel-tab-color: var(--cpk-accent);
+  --dv-group-view-background-color: var(--cpk-surface-elevated);
+  --dv-inactivegroup-hiddenpanel-tab-background-color: transparent;
+  --dv-inactivegroup-hiddenpanel-tab-color: var(--cpk-text-faint);
+  --dv-inactivegroup-visiblepanel-tab-background-color: var(--cpk-surface-elevated);
+  --dv-inactivegroup-visiblepanel-tab-color: var(--cpk-text-secondary);
+  --dv-paneview-header-border-color: var(--cpk-border);
+  --dv-separator-border: var(--cpk-border);
+  --dv-tab-divider-color: var(--cpk-divider);
+  --dv-tabs-and-actions-container-background-color: var(--cpk-page-bg);
 
   // We use Dockview's `defaultRenderer: 'always'` configuration option,
   // which keeps all the tabs always mounted. In order to ensure the tabs
@@ -59,7 +98,7 @@
   // `pointer-events: auto`, ensuring tab header hit-testing is not intercepted
   // by dockview watermark/overlay render containers.
   .dv-tabs-and-actions-container {
-    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    border-bottom: 1px solid var(--cpk-border);
     position: relative;
     z-index: 5;
     pointer-events: auto;
@@ -81,7 +120,7 @@
   .dv-tab {
     height: var(--dv-tabs-and-actions-container-height, 48px);
     padding: 0 16px 0 26px;
-    font-family: var(--mat-sys-title-small-font, Roboto, sans-serif);
+    font-family: var(--cpk-font-body, 'Plus Jakarta Sans', sans-serif);
     font-size: var(--mat-sys-title-small-size, 14px);
     font-weight: var(--mat-sys-title-small-weight, 500);
     position: relative;
@@ -98,7 +137,7 @@
       .dv-default-tab::before {
         visibility: visible;
         opacity: 0.85;
-        color: var(--mat-sys-on-surface-variant);
+        color: var(--cpk-text-secondary);
       }
     }
 
@@ -155,7 +194,7 @@
         outline: none;
         border-top-left-radius: 3px;
         border-top-right-radius: 3px;
-        background: var(--mat-sys-primary);
+        background: var(--cpk-accent);
         z-index: 100;
         pointer-events: none;
       }

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -113,6 +113,7 @@ describe('ComposerWorkspace Dashboard', () => {
   let harness: ComposerWorkspaceHarness;
 
   beforeEach(async () => {
+    localStorage.clear();
     await TestBed.configureTestingModule({
       imports: [ComposerWorkspace],
       providers: [
@@ -136,14 +137,15 @@ describe('ComposerWorkspace Dashboard', () => {
   });
 
   it('mounts all primary feature drawer placeholder components', () => {
-    // Dockview dynamically renders panels via componentRefs.
-    // In jsdom without real dimensions, dockview may not attach them all to the DOM,
-    // so we verify they were instantiated by the Angular view container.
-    const refs = (fixture.componentInstance as unknown as {componentRefs: unknown[]}).componentRefs;
-    expect(refs.length).toBe(7);
-    const types = refs.map(
-      (r: unknown) => (r as {componentType: {name: string}}).componentType.name,
-    );
+    // Default preset is chat-preview; switch to the full layout to exercise every panel type.
+    fixture.componentInstance.applyPreset('full');
+    fixture.detectChanges();
+    // Dockview dynamically renders panels via componentRefs. In jsdom without real
+    // dimensions we verify the panel types were instantiated by the view container.
+    const refs = (
+      fixture.componentInstance as unknown as {componentRefs: {componentType: {name: string}}[]}
+    ).componentRefs;
+    const types = refs.map(r => r.componentType.name);
     expect(types).toContain('ChatPanel');
     expect(types).toContain('RenderedFrame');
     expect(types).toContain('RawFrame');
@@ -152,6 +154,9 @@ describe('ComposerWorkspace Dashboard', () => {
 
   it('delegates clearLogs to all queried child components when clearAllLogs is called', () => {
     const component = fixture.componentInstance;
+    // The debug consoles (Raw Messages / Events / Errors) exist only in the full layout.
+    component.applyPreset('full');
+    fixture.detectChanges();
 
     const rawMsgSpy = vi.spyOn(component['rawMessagesInstance']!, 'clearLogs');
     const eventsSpy = vi.spyOn(component['eventsInstance']!, 'clearLogs');
@@ -259,6 +264,8 @@ describe('ComposerWorkspace Dashboard', () => {
 
   describe('Dockview Layout and Effects', () => {
     it('updates events and errors panel titles based on unread count', async () => {
+      fixture.componentInstance.applyPreset('full');
+      fixture.detectChanges();
       fixture.componentInstance.unreadEventsCount.set(5);
       fixture.componentInstance.unreadErrorsCount.set(3);
       fixture.detectChanges();
@@ -283,6 +290,8 @@ describe('ComposerWorkspace Dashboard', () => {
     });
 
     it('adds and removes the mockRules panel when showMockRules signal changes', async () => {
+      fixture.componentInstance.applyPreset('full');
+      fixture.detectChanges();
       fixture.componentInstance.showMockRules.set(true);
       fixture.detectChanges();
       await fixture.whenStable();
@@ -323,7 +332,9 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('restores dockview layout from localStorage on initialization', async () => {
       // Create new fixture since dockview is initialized on AfterViewInit
-      vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify({}));
+      const getItemSpy = vi
+        .spyOn(Storage.prototype, 'getItem')
+        .mockReturnValue(JSON.stringify({}));
       const newFixture = TestBed.createComponent(ComposerWorkspace);
 
       const apiSpy = vi.spyOn(DockviewComponent.prototype, 'fromJSON').mockImplementation(() => {});
@@ -333,6 +344,8 @@ describe('ComposerWorkspace Dashboard', () => {
 
       expect(apiSpy).toHaveBeenCalled();
       apiSpy.mockRestore();
+      // Restore the getItem spy so its '{}' return does not leak into later tests.
+      getItemSpy.mockRestore();
     });
 
     it('applies Material M3 tab styling class hook to the Dockview root element', () => {
@@ -556,6 +569,60 @@ describe('ComposerWorkspace Dashboard', () => {
         true,
       );
       expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function), true);
+    });
+  });
+
+  describe('Panel-setup presets', () => {
+    it('opens on the chat-preview default when no saved layout exists', async () => {
+      localStorage.clear();
+      const newFixture = TestBed.createComponent(ComposerWorkspace);
+      newFixture.detectChanges();
+      await newFixture.whenStable();
+
+      const ids = newFixture.componentInstance['dockviewApi'].panels.map(p => p.id).sort();
+      expect(ids).toEqual([ComposerPanelId.Chat, ComposerPanelId.Rendered].sort());
+      expect(newFixture.componentInstance.activePreset()).toBe('chat-preview');
+    });
+
+    it('applyPreset("chat") leaves only the Chat panel', () => {
+      const component = fixture.componentInstance;
+      component.applyPreset('chat');
+      fixture.detectChanges();
+
+      const ids = component['dockviewApi'].panels.map(p => p.id);
+      expect(ids).toEqual([ComposerPanelId.Chat]);
+      expect(component.activePreset()).toBe('chat');
+    });
+
+    it('applyPreset("chat-preview") yields Chat + Rendered', () => {
+      const component = fixture.componentInstance;
+      component.applyPreset('chat-preview');
+      fixture.detectChanges();
+
+      const ids = component['dockviewApi'].panels.map(p => p.id).sort();
+      expect(ids).toEqual([ComposerPanelId.Chat, ComposerPanelId.Rendered].sort());
+      expect(component.activePreset()).toBe('chat-preview');
+    });
+
+    it('applyPreset("full") yields the full panel set', () => {
+      const component = fixture.componentInstance;
+      component.applyPreset('full');
+      fixture.detectChanges();
+
+      const ids = component['dockviewApi'].panels.map(p => p.id);
+      expect(ids).toContain(ComposerPanelId.Chat);
+      expect(ids).toContain(ComposerPanelId.Rendered);
+      expect(ids).toContain(ComposerPanelId.Raw);
+      expect(ids).toContain(ComposerPanelId.DataModel);
+      expect(ids).toContain(ComposerPanelId.Events);
+      expect(ids).toContain(ComposerPanelId.Errors);
+      expect(ids).toContain(ComposerPanelId.RawMessages);
+      expect(component.activePreset()).toBe('full');
+    });
+
+    it('persists the applied preset to localStorage', () => {
+      fixture.componentInstance.applyPreset('chat');
+      expect(localStorage.getItem('composer_workspace_preset')).toBe('chat');
     });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -23,7 +23,6 @@ import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {provideRouter} from '@angular/router';
 import {HostCommunication} from '../host-communication/host-communication';
-import {StartupResolution} from '../startup-resolution/startup-resolution';
 import {DockviewComponent} from 'dockview';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import {ChatCoordinator} from '../../chat/chat-service/chat-coordinator';
@@ -253,16 +252,6 @@ describe('ComposerWorkspace Dashboard', () => {
     });
   });
 
-  it('sets isExtensionMode correctly', async () => {
-    const resolutionService = TestBed.inject(StartupResolution);
-    vi.spyOn(resolutionService, 'isExtensionMode').mockReturnValue(true);
-
-    const newFixture = TestBed.createComponent(ComposerWorkspace);
-    newFixture.detectChanges();
-
-    expect(newFixture.componentInstance.isExtension()).toBe(true);
-  });
-
   describe('Dockview Layout and Effects', () => {
     it('updates events and errors panel titles based on unread count', async () => {
       fixture.componentInstance.applyPreset('full');
@@ -430,6 +419,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('activates panel and triggers change detection when pointerdown occurs on tab element', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
       expect(eventsPanel).toBeDefined();
       if (!eventsPanel) return;
@@ -451,6 +444,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('activates panel when click occurs on tab element', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
       expect(eventsPanel).toBeDefined();
       if (!eventsPanel) return;
@@ -472,6 +469,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('activates panel when pointerdown occurs on a nested child element within a tab', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
       expect(eventsPanel).toBeDefined();
       if (!eventsPanel) return;
@@ -497,6 +498,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('activates panel when click occurs on a nested child element within a tab', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
       expect(eventsPanel).toBeDefined();
       if (!eventsPanel) return;
@@ -522,6 +527,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('does not activate panel when click occurs on non-tab workspace elements', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
       expect(eventsPanel).toBeDefined();
       if (!eventsPanel) return;
@@ -541,6 +550,10 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('triggers change detection via cdr.markForCheck when active panel changes', () => {
       const component = fixture.componentInstance;
+      // The default layout is now the render-focused chat-preview preset, which
+      // omits the Events panel; build the full layout so the tab is present.
+      component.applyPreset('full');
+      fixture.detectChanges();
       const markForCheckSpy = vi.spyOn(component['cdr'], 'markForCheck');
 
       const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -16,6 +16,7 @@
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ComposerWorkspace, ComposerPanelId} from './composer-workspace';
+import {WorkspaceLayout} from '../workspace-layout/workspace-layout';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComposerWorkspaceHarness} from './test/composer-workspace.harness';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
@@ -332,9 +333,7 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('restores dockview layout from localStorage on initialization', async () => {
       // Create new fixture since dockview is initialized on AfterViewInit
-      const getItemSpy = vi
-        .spyOn(Storage.prototype, 'getItem')
-        .mockReturnValue(JSON.stringify({}));
+      const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(JSON.stringify({}));
       const newFixture = TestBed.createComponent(ComposerWorkspace);
 
       const apiSpy = vi.spyOn(DockviewComponent.prototype, 'fromJSON').mockImplementation(() => {});
@@ -623,6 +622,20 @@ describe('ComposerWorkspace Dashboard', () => {
     it('persists the applied preset to localStorage', () => {
       fixture.componentInstance.applyPreset('chat');
       expect(localStorage.getItem('composer_workspace_preset')).toBe('chat');
+    });
+
+    it('registers with WorkspaceLayout so the header toggle can drive a rebuild', () => {
+      const layout = TestBed.inject(WorkspaceLayout);
+      expect(layout.isActive()).toBe(true);
+      expect(layout.activePreset()).toBe('chat-preview');
+
+      layout.cycle(); // chat-preview -> full
+      fixture.detectChanges();
+
+      expect(layout.activePreset()).toBe('full');
+      const ids = fixture.componentInstance['dockviewApi'].panels.map(p => p.id);
+      expect(ids).toContain(ComposerPanelId.Raw);
+      expect(ids).toContain(ComposerPanelId.DataModel);
     });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -32,6 +32,9 @@ import {
   ChangeDetectorRef,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatIconModule} from '@angular/material/icon';
+import {MatTooltipModule} from '@angular/material/tooltip';
 import {ChatPanel} from '../../chat/chat-panel/chat-panel';
 import {RawFrame} from '../../preview/raw/raw-frame';
 import {RenderedFrame} from '../../preview/rendered/rendered-frame';
@@ -71,6 +74,12 @@ export enum ComposerPanelId {
   MockRules = 'mockRules',
 }
 
+/** Named workspace layout presets selectable from the panel-setup switcher. */
+export type WorkspacePreset = 'chat' | 'chat-preview' | 'full';
+
+/** localStorage key remembering the last-applied preset (for the toggle highlight). */
+const WORKSPACE_PRESET_KEY = 'composer_workspace_preset';
+
 /**
  * The central workspace hub coordinating split-pane views between
  * the layout editors, active preview frame, and debug consoles.
@@ -78,6 +87,7 @@ export enum ComposerPanelId {
 @Component({
   selector: 'a2ui-composer-workspace',
   standalone: true,
+  imports: [MatButtonToggleModule, MatIconModule, MatTooltipModule],
   templateUrl: './composer-workspace.ng.html',
   styleUrl: './composer-workspace.scss',
 })
@@ -99,6 +109,9 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   unreadEventsCount = signal(0);
   unreadErrorsCount = signal(0);
   isDarkTheme = computed(() => this.configProvider.themePreference() === ThemePreference.DARK);
+
+  /** The workspace layout preset currently applied (drives the switcher highlight). */
+  readonly activePreset = signal<WorkspacePreset>('chat-preview');
 
   private readonly isDockviewInitialized = signal(false);
   private dockviewApi!: DockviewComponent;
@@ -296,57 +309,9 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
     }
 
     if (!layoutRestored) {
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.Chat,
-        component: ComposerPanelId.Chat,
-        title: 'Gemini Assistant',
-      });
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.Rendered,
-        component: ComposerPanelId.Rendered,
-        title: 'Rendered A2UI Preview',
-        position: {direction: 'right', referencePanel: ComposerPanelId.Chat},
-      });
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.Raw,
-        component: ComposerPanelId.Raw,
-        title: 'A2UI JSON Editor',
-        position: {direction: 'right', referencePanel: ComposerPanelId.Rendered},
-      });
-
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.DataModel,
-        component: ComposerPanelId.DataModel,
-        title: 'Data Model',
-        position: {direction: 'below', referencePanel: ComposerPanelId.Rendered},
-      });
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.Events,
-        component: ComposerPanelId.Events,
-        title: 'Events',
-        position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
-      });
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.Errors,
-        component: ComposerPanelId.Errors,
-        title: 'Errors',
-        position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
-      });
-      this.dockviewApi.addPanel({
-        id: ComposerPanelId.RawMessages,
-        component: ComposerPanelId.RawMessages,
-        title: 'Raw Messages',
-        position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
-      });
-
-      if (this.showMockRules()) {
-        this.dockviewApi.addPanel({
-          id: ComposerPanelId.MockRules,
-          component: ComposerPanelId.MockRules,
-          title: 'Mock Rules',
-          position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
-        });
-      }
+      // Fresh workspace opens on the "Chat + Preview" preset (focus on render)
+      // rather than the full debug layout. Users switch via the preset toolbar.
+      this.buildChatPreviewLayout();
     }
 
     let saveTimeout: ReturnType<typeof setTimeout>;
@@ -409,6 +374,102 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       rootEl.removeEventListener('pointerdown', handleTabInteraction, true);
       rootEl.removeEventListener('click', handleTabInteraction, true);
     });
+
+    // Highlight the toggle matching the last-applied preset. The layout itself
+    // is Google's saved freeform JSON when present, so the toggle is a hint of
+    // the last chosen arrangement, not a guarantee the layout still matches it.
+    const savedPreset = localStorage.getItem(WORKSPACE_PRESET_KEY);
+    if (savedPreset === 'chat' || savedPreset === 'chat-preview' || savedPreset === 'full') {
+      this.activePreset.set(savedPreset);
+    }
+  }
+
+  /**
+   * Applies a named layout preset: clears the workspace and rebuilds it with the
+   * preset's panel subset. Dockview's debounced layout-save then records the
+   * result, so a reload restores it (freeform edits included). No-op until the
+   * Dockview instance is initialized.
+   */
+  applyPreset(preset: WorkspacePreset): void {
+    if (!this.isDockviewInitialized()) return;
+    this.dockviewApi.clear();
+    if (preset === 'chat') {
+      this.buildChatLayout();
+    } else if (preset === 'chat-preview') {
+      this.buildChatPreviewLayout();
+    } else {
+      this.buildFullLayout();
+    }
+    this.activePreset.set(preset);
+    localStorage.setItem(WORKSPACE_PRESET_KEY, preset);
+  }
+
+  /** Preset "Chat": conversation only. */
+  private buildChatLayout(): void {
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.Chat,
+      component: ComposerPanelId.Chat,
+      title: 'Gemini Assistant',
+    });
+  }
+
+  /** Preset "Chat + Preview": conversation beside the live render (default focus). */
+  private buildChatPreviewLayout(): void {
+    this.buildChatLayout();
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.Rendered,
+      component: ComposerPanelId.Rendered,
+      title: 'Rendered A2UI Preview',
+      position: {direction: 'right', referencePanel: ComposerPanelId.Chat},
+    });
+  }
+
+  /**
+   * Preset "Chat + Preview + Code & Engine": the full workspace — chat, render,
+   * JSON editor, and the data-model / events / errors / raw-messages consoles.
+   * This is Google's original default layout.
+   */
+  private buildFullLayout(): void {
+    this.buildChatPreviewLayout();
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.Raw,
+      component: ComposerPanelId.Raw,
+      title: 'A2UI JSON Editor',
+      position: {direction: 'right', referencePanel: ComposerPanelId.Rendered},
+    });
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.DataModel,
+      component: ComposerPanelId.DataModel,
+      title: 'Data Model',
+      position: {direction: 'below', referencePanel: ComposerPanelId.Rendered},
+    });
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.Events,
+      component: ComposerPanelId.Events,
+      title: 'Events',
+      position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
+    });
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.Errors,
+      component: ComposerPanelId.Errors,
+      title: 'Errors',
+      position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
+    });
+    this.dockviewApi.addPanel({
+      id: ComposerPanelId.RawMessages,
+      component: ComposerPanelId.RawMessages,
+      title: 'Raw Messages',
+      position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
+    });
+
+    if (this.showMockRules()) {
+      this.dockviewApi.addPanel({
+        id: ComposerPanelId.MockRules,
+        component: ComposerPanelId.MockRules,
+        title: 'Mock Rules',
+        position: {direction: 'within', referencePanel: ComposerPanelId.DataModel},
+      });
+    }
   }
 
   /**

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -18,7 +18,6 @@ import {
   Component,
   effect,
   inject,
-  OnInit,
   AfterViewInit,
   DestroyRef,
   signal,
@@ -40,7 +39,6 @@ import {Events} from '../../debug/events/events';
 import {Errors} from '../../debug/errors/errors';
 import {RawMessages} from '../../debug/raw-messages/raw-messages';
 import {MockRules} from '../../debug/mock-rules/mock-rules';
-import {StartupResolution} from '../startup-resolution/startup-resolution';
 import {HostCommunication} from '../host-communication/host-communication';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import {
@@ -83,12 +81,11 @@ export enum ComposerPanelId {
   templateUrl: './composer-workspace.ng.html',
   styleUrl: './composer-workspace.scss',
 })
-export class ComposerWorkspace implements OnInit, AfterViewInit {
+export class ComposerWorkspace implements AfterViewInit {
   private readonly destroyRef = inject(DestroyRef);
   // Injected to notify zoneless Angular change detection when active panel
   // signals update.
   private readonly cdr = inject(ChangeDetectorRef);
-  private startupResolution = inject(StartupResolution);
   private hostComm = inject(HostCommunication);
   private viewContainerRef = inject(ViewContainerRef);
   private configProvider = inject(AppConfigProvider);
@@ -97,7 +94,6 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
 
   readonly dockviewRoot = viewChild.required<ElementRef<HTMLElement>>('dockviewRoot');
 
-  isExtension = signal(false);
   showMockRules = signal(false);
   unreadEventsCount = signal(0);
   unreadErrorsCount = signal(0);
@@ -208,11 +204,6 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
         api.updateOptions({className: isDark ? 'dockview-theme-dark' : 'dockview-theme-light'});
       }
     });
-  }
-
-  ngOnInit(): void {
-    const isExt = this.startupResolution.isExtensionMode();
-    this.isExtension.set(isExt);
   }
 
   ngAfterViewInit() {
@@ -400,12 +391,18 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private rebuildLayout(preset: WorkspacePreset): void {
     if (!this.isDockviewInitialized()) return;
     this.dockviewApi.clear();
-    if (preset === 'chat') {
-      this.buildChatLayout();
-    } else if (preset === 'chat-preview') {
-      this.buildChatPreviewLayout();
-    } else {
-      this.buildFullLayout();
+    switch (preset) {
+      case 'chat':
+        this.buildChatLayout();
+        break;
+      case 'full':
+        this.buildFullLayout();
+        break;
+      case 'chat-preview':
+      default:
+        // Render-focused default: chat beside the live preview.
+        this.buildChatPreviewLayout();
+        break;
     }
   }
 

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -32,9 +32,6 @@ import {
   ChangeDetectorRef,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
-import {MatIconModule} from '@angular/material/icon';
-import {MatTooltipModule} from '@angular/material/tooltip';
 import {ChatPanel} from '../../chat/chat-panel/chat-panel';
 import {RawFrame} from '../../preview/raw/raw-frame';
 import {RenderedFrame} from '../../preview/rendered/rendered-frame';
@@ -52,6 +49,7 @@ import {
 } from '../../settings/app-config-provider/app-config-provider';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {WorkspaceLayout, WorkspacePreset} from '../workspace-layout/workspace-layout';
 import {DockviewComponent} from 'dockview';
 
 /** Internal interface mapping raw cross-frame workspace telemetry payloads */
@@ -74,12 +72,6 @@ export enum ComposerPanelId {
   MockRules = 'mockRules',
 }
 
-/** Named workspace layout presets selectable from the panel-setup switcher. */
-export type WorkspacePreset = 'chat' | 'chat-preview' | 'full';
-
-/** localStorage key remembering the last-applied preset (for the toggle highlight). */
-const WORKSPACE_PRESET_KEY = 'composer_workspace_preset';
-
 /**
  * The central workspace hub coordinating split-pane views between
  * the layout editors, active preview frame, and debug consoles.
@@ -87,7 +79,7 @@ const WORKSPACE_PRESET_KEY = 'composer_workspace_preset';
 @Component({
   selector: 'a2ui-composer-workspace',
   standalone: true,
-  imports: [MatButtonToggleModule, MatIconModule, MatTooltipModule],
+  imports: [],
   templateUrl: './composer-workspace.ng.html',
   styleUrl: './composer-workspace.scss',
 })
@@ -101,6 +93,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private viewContainerRef = inject(ViewContainerRef);
   private configProvider = inject(AppConfigProvider);
   private storage = inject(LocalStorageInteractions);
+  private readonly layout = inject(WorkspaceLayout);
 
   readonly dockviewRoot = viewChild.required<ElementRef<HTMLElement>>('dockviewRoot');
 
@@ -110,8 +103,12 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   unreadErrorsCount = signal(0);
   isDarkTheme = computed(() => this.configProvider.themePreference() === ThemePreference.DARK);
 
-  /** The workspace layout preset currently applied (drives the switcher highlight). */
-  readonly activePreset = signal<WorkspacePreset>('chat-preview');
+  /**
+   * The workspace layout preset currently applied. Owned by WorkspaceLayout so
+   * the header toggle and this workspace share one source of truth; re-exposed
+   * here for programmatic and test access.
+   */
+  readonly activePreset = this.layout.activePreset;
 
   private readonly isDockviewInitialized = signal(false);
   private dockviewApi!: DockviewComponent;
@@ -375,22 +372,32 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       rootEl.removeEventListener('click', handleTabInteraction, true);
     });
 
-    // Highlight the toggle matching the last-applied preset. The layout itself
-    // is Google's saved freeform JSON when present, so the toggle is a hint of
+    // Expose this workspace to the header's layout toggle while it is mounted,
+    // and tear the registration down on destroy. WorkspaceLayout already
+    // reflects the last-applied preset on the toggle; the saved Dockview layout
+    // above is Google's freeform JSON when present, so the toggle is a hint of
     // the last chosen arrangement, not a guarantee the layout still matches it.
-    const savedPreset = localStorage.getItem(WORKSPACE_PRESET_KEY);
-    if (savedPreset === 'chat' || savedPreset === 'chat-preview' || savedPreset === 'full') {
-      this.activePreset.set(savedPreset);
-    }
+    this.destroyRef.onDestroy(this.layout.register(preset => this.rebuildLayout(preset)));
   }
 
   /**
-   * Applies a named layout preset: clears the workspace and rebuilds it with the
-   * preset's panel subset. Dockview's debounced layout-save then records the
-   * result, so a reload restores it (freeform edits included). No-op until the
-   * Dockview instance is initialized.
+   * Applies a named layout preset through WorkspaceLayout, which rebuilds this
+   * workspace (via the registered callback), updates the header toggle, and
+   * persists the choice. Dockview's debounced layout-save then records the
+   * result, so a reload restores it (freeform edits included). A thin
+   * pass-through for programmatic/host and test use; the header toggle drives
+   * normal usage.
    */
   applyPreset(preset: WorkspacePreset): void {
+    this.layout.apply(preset);
+  }
+
+  /**
+   * Clears and rebuilds the Dockview layout for a preset. Registered with
+   * WorkspaceLayout so the header toggle can drive it; WorkspaceLayout owns the
+   * active-preset signal and persistence. No-op until Dockview is initialized.
+   */
+  private rebuildLayout(preset: WorkspacePreset): void {
     if (!this.isDockviewInitialized()) return;
     this.dockviewApi.clear();
     if (preset === 'chat') {
@@ -400,8 +407,6 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
     } else {
       this.buildFullLayout();
     }
-    this.activePreset.set(preset);
-    localStorage.setItem(WORKSPACE_PRESET_KEY, preset);
   }
 
   /** Preset "Chat": conversation only. */

--- a/shell/src/app/shell/workspace-layout/workspace-layout.spec.ts
+++ b/shell/src/app/shell/workspace-layout/workspace-layout.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {WorkspaceLayout, WorkspacePreset} from './workspace-layout';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+
+describe('WorkspaceLayout', () => {
+  let layout: WorkspaceLayout;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    layout = TestBed.inject(WorkspaceLayout);
+  });
+
+  it('defaults to chat-preview when no preset is saved', () => {
+    expect(layout.activePreset()).toBe('chat-preview');
+    expect(layout.isActive()).toBe(false);
+  });
+
+  it('cycle steps chat -> chat-preview -> full -> chat', () => {
+    layout.apply('chat');
+
+    layout.cycle();
+    expect(layout.activePreset()).toBe('chat-preview');
+
+    layout.cycle();
+    expect(layout.activePreset()).toBe('full');
+
+    layout.cycle();
+    expect(layout.activePreset()).toBe('chat');
+  });
+
+  it('exposes icon + label metadata for the active and next presets', () => {
+    layout.apply('full');
+    expect(layout.activePresetMeta()).toEqual({icon: 'dashboard', label: 'Code & Engine'});
+    expect(layout.nextPreset()).toBe('chat');
+    expect(layout.nextPresetMeta()).toEqual({icon: 'forum', label: 'Chat'});
+  });
+
+  it('invokes the registered rebuild callback on apply', () => {
+    const rebuilt: WorkspacePreset[] = [];
+    layout.register(preset => rebuilt.push(preset));
+
+    layout.apply('full');
+    layout.cycle();
+
+    expect(rebuilt).toEqual(['full', 'chat']);
+    expect(layout.isActive()).toBe(true);
+  });
+
+  it('stops invoking the callback and clears isActive after the disposer runs', () => {
+    const rebuild = vi.fn();
+    const dispose = layout.register(rebuild);
+
+    dispose();
+    expect(layout.isActive()).toBe(false);
+
+    layout.apply('full');
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it('persists the applied preset to localStorage', () => {
+    layout.apply('chat');
+    expect(localStorage.getItem('composer_workspace_preset')).toBe('chat');
+  });
+
+  it('restores the saved preset for a freshly-created instance', () => {
+    localStorage.setItem('composer_workspace_preset', 'full');
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const restored = TestBed.inject(WorkspaceLayout);
+    expect(restored.activePreset()).toBe('full');
+  });
+});

--- a/shell/src/app/shell/workspace-layout/workspace-layout.ts
+++ b/shell/src/app/shell/workspace-layout/workspace-layout.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {computed, Injectable, signal} from '@angular/core';
+
+/** Named workspace layout presets the single header toggle cycles through. */
+export type WorkspacePreset = 'chat' | 'chat-preview' | 'full';
+
+/** Icon + label shown on the cycle toggle for a preset. */
+export interface WorkspacePresetMeta {
+  readonly icon: string;
+  readonly label: string;
+}
+
+/** Order the toggle steps through on each click, wrapping at the end. */
+const PRESET_CYCLE: readonly WorkspacePreset[] = ['chat', 'chat-preview', 'full'];
+
+/** Icon + label the cycle toggle shows for each preset. */
+const PRESET_META: Record<WorkspacePreset, WorkspacePresetMeta> = {
+  chat: {icon: 'forum', label: 'Chat'},
+  'chat-preview': {icon: 'preview', label: 'Chat + Preview'},
+  full: {icon: 'dashboard', label: 'Code & Engine'},
+};
+
+/** localStorage key remembering the last-applied preset (drives the toggle label). */
+const WORKSPACE_PRESET_KEY = 'composer_workspace_preset';
+
+/**
+ * Bridges the layout toggle that lives in the header (ComposerShell) with the
+ * Dockview workspace it controls (ComposerWorkspace). The two are siblings
+ * across the router outlet, so the workspace registers a rebuild callback here
+ * while it is mounted, and the header reads the active preset for the toggle's
+ * icon/label and asks to cycle it.
+ */
+@Injectable({providedIn: 'root'})
+export class WorkspaceLayout {
+  /** The preset currently applied (drives the toggle's icon + label). */
+  readonly activePreset = signal<WorkspacePreset>(this.readSavedPreset() ?? 'chat-preview');
+
+  /** True while a workspace is mounted and can accept layout commands. */
+  readonly isActive = signal(false);
+
+  /** Icon + label for the applied preset (what the toggle displays). */
+  readonly activePresetMeta = computed(() => PRESET_META[this.activePreset()]);
+
+  /** The preset the next click will apply (drives the tooltip). */
+  readonly nextPreset = computed<WorkspacePreset>(() => {
+    const idx = PRESET_CYCLE.indexOf(this.activePreset());
+    return PRESET_CYCLE[(idx + 1) % PRESET_CYCLE.length];
+  });
+
+  /** Icon + label for the upcoming preset in the cycle (drives the tooltip). */
+  readonly nextPresetMeta = computed(() => PRESET_META[this.nextPreset()]);
+
+  private rebuild?: (preset: WorkspacePreset) => void;
+
+  /**
+   * Registers the mounted workspace's rebuild callback, which clears and
+   * reconstructs the Dockview layout for a given preset. Returns a disposer
+   * the workspace calls on destroy so a stale callback is never invoked.
+   */
+  register(rebuild: (preset: WorkspacePreset) => void): () => void {
+    this.rebuild = rebuild;
+    this.isActive.set(true);
+    return () => {
+      if (this.rebuild === rebuild) {
+        this.rebuild = undefined;
+        this.isActive.set(false);
+      }
+    };
+  }
+
+  /** Rebuild the workspace to `preset`, update the toggle label, and persist it. */
+  apply(preset: WorkspacePreset): void {
+    this.rebuild?.(preset);
+    this.activePreset.set(preset);
+    localStorage.setItem(WORKSPACE_PRESET_KEY, preset);
+  }
+
+  /** Advance to the next preset (chat -> chat-preview -> full -> chat). */
+  cycle(): void {
+    this.apply(this.nextPreset());
+  }
+
+  private readSavedPreset(): WorkspacePreset | null {
+    const saved = localStorage.getItem(WORKSPACE_PRESET_KEY);
+    return saved === 'chat' || saved === 'chat-preview' || saved === 'full' ? saved : null;
+  }
+}

--- a/shell/src/app/shell/workspace-layout/workspace-layout.ts
+++ b/shell/src/app/shell/workspace-layout/workspace-layout.ts
@@ -87,7 +87,14 @@ export class WorkspaceLayout {
   apply(preset: WorkspacePreset): void {
     this.rebuild?.(preset);
     this.activePreset.set(preset);
-    localStorage.setItem(WORKSPACE_PRESET_KEY, preset);
+    // Persisting is best-effort: localStorage access can throw a SecurityError
+    // in sandboxed/restricted contexts (e.g. cross-origin iframes, disabled
+    // storage). A failed write must not break the toggle, so swallow it.
+    try {
+      localStorage.setItem(WORKSPACE_PRESET_KEY, preset);
+    } catch (e) {
+      console.warn('Failed to persist workspace preset to localStorage', e);
+    }
   }
 
   /** Advance to the next preset (chat -> chat-preview -> full -> chat). */
@@ -96,7 +103,16 @@ export class WorkspaceLayout {
   }
 
   private readSavedPreset(): WorkspacePreset | null {
-    const saved = localStorage.getItem(WORKSPACE_PRESET_KEY);
+    // Reading is best-effort: localStorage access can throw a SecurityError in
+    // sandboxed/restricted contexts. On failure, fall back to no saved preset
+    // (the initializer then uses the render-focused default).
+    let saved: string | null;
+    try {
+      saved = localStorage.getItem(WORKSPACE_PRESET_KEY);
+    } catch (e) {
+      console.warn('Failed to read workspace preset from localStorage', e);
+      return null;
+    }
     return saved === 'chat' || saved === 'chat-preview' || saved === 'full' ? saved : null;
   }
 }


### PR DESCRIPTION
A segmented switcher fronting the Dockview workspace with named one-click layout presets, on top of the existing freeform Dockview.

### What
- Three presets — **Chat**, **Chat + Preview** (new render-focused default), **Code & Engine** (full JSON editor + data/engine panels).
- `applyPreset()` clears and rebuilds Dockview per preset; freeform drag-and-save (`composer_dockview_layout`) is preserved untouched.
- New `composer_workspace_preset` key drives the toggle highlight.
- Files: `composer-workspace.{ts,ng.html,scss,spec.ts}`.

### Why
Fast, named layout arrangements while keeping the freeform Dockview underneath.

### Testing
Workspace unit spec passing; `ng build` clean.

### Notes
Styles reference the theme PR's `--cpk-*` tokens and fall back to Material without it — functionally standalone.

---
Contributed by CopilotKit.


## Screenshots

The layout toggle lives in the header (single cycle button through Chat / Chat + Preview / Code & Engine):

| Light | Dark |
|---|---|
| <img src="https://raw.githubusercontent.com/jerelvelarde/a2ui-composer/jerel/pr-media/media/pr2-workspace-light.png" width="420"> | <img src="https://raw.githubusercontent.com/jerelvelarde/a2ui-composer/jerel/pr-media/media/pr2-workspace-dark.png" width="420"> |

