### PR TITLE
Fix property renaming resilience in IPC payloads and catalog lookups

### DIFF
--- a/bridge/src/angular/angular-bridge.ts
+++ b/bridge/src/angular/angular-bridge.ts
@@ -94,7 +94,7 @@ export class A2uiSandboxConnection implements OnDestroy {
         if (catalogs) {
           for (const catalog of catalogs) {
             if (catalog) {
-              (catalog as {id: string}).id = catalogId;
+              (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
             }
           }
         }

--- a/bridge/src/lit/lit-bridge.ts
+++ b/bridge/src/lit/lit-bridge.ts
@@ -133,7 +133,7 @@ export class A2uiSandboxRoot extends LitElement {
       onCatalogResolved: catalogId => {
         for (const catalog of (this.constructor as typeof A2uiSandboxRoot).catalogs) {
           if (catalog) {
-            (catalog as {id: string}).id = catalogId;
+            (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
           }
         }
       },

--- a/bridge/src/preview-bridge.spec.ts
+++ b/bridge/src/preview-bridge.spec.ts
@@ -1718,6 +1718,32 @@ describe('PreviewBridge Core API Runtime', () => {
       }).not.toThrow();
     });
 
+    it('dispatches reset payload with explicit quoted keys for protocol properties during resetActiveRendererState', () => {
+      const processSpy = vi.fn();
+      const mockGroup = {
+        onSurfaceCreated: {subscribe: vi.fn().mockReturnValue({unsubscribe: vi.fn()})},
+      };
+
+      bridge.attachRenderer(
+        {processMessages: processSpy},
+        {
+          surfaceGroup: mockGroup as unknown as SurfaceGroupLike,
+          onSurfaceReady: vi.fn(),
+        },
+      );
+
+      bridge['activeRenderer']!.activeSurfaceIds.add('surf-1');
+
+      bridge['resetActiveRendererState']();
+
+      expect(processSpy).toHaveBeenCalledWith([
+        {
+          version: 'v0.9',
+          deleteSurface: {surfaceId: 'surf-1'},
+        },
+      ]);
+    });
+
     it('logs warning and falls back to entire message payload when RENDER_A2UI data payload field is omitted', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const mockGroup = {

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -535,10 +535,14 @@ export class PreviewBridge {
     const {processor, config, activeSurfaceIds} = this.activeRenderer;
     for (const surfaceId of activeSurfaceIds) {
       try {
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         processor.processMessages([
           {
-            version: 'v0.9',
-            deleteSurface: {surfaceId},
+            'version': 'v0.9',
+            'deleteSurface': {
+              'surfaceId': surfaceId,
+            },
           } as A2uiMessage,
         ]);
       } catch (e: unknown) {

--- a/bridge/src/react/react-bridge.ts
+++ b/bridge/src/react/react-bridge.ts
@@ -68,7 +68,7 @@ export function useA2uiSandbox<C extends ComponentApi = ComponentApi>(
       onCatalogResolved: catalogId => {
         for (const catalog of catalogs) {
           if (catalog) {
-            (catalog as {id: string}).id = catalogId;
+            (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
           }
         }
       },

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -402,10 +402,13 @@ export class ChatCoordinator {
    */
   private runCatalogComponentSchemaCheck(parsedBlocks: unknown[]): void {
     const catalog = this.catalogManagement.activeCatalog();
+    const componentsObj = catalog
+      ? (catalog['components'] as Record<string, unknown> | undefined)
+      : undefined;
     const componentHealMap: Record<string, string> = {};
 
-    if (catalog && catalog['components']) {
-      for (const key of Object.keys(catalog['components'])) {
+    if (componentsObj) {
+      for (const key of Object.keys(componentsObj)) {
         const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, '');
         componentHealMap[normalizedKey] = key;
       }
@@ -460,8 +463,8 @@ export class ChatCoordinator {
         let targetType = compType;
 
         // Schema validation (only if catalog is actively loaded with components)
-        if (catalog && catalog.components) {
-          if (!catalog.components[compType]) {
+        if (componentsObj) {
+          if (!componentsObj[compType]) {
             // Unrecognized component type - check case-insensitive lookup!
             const normalized = compType.toLowerCase().replace(/[^a-z]/g, '');
             let healedType = componentHealMap[normalized];
@@ -474,13 +477,13 @@ export class ChatCoordinator {
               }
             }
 
-            if (healedType && catalog.components[healedType]) {
+            if (healedType && componentsObj[healedType]) {
               this.chatState.setPipelineStatus(PipelineStatus.HEALING);
               targetType = healedType;
             } else {
               // Fuzzy search matches
               const fuzzyMatch = normalized
-                ? Object.keys(catalog.components).find(
+                ? Object.keys(componentsObj).find(
                     key =>
                       key.toLowerCase().includes(normalized) ||
                       normalized.includes(key.toLowerCase()),

--- a/shell/src/app/chat/state-sync/state-sync.ts
+++ b/shell/src/app/chat/state-sync/state-sync.ts
@@ -73,7 +73,7 @@ export class StateSync {
     effect(() => {
       const catalog = this.catalogManagement.activeCatalog();
       if (catalog) {
-        const catalogId = catalog.catalogId || '';
+        const catalogId = (catalog['catalogId'] as string) || (catalog['$id'] as string) || '';
         untracked(() => {
           const currentDraft = this._activeDraft();
           const draftCatalogId = this.getCatalogIdFromDraft(currentDraft);
@@ -122,7 +122,9 @@ export class StateSync {
    */
   flushDraft(): void {
     const catalog = this.catalogManagement.activeCatalog();
-    const catalogId = catalog?.catalogId || '';
+    const catalogId = catalog
+      ? (catalog['catalogId'] as string) || (catalog['$id'] as string) || ''
+      : '';
     this._activeDraft.set(this.getInitialDraft(catalogId));
   }
 
@@ -133,13 +135,15 @@ export class StateSync {
     if (!catalogId) {
       return '';
     }
+    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+    // prettier-ignore
     const draftObj = [
       {
-        version: 'v0.9',
-        createSurface: {
-          surfaceId: 'sample-surface',
-          catalogId,
-          sendDataModel: true,
+        'version': 'v0.9',
+        'createSurface': {
+          'surfaceId': 'sample-surface',
+          'catalogId': catalogId,
+          'sendDataModel': true,
         },
       },
     ];
@@ -155,12 +159,27 @@ export class StateSync {
       const parsed = JSON.parse(trimmed);
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
-          if (item?.createSurface?.catalogId) {
-            return item.createSurface.catalogId;
+          const createSurface =
+            item && typeof item === 'object'
+              ? (item as Record<string, unknown>)['createSurface']
+              : undefined;
+          if (
+            createSurface &&
+            typeof createSurface === 'object' &&
+            (createSurface as Record<string, unknown>)['catalogId']
+          ) {
+            return (createSurface as Record<string, unknown>)['catalogId'] as string;
           }
         }
-      } else if (parsed?.createSurface?.catalogId) {
-        return parsed.createSurface.catalogId;
+      } else if (parsed && typeof parsed === 'object') {
+        const createSurface = (parsed as Record<string, unknown>)['createSurface'];
+        if (
+          createSurface &&
+          typeof createSurface === 'object' &&
+          (createSurface as Record<string, unknown>)['catalogId']
+        ) {
+          return (createSurface as Record<string, unknown>)['catalogId'] as string;
+        }
       }
     } catch (e) {
       // ignore

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -141,7 +141,7 @@ export class Gallery implements OnInit, OnDestroy {
   protected readonly catalogId = computed<string | null>(() => {
     const catalog = this.catalogManagement.activeCatalog();
     if (!catalog) return null;
-    return (catalog.catalogId || catalog.$id) ?? null;
+    return ((catalog['catalogId'] as string) || (catalog['$id'] as string)) ?? null;
   });
 
   /** The table column names mapped by MatTable. */
@@ -157,8 +157,11 @@ export class Gallery implements OnInit, OnDestroy {
   protected readonly selectedComponentDescription = computed<string>(() => {
     const key = this.selectedComponentKey();
     const catalog = this.catalogManagement.activeCatalog();
-    const comp = key ? catalog?.components?.[key] : null;
-    return comp && typeof comp['description'] === 'string' ? comp['description'] : '';
+    const comp =
+      key && catalog && catalog['components']
+        ? (catalog['components'] as Record<string, Record<string, unknown>>)[key]
+        : null;
+    return comp && typeof comp['description'] === 'string' ? (comp['description'] as string) : '';
   });
 
   /**
@@ -176,7 +179,10 @@ export class Gallery implements OnInit, OnDestroy {
       return componentsArray;
     }
 
-    const componentKeys = Object.keys(catalog.components || {});
+    const componentsObj = catalog
+      ? (catalog['components'] as Record<string, unknown> | undefined)
+      : undefined;
+    const componentKeys = Object.keys(componentsObj || {});
     // Support prefixed columns by checking if exactly 'column' or ends with 'column' (case-insensitive).
     // Prioritize exact match.
     let columnKey = componentKeys.find(k => k.toLowerCase() === 'column');
@@ -237,32 +243,38 @@ export class Gallery implements OnInit, OnDestroy {
         return;
       }
 
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       const createSurfaceCmd = {
-        version: 'v0.9',
-        createSurface: {
-          surfaceId: 'gallery-preview',
-          catalogId,
+        'version': 'v0.9',
+        'createSurface': {
+          'surfaceId': 'gallery-preview',
+          'catalogId': catalogId,
         },
       };
 
       const componentsPayload = this.getComponentsPayload(components as unknown[]);
 
+      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+      // prettier-ignore
       const updateComponentsCmd = {
-        version: 'v0.9',
-        updateComponents: {
-          surfaceId: 'gallery-preview',
-          components: componentsPayload,
+        'version': 'v0.9',
+        'updateComponents': {
+          'surfaceId': 'gallery-preview',
+          'components': componentsPayload,
         },
       };
 
       const commands: unknown[] = [createSurfaceCmd, updateComponentsCmd];
 
       if (dataObj !== undefined) {
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         commands.push({
-          version: 'v0.9',
-          updateDataModel: {
-            surfaceId: 'gallery-preview',
-            value: dataObj,
+          'version': 'v0.9',
+          'updateDataModel': {
+            'surfaceId': 'gallery-preview',
+            'value': dataObj,
           },
         });
       }

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -79,30 +79,36 @@ export class Gallery implements OnInit, OnDestroy {
 
         const componentsPayload = this.getComponentsPayload(componentsArray);
 
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         const cmd1 = {
-          version: 'v0.9',
-          createSurface: {
-            surfaceId: 'gallery-preview',
-            catalogId: catalogId,
+          'version': 'v0.9',
+          'createSurface': {
+            'surfaceId': 'gallery-preview',
+            'catalogId': catalogId,
           },
         };
 
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         const cmd2 = {
-          version: 'v0.9',
-          updateComponents: {
-            surfaceId: 'gallery-preview',
-            components: componentsPayload,
+          'version': 'v0.9',
+          'updateComponents': {
+            'surfaceId': 'gallery-preview',
+            'components': componentsPayload,
           },
         };
 
         const payload: unknown[] = [cmd1, cmd2];
 
         if (dataObj !== undefined) {
+          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+          // prettier-ignore
           const cmd3 = {
-            version: 'v0.9',
-            updateDataModel: {
-              surfaceId: 'gallery-preview',
-              value: dataObj,
+            'version': 'v0.9',
+            'updateDataModel': {
+              'surfaceId': 'gallery-preview',
+              'value': dataObj,
             },
           };
           payload.push(cmd3);

--- a/shell/src/app/gallery/services/gallery-catalog.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.ts
@@ -283,8 +283,10 @@ export class GalleryCatalog {
           clearTimeout(this.usageTimeoutId);
         }
 
+        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
+        // prettier-ignore
         this.hostCommunication.sendMessage({
-          type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
+          'type': PreviewBridgeMessageType.GET_COMPONENT_USAGES,
         });
 
         this.usageTimeoutId = setTimeout(() => {

--- a/shell/src/app/storage/models/catalog-storage.model.ts
+++ b/shell/src/app/storage/models/catalog-storage.model.ts
@@ -18,7 +18,7 @@
  * Database record schema representing a cached component catalog
  * stored inside the IndexedDB object store.
  */
-export interface CachedCatalogRecord {
+export declare interface CachedCatalogRecord {
   rendererUrl: string;
   catalogString: string;
   checksumHash: string;
@@ -29,7 +29,7 @@ export interface CachedCatalogRecord {
  * Schema defining metadata and structure for a single component definition
  * registered within a catalog.
  */
-export interface CatalogComponentSchema {
+export declare interface CatalogComponentSchema {
   [key: string]: unknown;
 }
 
@@ -37,7 +37,7 @@ export interface CatalogComponentSchema {
  * Represents a complete validated catalog package containing components,
  * identifiers, versions, and origin URLs.
  */
-export interface Catalog {
+export declare interface Catalog {
   $schema?: string;
   $id?: string;
   title?: string;


### PR DESCRIPTION
# Description

Quote property keys in cross-frame IPC message interfaces and protocol payload objects prevent property drop during Closure Compiler minification. Use bracket access for dynamic catalog object property lookups and ID mutations.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
