### PR TITLE
fix(composer): use dynamic initial layout dimensions

### DIFF
--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -146,6 +146,9 @@ describe('ComposerShell Layout', () => {
         LocalStorageKey.SESSION_STATE,
       );
       expect(localStorageServiceMock.removeItem).toHaveBeenCalledWith(LocalStorageKey.EDITOR_CACHE);
+      expect(localStorageServiceMock.removeItem).not.toHaveBeenCalledWith(
+        LocalStorageKey.DOCKVIEW_LAYOUT,
+      );
       expect(sessionStorageServiceMock.clear).toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith('Session state cleared.');
     },

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -400,5 +400,19 @@ describe('ComposerWorkspace Dashboard', () => {
       requestSpy.mockRestore();
       cancelSpy.mockRestore();
     });
+
+    it('uses container element dimensions during initial dockview layout pass', async () => {
+      const layoutSpy = vi.spyOn(DockviewComponent.prototype, 'layout');
+      const newFixture = TestBed.createComponent(ComposerWorkspace);
+      const rootEl = newFixture.nativeElement.querySelector('.dockview-root');
+      Object.defineProperty(rootEl, 'clientWidth', {value: 1200, configurable: true});
+      Object.defineProperty(rootEl, 'clientHeight', {value: 800, configurable: true});
+
+      newFixture.detectChanges();
+      await newFixture.whenStable();
+
+      expect(layoutSpy).toHaveBeenCalledWith(1200, 800);
+      layoutSpy.mockRestore();
+    });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -403,16 +403,17 @@ describe('ComposerWorkspace Dashboard', () => {
 
     it('uses container element dimensions during initial dockview layout pass', async () => {
       const layoutSpy = vi.spyOn(DockviewComponent.prototype, 'layout');
-      const newFixture = TestBed.createComponent(ComposerWorkspace);
-      const rootEl = newFixture.nativeElement.querySelector('.dockview-root');
-      Object.defineProperty(rootEl, 'clientWidth', {value: 1200, configurable: true});
-      Object.defineProperty(rootEl, 'clientHeight', {value: 800, configurable: true});
+      const widthSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(1200);
+      const heightSpy = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(800);
 
+      const newFixture = TestBed.createComponent(ComposerWorkspace);
       newFixture.detectChanges();
       await newFixture.whenStable();
 
       expect(layoutSpy).toHaveBeenCalledWith(1200, 800);
       layoutSpy.mockRestore();
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
     });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -46,6 +46,8 @@ import {
   AppConfigProvider,
   ThemePreference,
 } from '../../settings/app-config-provider/app-config-provider';
+import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
+import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {DockviewComponent} from 'dockview';
 
 /** Internal interface mapping raw cross-frame workspace telemetry payloads */
@@ -84,6 +86,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private hostComm = inject(HostCommunication);
   private viewContainerRef = inject(ViewContainerRef);
   private configProvider = inject(AppConfigProvider);
+  private storage = inject(LocalStorageInteractions);
 
   readonly dockviewRoot = viewChild.required<ElementRef<HTMLElement>>('dockviewRoot');
 
@@ -274,7 +277,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       this.checkTabOverflow();
     });
 
-    const savedLayout = localStorage.getItem('composer_dockview_layout');
+    const savedLayout = this.storage.getItem(LocalStorageKey.DOCKVIEW_LAYOUT);
     let layoutRestored = false;
 
     if (savedLayout) {
@@ -345,7 +348,10 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       this.checkTabOverflow();
       clearTimeout(saveTimeout);
       saveTimeout = setTimeout(() => {
-        localStorage.setItem('composer_dockview_layout', JSON.stringify(this.dockviewApi.toJSON()));
+        this.storage.setItem(
+          LocalStorageKey.DOCKVIEW_LAYOUT,
+          JSON.stringify(this.dockviewApi.toJSON()),
+        );
       }, 1000);
     });
     this.dockviewApi.onDidAddPanel(() => this.checkTabOverflow());
@@ -356,7 +362,9 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
 
     // Force an initial layout pass. In browsers, ResizeObserver handles this,
     // but in jsdom tests with mocked observers, it requires an explicit call.
-    this.dockviewApi.layout(1000, 1000);
+    const width = this.dockviewRoot().nativeElement.clientWidth || 1000;
+    const height = this.dockviewRoot().nativeElement.clientHeight || 1000;
+    this.dockviewApi.layout(width, height);
     this.isDockviewInitialized.set(true);
     this.checkTabOverflow();
   }

--- a/shell/src/app/storage/models/local-storage-keys.ts
+++ b/shell/src/app/storage/models/local-storage-keys.ts
@@ -32,6 +32,8 @@ export enum LocalStorageKey {
   ACTIVE_DRAFT = 'a2ui_composer_active_draft',
   SESSION_STATE = 'a2ui_composer_session_state',
   EDITOR_CACHE = 'a2ui_composer_editor_cache',
+  /** Key for persisting dockview window split layout state. */
+  DOCKVIEW_LAYOUT = 'composer_dockview_layout',
   /** Key for persisting the user's theme selection (light vs dark). */
   THEME_PREFERENCE = 'a2ui_composer_theme_preference',
 }


### PR DESCRIPTION
# Description

Use dynamic container client dimensions (clientWidth/clientHeight) for the initial Dockview layout pass in ComposerWorkspace, preventing layout race conditions on load.

Add DOCKVIEW_LAYOUT to LocalStorageKey enum to enforce strong typing and layer abstraction with LocalStorageInteractions.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

