### PR TITLE
feat: Theater route — A2UI message-stream playback (native @a2ui/angular)

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -18,6 +18,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@a2ui/angular": "0.10.4",
+    "@a2ui/web_core": "0.10.5",
     "@angular/animations": "22.0.7",
     "@angular/cdk": "22.0.5",
     "@angular/common": "22.0.7",
@@ -36,7 +38,8 @@
     "monaco-editor": "0.56.0",
     "rxjs": "7.8.2",
     "safevalues": "1.2.0",
-    "tslib": "2.8.1"
+    "tslib": "2.8.1",
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "2.6.3",

--- a/shell/src/app/app.routes.ts
+++ b/shell/src/app/app.routes.ts
@@ -40,6 +40,13 @@ export const routes: Routes = [
         canActivate: [startupGuard],
       },
       {
+        path: 'custom-catalog',
+        loadComponent: () =>
+          import('./custom-catalog/assembled/custom-catalog').then(m => m.CustomCatalog),
+        title: 'A2UI Custom Catalog',
+        // No startupGuard: renders natively via @a2ui/angular, not the iframe renderer.
+      },
+      {
         path: 'settings',
         loadComponent: () => import('./settings/settings-view/settings').then(m => m.Settings),
         title: 'A2UI Composer Settings',

--- a/shell/src/app/app.routes.ts
+++ b/shell/src/app/app.routes.ts
@@ -47,6 +47,12 @@ export const routes: Routes = [
         // No startupGuard: renders natively via @a2ui/angular, not the iframe renderer.
       },
       {
+        path: 'theater',
+        loadComponent: () => import('./theater/theater').then(m => m.Theater),
+        title: 'A2UI Theater',
+        // No startupGuard: renders natively via @a2ui/angular, not the iframe renderer.
+      },
+      {
         path: 'settings',
         loadComponent: () => import('./settings/settings-view/settings').then(m => m.Settings),
         title: 'A2UI Composer Settings',

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.ng.html
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.ng.html
@@ -1,0 +1,74 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="cc-page">
+  <header class="cc-header">
+    <div class="cc-intro">
+      <h1 class="cc-title">Custom Catalog</h1>
+      <p class="cc-subtitle">
+        Two example trees assembled from one custom A2UI v0.9 catalog (11 components), rendered
+        natively. Edit the data model on the right — the preview updates live.
+      </p>
+    </div>
+    <mat-button-toggle-group
+      class="cc-example-switch"
+      [value]="activeExampleId()"
+      (change)="selectExample($event.value)"
+      aria-label="Example tree"
+      hideSingleSelectionIndicator
+    >
+      @for (ex of examples; track ex.id) {
+        <mat-button-toggle [value]="ex.id">
+          <mat-icon aria-hidden="true">{{ ex.icon }}</mat-icon>
+          <span class="cc-example-label">{{ ex.label }}</span>
+        </mat-button-toggle>
+      }
+    </mat-button-toggle-group>
+  </header>
+
+  <div class="cc-body">
+    <section class="cc-preview">
+      <div class="cc-pane-label">Assembled Components</div>
+      <div class="cc-surface-scroll">
+        <a2ui-v09-surface [surfaceId]="activeExampleId()"></a2ui-v09-surface>
+      </div>
+    </section>
+
+    <section class="cc-data">
+      <div class="cc-pane-label">Component Data</div>
+      <div class="cc-data-tabs" role="tablist">
+        @for (state of activeStates(); track state.name; let i = $index) {
+          <button
+            type="button"
+            role="tab"
+            class="cc-data-tab"
+            [class.active]="i === activeStateIndex()"
+            [attr.aria-selected]="i === activeStateIndex()"
+            (click)="selectState(i)"
+          >
+            {{ state.name }}
+          </button>
+        }
+      </div>
+      <div class="cc-editor">
+        <a2ui-composer-monaco-editor
+          [value]="editorValue()"
+          (valueChange)="onEdit($event)"
+        ></a2ui-composer-monaco-editor>
+      </div>
+    </section>
+  </div>
+</div>

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.scss
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.scss
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: block;
+  height: 100%;
+  box-sizing: border-box;
+  color: var(--cpk-text-primary);
+  font-family: var(--cpk-font-body);
+}
+
+.cc-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: var(--cpk-space-4);
+  padding: var(--cpk-space-5);
+  box-sizing: border-box;
+}
+
+.cc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--cpk-space-5);
+  flex-wrap: wrap;
+}
+
+.cc-title {
+  margin: 0 0 var(--cpk-space-1);
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.cc-subtitle {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--cpk-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.cc-example-switch {
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-pill);
+  overflow: hidden;
+  background: var(--cpk-surface-elevated);
+  flex: 0 0 auto;
+
+  ::ng-deep .mat-button-toggle-label-content {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cpk-space-2);
+    line-height: 36px;
+    padding: 0 var(--cpk-space-4);
+  }
+
+  ::ng-deep .mat-button-toggle {
+    color: var(--cpk-text-secondary);
+  }
+
+  ::ng-deep .mat-button-toggle-checked {
+    background: var(--cpk-accent-bg);
+    color: var(--cpk-accent);
+  }
+
+  ::ng-deep mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.cc-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--cpk-space-4);
+
+  @media (max-width: 900px) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: minmax(320px, 1fr);
+  }
+}
+
+.cc-preview,
+.cc-data {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-lg);
+  background: var(--cpk-surface-elevated);
+  box-shadow: var(--cpk-shadow-card);
+  overflow: hidden;
+}
+
+.cc-pane-label {
+  flex: 0 0 auto;
+  padding: var(--cpk-space-3) var(--cpk-space-4);
+  border-bottom: 1px solid var(--cpk-divider);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--cpk-text-secondary);
+}
+
+.cc-surface-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--cpk-space-5);
+}
+
+.cc-data-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: var(--cpk-space-1);
+  padding: var(--cpk-space-2) var(--cpk-space-3);
+  border-bottom: 1px solid var(--cpk-divider);
+  overflow-x: auto;
+}
+
+.cc-data-tab {
+  flex: 0 0 auto;
+  padding: var(--cpk-space-2) var(--cpk-space-3);
+  border: 1px solid transparent;
+  border-radius: var(--cpk-radius-pill);
+  background: transparent;
+  color: var(--cpk-text-secondary);
+  font-family: var(--cpk-font-body);
+  font-size: 0.8125rem;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--cpk-glass-bg-hover);
+  }
+
+  &.active {
+    background: var(--cpk-accent-bg);
+    border-color: var(--cpk-accent);
+    color: var(--cpk-accent);
+    font-weight: 600;
+  }
+}
+
+.cc-editor {
+  flex: 1 1 auto;
+  min-height: 0;
+
+  a2ui-composer-monaco-editor {
+    display: block;
+    height: 100%;
+  }
+}

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.scss
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.scss
@@ -14,20 +14,30 @@
  * limitations under the License.
  */
 
+@use '../../styles/cpk-fallbacks' as cpk-fallbacks;
+
+// Render correctly even when the shell theme layer is absent.
+:host {
+  @include cpk-fallbacks.light;
+}
+
+:host-context(.dark-theme) {
+  @include cpk-fallbacks.dark;
+}
 :host {
   display: block;
   height: 100%;
   box-sizing: border-box;
-  color: var(--cpk-text-primary);
-  font-family: var(--cpk-font-body);
+  color: var(--cpk-text-primary, var(--cpk-fb-text-primary));
+  font-family: var(--cpk-font-body, var(--cpk-fb-font-body));
 }
 
 .cc-page {
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: var(--cpk-space-4);
-  padding: var(--cpk-space-5);
+  gap: var(--cpk-space-4, var(--cpk-fb-space-4));
+  padding: var(--cpk-space-5, var(--cpk-fb-space-5));
   box-sizing: border-box;
 }
 
@@ -35,12 +45,12 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--cpk-space-5);
+  gap: var(--cpk-space-5, var(--cpk-fb-space-5));
   flex-wrap: wrap;
 }
 
 .cc-title {
-  margin: 0 0 var(--cpk-space-1);
+  margin: 0 0 var(--cpk-space-1, var(--cpk-fb-space-1));
   font-size: 1.5rem;
   font-weight: 600;
 }
@@ -48,33 +58,33 @@
 .cc-subtitle {
   margin: 0;
   max-width: 60ch;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   font-size: 0.875rem;
   line-height: 1.5;
 }
 
 .cc-example-switch {
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-pill);
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-pill, var(--cpk-fb-radius-pill));
   overflow: hidden;
-  background: var(--cpk-surface-elevated);
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
   flex: 0 0 auto;
 
   ::ng-deep .mat-button-toggle-label-content {
     display: inline-flex;
     align-items: center;
-    gap: var(--cpk-space-2);
+    gap: var(--cpk-space-2, var(--cpk-fb-space-2));
     line-height: 36px;
-    padding: 0 var(--cpk-space-4);
+    padding: 0 var(--cpk-space-4, var(--cpk-fb-space-4));
   }
 
   ::ng-deep .mat-button-toggle {
-    color: var(--cpk-text-secondary);
+    color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   }
 
   ::ng-deep .mat-button-toggle-checked {
-    background: var(--cpk-accent-bg);
-    color: var(--cpk-accent);
+    background: var(--cpk-accent-bg, var(--cpk-fb-accent-bg));
+    color: var(--cpk-accent, var(--cpk-fb-accent));
   }
 
   ::ng-deep mat-icon {
@@ -89,7 +99,7 @@
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: var(--cpk-space-4);
+  gap: var(--cpk-space-4, var(--cpk-fb-space-4));
 
   @media (max-width: 900px) {
     grid-template-columns: minmax(0, 1fr);
@@ -103,59 +113,59 @@
   flex-direction: column;
   min-height: 0;
   min-width: 0;
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-lg);
-  background: var(--cpk-surface-elevated);
-  box-shadow: var(--cpk-shadow-card);
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-lg, var(--cpk-fb-radius-lg));
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
+  box-shadow: var(--cpk-shadow-card, var(--cpk-fb-shadow-card));
   overflow: hidden;
 }
 
 .cc-pane-label {
   flex: 0 0 auto;
-  padding: var(--cpk-space-3) var(--cpk-space-4);
-  border-bottom: 1px solid var(--cpk-divider);
+  padding: var(--cpk-space-3, var(--cpk-fb-space-3)) var(--cpk-space-4, var(--cpk-fb-space-4));
+  border-bottom: 1px solid var(--cpk-divider, var(--cpk-fb-divider));
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
 }
 
 .cc-surface-scroll {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: var(--cpk-space-5);
+  padding: var(--cpk-space-5, var(--cpk-fb-space-5));
 }
 
 .cc-data-tabs {
   flex: 0 0 auto;
   display: flex;
-  gap: var(--cpk-space-1);
-  padding: var(--cpk-space-2) var(--cpk-space-3);
-  border-bottom: 1px solid var(--cpk-divider);
+  gap: var(--cpk-space-1, var(--cpk-fb-space-1));
+  padding: var(--cpk-space-2, var(--cpk-fb-space-2)) var(--cpk-space-3, var(--cpk-fb-space-3));
+  border-bottom: 1px solid var(--cpk-divider, var(--cpk-fb-divider));
   overflow-x: auto;
 }
 
 .cc-data-tab {
   flex: 0 0 auto;
-  padding: var(--cpk-space-2) var(--cpk-space-3);
+  padding: var(--cpk-space-2, var(--cpk-fb-space-2)) var(--cpk-space-3, var(--cpk-fb-space-3));
   border: 1px solid transparent;
-  border-radius: var(--cpk-radius-pill);
+  border-radius: var(--cpk-radius-pill, var(--cpk-fb-radius-pill));
   background: transparent;
-  color: var(--cpk-text-secondary);
-  font-family: var(--cpk-font-body);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
+  font-family: var(--cpk-font-body, var(--cpk-fb-font-body));
   font-size: 0.8125rem;
   cursor: pointer;
 
   &:hover {
-    background: var(--cpk-glass-bg-hover);
+    background: var(--cpk-glass-bg-hover, var(--cpk-fb-glass-bg-hover));
   }
 
   &.active {
-    background: var(--cpk-accent-bg);
-    border-color: var(--cpk-accent);
-    color: var(--cpk-accent);
+    background: var(--cpk-accent-bg, var(--cpk-fb-accent-bg));
+    border-color: var(--cpk-accent, var(--cpk-fb-accent));
+    color: var(--cpk-accent, var(--cpk-fb-accent));
     font-weight: 600;
   }
 }

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.spec.ts
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, input, output, provideZonelessChangeDetection} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {A2uiRendererService} from '@a2ui/angular/v0_9';
+import {CustomCatalog} from './custom-catalog';
+import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
+
+// Stub the Monaco editor: the real one loads the Monaco AMD bundle in
+// afterNextRender, which never resolves under jsdom. The stub mirrors the
+// selector + I/O the template binds to.
+@Component({
+  selector: 'a2ui-composer-monaco-editor',
+  standalone: true,
+  template: '',
+})
+class MonacoEditorStub {
+  readonly value = input<string>('');
+  readonly valueChange = output<string>();
+}
+
+// Access protected members without leaking `any` across the file.
+interface CustomCatalogInternals {
+  activeExampleId: () => string;
+  activeStateIndex: () => number;
+  editorValue: () => string;
+  selectExample: (id: string) => void;
+  selectState: (index: number) => void;
+  onEdit: (text: string) => void;
+}
+
+describe('CustomCatalog (Assembled Components)', () => {
+  let fixture: ComponentFixture<CustomCatalog>;
+  let component: CustomCatalogInternals;
+  let renderer: A2uiRendererService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CustomCatalog],
+      providers: [provideZonelessChangeDetection()],
+    })
+      .overrideComponent(CustomCatalog, {
+        remove: {imports: [MonacoEditor]},
+        add: {imports: [MonacoEditorStub]},
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(CustomCatalog);
+    component = fixture.componentInstance as unknown as CustomCatalogInternals;
+    renderer = fixture.debugElement.injector.get(A2uiRendererService);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('opens on the Flight Card example with its first data state', () => {
+    expect(component.activeExampleId()).toBe('flight');
+    expect(component.editorValue()).toContain('United Airlines');
+  });
+
+  it('creates a native surface for the active example', () => {
+    expect(renderer.surfaceGroup.getSurface('flight')).toBeTruthy();
+  });
+
+  it('switches example, builds its surface, and resets to the first data state', () => {
+    component.selectExample('sales');
+    fixture.detectChanges();
+
+    expect(component.activeExampleId()).toBe('sales');
+    expect(component.activeStateIndex()).toBe(0);
+    expect(renderer.surfaceGroup.getSurface('sales')).toBeTruthy();
+    expect(component.editorValue()).toContain('Sales Dashboard');
+  });
+
+  it('switching data state swaps the editor to that state (no surface rebuild)', () => {
+    component.selectExample('sales');
+    fixture.detectChanges();
+    component.selectState(1);
+    fixture.detectChanges();
+
+    expect(component.activeStateIndex()).toBe(1);
+    // Q2 is the second sales data state; the editor reflects it live.
+    expect(component.editorValue()).toContain('Q2');
+  });
+
+  it('ignores invalid JSON edits without throwing, and applies valid ones', () => {
+    expect(() => component.onEdit('not valid json {')).not.toThrow();
+    expect(() => component.onEdit('{"flights": []}')).not.toThrow();
+  });
+});

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.ts
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+  untracked,
+} from '@angular/core';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatIconModule} from '@angular/material/icon';
+import {A2uiRendererService, A2UI_RENDERER_CONFIG, SurfaceComponent} from '@a2ui/angular/v0_9';
+import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
+import {buildDashboardCatalog} from '../catalog/dashboard-catalog';
+import flightSchema from './examples/flight-schema.json';
+import flightData from './examples/flight-data.json';
+import salesSchema from './examples/sales-schema.json';
+import salesData from './examples/sales-data.json';
+
+const CATALOG_ID = 'copilotkit://app-dashboard-catalog';
+
+/** One selectable state of a demo's data model (a right-pane tab). */
+interface DataState {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+/** A demo tree assembled from the custom catalog, with switchable data states. */
+interface Example {
+  id: string;
+  label: string;
+  icon: string;
+  components: unknown[];
+  states: DataState[];
+}
+
+const EXAMPLES: Example[] = [
+  {
+    id: 'flight',
+    label: 'Flight Card',
+    icon: 'flight',
+    components: flightSchema as unknown[],
+    states: flightData as DataState[],
+  },
+  {
+    id: 'sales',
+    label: 'Sales Dashboard',
+    icon: 'insights',
+    components: salesSchema as unknown[],
+    states: salesData as DataState[],
+  },
+];
+
+/**
+ * Assembled Components page. Renders one of two example trees natively via
+ * `@a2ui/angular` (no iframe) from a custom 11-component dashboard catalog, and
+ * lets the user edit the bound data model live. Editing the Monaco JSON pushes
+ * an `updateDataModel` so the surface re-renders through the library binder.
+ */
+@Component({
+  selector: 'a2ui-composer-custom-catalog',
+  standalone: true,
+  imports: [MatButtonToggleModule, MatIconModule, SurfaceComponent, MonacoEditor],
+  templateUrl: './custom-catalog.ng.html',
+  styleUrl: './custom-catalog.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    A2uiRendererService,
+    {
+      provide: A2UI_RENDERER_CONFIG,
+      useFactory: () => ({
+        catalogs: [buildDashboardCatalog()],
+        actionHandler: (action: unknown) => console.info('[custom-catalog] action dispatched', action),
+      }),
+    },
+  ],
+})
+export class CustomCatalog {
+  private readonly renderer = inject(A2uiRendererService);
+  /** Surface ids already created (tree sent), so data changes only push updateDataModel. */
+  private readonly builtSurfaces = new Set<string>();
+
+  protected readonly examples = EXAMPLES;
+  protected readonly activeExampleId = signal<string>(EXAMPLES[0].id);
+  protected readonly activeStateIndex = signal<number>(0);
+  /** JSON text bound to the Monaco editor (reset on example/tab change). */
+  protected readonly editorValue = signal<string>('');
+
+  protected readonly activeExample = computed(
+    () => this.examples.find(e => e.id === this.activeExampleId()) ?? this.examples[0],
+  );
+  protected readonly activeStates = computed(() => this.activeExample().states);
+
+  constructor() {
+    // Re-render the surface whenever the selected example or data state changes,
+    // and reset the editor to that state's data model. Writes here don't feed
+    // the effect (untracked), so this runs once per selection, not per keystroke.
+    effect(() => {
+      const example = this.activeExample();
+      const index = this.activeStateIndex();
+      const data = example.states[index]?.data ?? {};
+      untracked(() => {
+        this.editorValue.set(JSON.stringify(data, null, 2));
+        this.applyData(example, data);
+      });
+    });
+  }
+
+  /**
+   * Ensures the surface for this example is created + populated exactly once
+   * (tree), then pushes the data model. Re-sending `createSurface` for an
+   * already-built surface would leave the view bound to stale state, so data
+   * changes (tab switch, live edit) go through `updateDataModel` alone.
+   */
+  private applyData(example: Example, data: Record<string, unknown>): void {
+    if (!this.builtSurfaces.has(example.id)) {
+      this.renderer.processMessages([
+        {createSurface: {surfaceId: example.id, catalogId: CATALOG_ID}},
+        {updateComponents: {surfaceId: example.id, components: example.components}},
+      ] as never);
+      this.builtSurfaces.add(example.id);
+    }
+    this.renderer.processMessages([
+      {updateDataModel: {surfaceId: example.id, path: '/', op: 'replace', value: data}},
+    ] as never);
+  }
+
+  /** Selects a demo tree, resetting to its first data state. */
+  protected selectExample(id: string): void {
+    if (id === this.activeExampleId()) return;
+    this.activeStateIndex.set(0);
+    this.activeExampleId.set(id);
+  }
+
+  /** Selects one of the active demo's preset data states. */
+  protected selectState(index: number): void {
+    this.activeStateIndex.set(index);
+  }
+
+  /** Live-updates the active surface's data model from edited JSON (ignores invalid JSON). */
+  protected onEdit(text: string): void {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    this.renderer.processMessages([
+      {updateDataModel: {surfaceId: this.activeExampleId(), path: '/', op: 'replace', value: parsed}},
+    ] as never);
+  }
+}

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.ts
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.ts
@@ -153,16 +153,26 @@ export class CustomCatalog {
     this.activeStateIndex.set(index);
   }
 
-  /** Live-updates the active surface's data model from edited JSON (ignores invalid JSON). */
+  /** Live-updates the active surface's data model from edited JSON (ignores invalid or non-object JSON). */
   protected onEdit(text: string): void {
-    let parsed: Record<string, unknown>;
+    let parsed: unknown;
     try {
-      parsed = JSON.parse(text) as Record<string, unknown>;
+      parsed = JSON.parse(text);
     } catch {
       return;
     }
+    // The data model root must be a plain object; a bare array/number/string
+    // (or null) would break the binder, so ignore those edits.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
     this.renderer.processMessages([
-      {updateDataModel: {surfaceId: this.activeExampleId(), path: '/', op: 'replace', value: parsed}},
+      {
+        updateDataModel: {
+          surfaceId: this.activeExampleId(),
+          path: '/',
+          op: 'replace',
+          value: parsed as Record<string, unknown>,
+        },
+      },
     ] as never);
   }
 }

--- a/shell/src/app/custom-catalog/assembled/custom-catalog.ts
+++ b/shell/src/app/custom-catalog/assembled/custom-catalog.ts
@@ -86,7 +86,8 @@ const EXAMPLES: Example[] = [
       provide: A2UI_RENDERER_CONFIG,
       useFactory: () => ({
         catalogs: [buildDashboardCatalog()],
-        actionHandler: (action: unknown) => console.info('[custom-catalog] action dispatched', action),
+        actionHandler: (action: unknown) =>
+          console.info('[custom-catalog] action dispatched', action),
       }),
     },
   ],

--- a/shell/src/app/custom-catalog/assembled/examples/flight-data.json
+++ b/shell/src/app/custom-catalog/assembled/examples/flight-data.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "Morning Flights",
+    "data": {
+      "flights": [
+        {
+          "id": "ua-1201",
+          "airline": "United Airlines",
+          "airlineLogo": "https://www.google.com/s2/favicons?domain=united.com&sz=128",
+          "flightNumber": "UA 1201",
+          "origin": "SFO",
+          "destination": "JFK",
+          "date": "Tue, Mar 18",
+          "departureTime": "08:15",
+          "arrivalTime": "16:40",
+          "duration": "5h 25m",
+          "status": "On Time",
+          "price": "$289"
+        },
+        {
+          "id": "dl-2204",
+          "airline": "Delta Air Lines",
+          "airlineLogo": "https://www.google.com/s2/favicons?domain=delta.com&sz=128",
+          "flightNumber": "DL 2204",
+          "origin": "SFO",
+          "destination": "JFK",
+          "date": "Tue, Mar 18",
+          "departureTime": "10:45",
+          "arrivalTime": "19:30",
+          "duration": "5h 45m",
+          "status": "Delayed",
+          "price": "$312"
+        }
+      ]
+    }
+  },
+  {
+    "name": "Afternoon Flights",
+    "data": {
+      "flights": [
+        {
+          "id": "aa-1140",
+          "airline": "American Airlines",
+          "airlineLogo": "https://www.google.com/s2/favicons?domain=aa.com&sz=128",
+          "flightNumber": "AA 1140",
+          "origin": "SFO",
+          "destination": "JFK",
+          "date": "Tue, Mar 18",
+          "departureTime": "12:20",
+          "arrivalTime": "20:55",
+          "duration": "5h 35m",
+          "status": "On Time",
+          "price": "$298"
+        },
+        {
+          "id": "b6-1218",
+          "airline": "JetBlue Airways",
+          "airlineLogo": "https://www.google.com/s2/favicons?domain=jetblue.com&sz=128",
+          "flightNumber": "B6 1218",
+          "origin": "SFO",
+          "destination": "JFK",
+          "date": "Tue, Mar 18",
+          "departureTime": "14:05",
+          "arrivalTime": "22:30",
+          "duration": "5h 25m",
+          "status": "Boarding",
+          "price": "$264"
+        },
+        {
+          "id": "as-32",
+          "airline": "Alaska Airlines",
+          "airlineLogo": "https://www.google.com/s2/favicons?domain=alaskaair.com&sz=128",
+          "flightNumber": "AS 32",
+          "origin": "SFO",
+          "destination": "JFK",
+          "date": "Tue, Mar 18",
+          "departureTime": "21:30",
+          "arrivalTime": "05:50",
+          "duration": "5h 20m",
+          "status": "On Time",
+          "price": "$276"
+        }
+      ]
+    }
+  }
+]

--- a/shell/src/app/custom-catalog/assembled/examples/flight-schema.json
+++ b/shell/src/app/custom-catalog/assembled/examples/flight-schema.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "root",
+    "component": "Row",
+    "children": {
+      "componentId": "flight-card",
+      "path": "/flights"
+    },
+    "gap": 16,
+    "justify": "center"
+  },
+  {
+    "id": "flight-card",
+    "component": "FlightCard",
+    "airline": { "path": "airline" },
+    "airlineLogo": { "path": "airlineLogo" },
+    "flightNumber": { "path": "flightNumber" },
+    "origin": { "path": "origin" },
+    "destination": { "path": "destination" },
+    "date": { "path": "date" },
+    "departureTime": { "path": "departureTime" },
+    "arrivalTime": { "path": "arrivalTime" },
+    "duration": { "path": "duration" },
+    "status": { "path": "status" },
+    "price": { "path": "price" },
+    "action": {
+      "event": {
+        "name": "book_flight",
+        "context": {
+          "flightNumber": { "path": "flightNumber" },
+          "origin": { "path": "origin" },
+          "destination": { "path": "destination" },
+          "price": { "path": "price" }
+        }
+      }
+    }
+  }
+]

--- a/shell/src/app/custom-catalog/assembled/examples/flight-schema.json
+++ b/shell/src/app/custom-catalog/assembled/examples/flight-schema.json
@@ -12,25 +12,25 @@
   {
     "id": "flight-card",
     "component": "FlightCard",
-    "airline": { "path": "airline" },
-    "airlineLogo": { "path": "airlineLogo" },
-    "flightNumber": { "path": "flightNumber" },
-    "origin": { "path": "origin" },
-    "destination": { "path": "destination" },
-    "date": { "path": "date" },
-    "departureTime": { "path": "departureTime" },
-    "arrivalTime": { "path": "arrivalTime" },
-    "duration": { "path": "duration" },
-    "status": { "path": "status" },
-    "price": { "path": "price" },
+    "airline": {"path": "airline"},
+    "airlineLogo": {"path": "airlineLogo"},
+    "flightNumber": {"path": "flightNumber"},
+    "origin": {"path": "origin"},
+    "destination": {"path": "destination"},
+    "date": {"path": "date"},
+    "departureTime": {"path": "departureTime"},
+    "arrivalTime": {"path": "arrivalTime"},
+    "duration": {"path": "duration"},
+    "status": {"path": "status"},
+    "price": {"path": "price"},
     "action": {
       "event": {
         "name": "book_flight",
         "context": {
-          "flightNumber": { "path": "flightNumber" },
-          "origin": { "path": "origin" },
-          "destination": { "path": "destination" },
-          "price": { "path": "price" }
+          "flightNumber": {"path": "flightNumber"},
+          "origin": {"path": "origin"},
+          "destination": {"path": "destination"},
+          "price": {"path": "price"}
         }
       }
     }

--- a/shell/src/app/custom-catalog/assembled/examples/sales-data.json
+++ b/shell/src/app/custom-catalog/assembled/examples/sales-data.json
@@ -1,0 +1,134 @@
+[
+  {
+    "name": "Q1",
+    "data": {
+      "period": {
+        "title": "Q1 2025 Sales Dashboard",
+        "date_range": "Jan 1 \u2013 Mar 31, 2025"
+      },
+      "kpis": {
+        "revenue":   { "label": "Total", "value": "$980K", "trend": "up",      "trendValue": "+8.5%" },
+        "customers": { "label": "Count", "value": "2,940", "trend": "up",      "trendValue": "+5.2%" },
+        "aov":       { "label": "AOV",   "value": "$333",  "trend": "down",    "trendValue": "-2.1%" },
+        "churn":     { "label": "Rate",  "value": "4.4%",  "trend": "neutral", "trendValue": "+0.3%" }
+      },
+      "revenue_by_region": [
+        { "label": "North America", "value": 58, "color": "#3b82f6" },
+        { "label": "Europe",        "value": 25, "color": "#8b5cf6" },
+        { "label": "APAC",          "value": 12, "color": "#ec4899" },
+        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+      ],
+      "monthly_revenue": [
+        { "label": "Jan", "value": 305 },
+        { "label": "Feb", "value": 320 },
+        { "label": "Mar", "value": 355 }
+      ],
+      "recent_orders": [
+        { "id": "#10112", "customer": "Initrode",     "region": "NA",   "total": "$9,420",  "status": "Paid" },
+        { "id": "#10118", "customer": "Stark Ind.",   "region": "NA",   "total": "$7,880",  "status": "Paid" },
+        { "id": "#10121", "customer": "Massive Dyn.", "region": "EU",   "total": "$5,310",  "status": "Pending" },
+        { "id": "#10127", "customer": "Tyrell Corp",  "region": "APAC", "total": "$4,760",  "status": "Paid" },
+        { "id": "#10133", "customer": "Wayne Ent.",   "region": "NA",   "total": "$3,990",  "status": "Failed" }
+      ]
+    }
+  },
+  {
+    "name": "Q2",
+    "data": {
+      "period": {
+        "title": "Q2 2025 Sales Dashboard",
+        "date_range": "Apr 1 \u2013 Jun 30, 2025"
+      },
+      "kpis": {
+        "revenue":   { "label": "Total", "value": "$1.12M", "trend": "up",      "trendValue": "+14.3%" },
+        "customers": { "label": "Count", "value": "3,160",  "trend": "up",      "trendValue": "+11.8%" },
+        "aov":       { "label": "AOV",   "value": "$354",   "trend": "up",      "trendValue": "+0.4%" },
+        "churn":     { "label": "Rate",  "value": "4.2%",   "trend": "neutral", "trendValue": "\u00b10.0%" }
+      },
+      "revenue_by_region": [
+        { "label": "North America", "value": 54, "color": "#3b82f6" },
+        { "label": "Europe",        "value": 27, "color": "#8b5cf6" },
+        { "label": "APAC",          "value": 14, "color": "#ec4899" },
+        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+      ],
+      "monthly_revenue": [
+        { "label": "Apr", "value": 360 },
+        { "label": "May", "value": 370 },
+        { "label": "Jun", "value": 390 }
+      ],
+      "recent_orders": [
+        { "id": "#10284", "customer": "Acme Corp",   "region": "NA",   "total": "$11,200", "status": "Paid" },
+        { "id": "#10292", "customer": "Globex",      "region": "EU",   "total": "$7,640",  "status": "Paid" },
+        { "id": "#10301", "customer": "Cyberdyne",   "region": "APAC", "total": "$6,480",  "status": "Pending" },
+        { "id": "#10308", "customer": "Pied Piper",  "region": "NA",   "total": "$5,120",  "status": "Paid" },
+        { "id": "#10314", "customer": "Soylent Co.", "region": "NA",   "total": "$4,830",  "status": "Paid" }
+      ]
+    }
+  },
+  {
+    "name": "Q3",
+    "data": {
+      "period": {
+        "title": "Q3 2025 Sales Dashboard",
+        "date_range": "Jul 1 \u2013 Sep 30, 2025"
+      },
+      "kpis": {
+        "revenue":   { "label": "Total", "value": "$1.24M", "trend": "up",      "trendValue": "+19.2%" },
+        "customers": { "label": "Count", "value": "3,258",  "trend": "up",      "trendValue": "+15.7%" },
+        "aov":       { "label": "AOV",   "value": "$380",   "trend": "up",      "trendValue": "+1.2%" },
+        "churn":     { "label": "Rate",  "value": "4.1%",   "trend": "neutral", "trendValue": "-0.2%" }
+      },
+      "revenue_by_region": [
+        { "label": "North America", "value": 51, "color": "#3b82f6" },
+        { "label": "Europe",        "value": 28, "color": "#8b5cf6" },
+        { "label": "APAC",          "value": 16, "color": "#ec4899" },
+        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+      ],
+      "monthly_revenue": [
+        { "label": "Jul", "value": 395 },
+        { "label": "Aug", "value": 415 },
+        { "label": "Sep", "value": 430 }
+      ],
+      "recent_orders": [
+        { "id": "#10402", "customer": "Hooli",       "region": "NA",   "total": "$13,880", "status": "Paid" },
+        { "id": "#10411", "customer": "Oscorp",      "region": "EU",   "total": "$9,050",  "status": "Paid" },
+        { "id": "#10418", "customer": "LexCorp",     "region": "NA",   "total": "$7,320",  "status": "Pending" },
+        { "id": "#10425", "customer": "Aperture",    "region": "NA",   "total": "$6,110",  "status": "Paid" },
+        { "id": "#10429", "customer": "Weyland-Y.",  "region": "APAC", "total": "$4,950",  "status": "Failed" }
+      ]
+    }
+  },
+  {
+    "name": "Q4",
+    "data": {
+      "period": {
+        "title": "Q4 2025 Sales Dashboard",
+        "date_range": "Oct 1 \u2013 Dec 31, 2025"
+      },
+      "kpis": {
+        "revenue":   { "label": "Total", "value": "$1.28M", "trend": "up",      "trendValue": "+12.4%" },
+        "customers": { "label": "Count", "value": "3,482",  "trend": "up",      "trendValue": "+8.1%" },
+        "aov":       { "label": "AOV",   "value": "$367",   "trend": "down",    "trendValue": "-2.3%" },
+        "churn":     { "label": "Rate",  "value": "4.0%",   "trend": "neutral", "trendValue": "\u00b10.0%" }
+      },
+      "revenue_by_region": [
+        { "label": "North America", "value": 48, "color": "#3b82f6" },
+        { "label": "Europe",        "value": 29, "color": "#8b5cf6" },
+        { "label": "APAC",          "value": 18, "color": "#ec4899" },
+        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+      ],
+      "monthly_revenue": [
+        { "label": "Oct", "value": 410 },
+        { "label": "Nov", "value": 425 },
+        { "label": "Dec", "value": 445 }
+      ],
+      "recent_orders": [
+        { "id": "#10482", "customer": "Acme Corp",     "region": "NA",   "total": "$12,480", "status": "Paid" },
+        { "id": "#10483", "customer": "Globex",        "region": "EU",   "total": "$8,320",  "status": "Paid" },
+        { "id": "#10484", "customer": "Initech",       "region": "NA",   "total": "$6,150",  "status": "Pending" },
+        { "id": "#10485", "customer": "Hooli",         "region": "NA",   "total": "$5,940",  "status": "Paid" },
+        { "id": "#10486", "customer": "Umbrella Corp", "region": "APAC", "total": "$4,220",  "status": "Failed" }
+      ]
+    }
+  }
+]

--- a/shell/src/app/custom-catalog/assembled/examples/sales-data.json
+++ b/shell/src/app/custom-catalog/assembled/examples/sales-data.json
@@ -7,28 +7,58 @@
         "date_range": "Jan 1 \u2013 Mar 31, 2025"
       },
       "kpis": {
-        "revenue":   { "label": "Total", "value": "$980K", "trend": "up",      "trendValue": "+8.5%" },
-        "customers": { "label": "Count", "value": "2,940", "trend": "up",      "trendValue": "+5.2%" },
-        "aov":       { "label": "AOV",   "value": "$333",  "trend": "down",    "trendValue": "-2.1%" },
-        "churn":     { "label": "Rate",  "value": "4.4%",  "trend": "neutral", "trendValue": "+0.3%" }
+        "revenue": {"label": "Total", "value": "$980K", "trend": "up", "trendValue": "+8.5%"},
+        "customers": {"label": "Count", "value": "2,940", "trend": "up", "trendValue": "+5.2%"},
+        "aov": {"label": "AOV", "value": "$333", "trend": "down", "trendValue": "-2.1%"},
+        "churn": {"label": "Rate", "value": "4.4%", "trend": "neutral", "trendValue": "+0.3%"}
       },
       "revenue_by_region": [
-        { "label": "North America", "value": 58, "color": "#3b82f6" },
-        { "label": "Europe",        "value": 25, "color": "#8b5cf6" },
-        { "label": "APAC",          "value": 12, "color": "#ec4899" },
-        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+        {"label": "North America", "value": 58, "color": "#3b82f6"},
+        {"label": "Europe", "value": 25, "color": "#8b5cf6"},
+        {"label": "APAC", "value": 12, "color": "#ec4899"},
+        {"label": "LATAM", "value": 5, "color": "#f59e0b"}
       ],
       "monthly_revenue": [
-        { "label": "Jan", "value": 305 },
-        { "label": "Feb", "value": 320 },
-        { "label": "Mar", "value": 355 }
+        {"label": "Jan", "value": 305},
+        {"label": "Feb", "value": 320},
+        {"label": "Mar", "value": 355}
       ],
       "recent_orders": [
-        { "id": "#10112", "customer": "Initrode",     "region": "NA",   "total": "$9,420",  "status": "Paid" },
-        { "id": "#10118", "customer": "Stark Ind.",   "region": "NA",   "total": "$7,880",  "status": "Paid" },
-        { "id": "#10121", "customer": "Massive Dyn.", "region": "EU",   "total": "$5,310",  "status": "Pending" },
-        { "id": "#10127", "customer": "Tyrell Corp",  "region": "APAC", "total": "$4,760",  "status": "Paid" },
-        { "id": "#10133", "customer": "Wayne Ent.",   "region": "NA",   "total": "$3,990",  "status": "Failed" }
+        {
+          "id": "#10112",
+          "customer": "Initrode",
+          "region": "NA",
+          "total": "$9,420",
+          "status": "Paid"
+        },
+        {
+          "id": "#10118",
+          "customer": "Stark Ind.",
+          "region": "NA",
+          "total": "$7,880",
+          "status": "Paid"
+        },
+        {
+          "id": "#10121",
+          "customer": "Massive Dyn.",
+          "region": "EU",
+          "total": "$5,310",
+          "status": "Pending"
+        },
+        {
+          "id": "#10127",
+          "customer": "Tyrell Corp",
+          "region": "APAC",
+          "total": "$4,760",
+          "status": "Paid"
+        },
+        {
+          "id": "#10133",
+          "customer": "Wayne Ent.",
+          "region": "NA",
+          "total": "$3,990",
+          "status": "Failed"
+        }
       ]
     }
   },
@@ -40,28 +70,52 @@
         "date_range": "Apr 1 \u2013 Jun 30, 2025"
       },
       "kpis": {
-        "revenue":   { "label": "Total", "value": "$1.12M", "trend": "up",      "trendValue": "+14.3%" },
-        "customers": { "label": "Count", "value": "3,160",  "trend": "up",      "trendValue": "+11.8%" },
-        "aov":       { "label": "AOV",   "value": "$354",   "trend": "up",      "trendValue": "+0.4%" },
-        "churn":     { "label": "Rate",  "value": "4.2%",   "trend": "neutral", "trendValue": "\u00b10.0%" }
+        "revenue": {"label": "Total", "value": "$1.12M", "trend": "up", "trendValue": "+14.3%"},
+        "customers": {"label": "Count", "value": "3,160", "trend": "up", "trendValue": "+11.8%"},
+        "aov": {"label": "AOV", "value": "$354", "trend": "up", "trendValue": "+0.4%"},
+        "churn": {"label": "Rate", "value": "4.2%", "trend": "neutral", "trendValue": "\u00b10.0%"}
       },
       "revenue_by_region": [
-        { "label": "North America", "value": 54, "color": "#3b82f6" },
-        { "label": "Europe",        "value": 27, "color": "#8b5cf6" },
-        { "label": "APAC",          "value": 14, "color": "#ec4899" },
-        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+        {"label": "North America", "value": 54, "color": "#3b82f6"},
+        {"label": "Europe", "value": 27, "color": "#8b5cf6"},
+        {"label": "APAC", "value": 14, "color": "#ec4899"},
+        {"label": "LATAM", "value": 5, "color": "#f59e0b"}
       ],
       "monthly_revenue": [
-        { "label": "Apr", "value": 360 },
-        { "label": "May", "value": 370 },
-        { "label": "Jun", "value": 390 }
+        {"label": "Apr", "value": 360},
+        {"label": "May", "value": 370},
+        {"label": "Jun", "value": 390}
       ],
       "recent_orders": [
-        { "id": "#10284", "customer": "Acme Corp",   "region": "NA",   "total": "$11,200", "status": "Paid" },
-        { "id": "#10292", "customer": "Globex",      "region": "EU",   "total": "$7,640",  "status": "Paid" },
-        { "id": "#10301", "customer": "Cyberdyne",   "region": "APAC", "total": "$6,480",  "status": "Pending" },
-        { "id": "#10308", "customer": "Pied Piper",  "region": "NA",   "total": "$5,120",  "status": "Paid" },
-        { "id": "#10314", "customer": "Soylent Co.", "region": "NA",   "total": "$4,830",  "status": "Paid" }
+        {
+          "id": "#10284",
+          "customer": "Acme Corp",
+          "region": "NA",
+          "total": "$11,200",
+          "status": "Paid"
+        },
+        {"id": "#10292", "customer": "Globex", "region": "EU", "total": "$7,640", "status": "Paid"},
+        {
+          "id": "#10301",
+          "customer": "Cyberdyne",
+          "region": "APAC",
+          "total": "$6,480",
+          "status": "Pending"
+        },
+        {
+          "id": "#10308",
+          "customer": "Pied Piper",
+          "region": "NA",
+          "total": "$5,120",
+          "status": "Paid"
+        },
+        {
+          "id": "#10314",
+          "customer": "Soylent Co.",
+          "region": "NA",
+          "total": "$4,830",
+          "status": "Paid"
+        }
       ]
     }
   },
@@ -73,28 +127,46 @@
         "date_range": "Jul 1 \u2013 Sep 30, 2025"
       },
       "kpis": {
-        "revenue":   { "label": "Total", "value": "$1.24M", "trend": "up",      "trendValue": "+19.2%" },
-        "customers": { "label": "Count", "value": "3,258",  "trend": "up",      "trendValue": "+15.7%" },
-        "aov":       { "label": "AOV",   "value": "$380",   "trend": "up",      "trendValue": "+1.2%" },
-        "churn":     { "label": "Rate",  "value": "4.1%",   "trend": "neutral", "trendValue": "-0.2%" }
+        "revenue": {"label": "Total", "value": "$1.24M", "trend": "up", "trendValue": "+19.2%"},
+        "customers": {"label": "Count", "value": "3,258", "trend": "up", "trendValue": "+15.7%"},
+        "aov": {"label": "AOV", "value": "$380", "trend": "up", "trendValue": "+1.2%"},
+        "churn": {"label": "Rate", "value": "4.1%", "trend": "neutral", "trendValue": "-0.2%"}
       },
       "revenue_by_region": [
-        { "label": "North America", "value": 51, "color": "#3b82f6" },
-        { "label": "Europe",        "value": 28, "color": "#8b5cf6" },
-        { "label": "APAC",          "value": 16, "color": "#ec4899" },
-        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+        {"label": "North America", "value": 51, "color": "#3b82f6"},
+        {"label": "Europe", "value": 28, "color": "#8b5cf6"},
+        {"label": "APAC", "value": 16, "color": "#ec4899"},
+        {"label": "LATAM", "value": 5, "color": "#f59e0b"}
       ],
       "monthly_revenue": [
-        { "label": "Jul", "value": 395 },
-        { "label": "Aug", "value": 415 },
-        { "label": "Sep", "value": 430 }
+        {"label": "Jul", "value": 395},
+        {"label": "Aug", "value": 415},
+        {"label": "Sep", "value": 430}
       ],
       "recent_orders": [
-        { "id": "#10402", "customer": "Hooli",       "region": "NA",   "total": "$13,880", "status": "Paid" },
-        { "id": "#10411", "customer": "Oscorp",      "region": "EU",   "total": "$9,050",  "status": "Paid" },
-        { "id": "#10418", "customer": "LexCorp",     "region": "NA",   "total": "$7,320",  "status": "Pending" },
-        { "id": "#10425", "customer": "Aperture",    "region": "NA",   "total": "$6,110",  "status": "Paid" },
-        { "id": "#10429", "customer": "Weyland-Y.",  "region": "APAC", "total": "$4,950",  "status": "Failed" }
+        {"id": "#10402", "customer": "Hooli", "region": "NA", "total": "$13,880", "status": "Paid"},
+        {"id": "#10411", "customer": "Oscorp", "region": "EU", "total": "$9,050", "status": "Paid"},
+        {
+          "id": "#10418",
+          "customer": "LexCorp",
+          "region": "NA",
+          "total": "$7,320",
+          "status": "Pending"
+        },
+        {
+          "id": "#10425",
+          "customer": "Aperture",
+          "region": "NA",
+          "total": "$6,110",
+          "status": "Paid"
+        },
+        {
+          "id": "#10429",
+          "customer": "Weyland-Y.",
+          "region": "APAC",
+          "total": "$4,950",
+          "status": "Failed"
+        }
       ]
     }
   },
@@ -106,28 +178,46 @@
         "date_range": "Oct 1 \u2013 Dec 31, 2025"
       },
       "kpis": {
-        "revenue":   { "label": "Total", "value": "$1.28M", "trend": "up",      "trendValue": "+12.4%" },
-        "customers": { "label": "Count", "value": "3,482",  "trend": "up",      "trendValue": "+8.1%" },
-        "aov":       { "label": "AOV",   "value": "$367",   "trend": "down",    "trendValue": "-2.3%" },
-        "churn":     { "label": "Rate",  "value": "4.0%",   "trend": "neutral", "trendValue": "\u00b10.0%" }
+        "revenue": {"label": "Total", "value": "$1.28M", "trend": "up", "trendValue": "+12.4%"},
+        "customers": {"label": "Count", "value": "3,482", "trend": "up", "trendValue": "+8.1%"},
+        "aov": {"label": "AOV", "value": "$367", "trend": "down", "trendValue": "-2.3%"},
+        "churn": {"label": "Rate", "value": "4.0%", "trend": "neutral", "trendValue": "\u00b10.0%"}
       },
       "revenue_by_region": [
-        { "label": "North America", "value": 48, "color": "#3b82f6" },
-        { "label": "Europe",        "value": 29, "color": "#8b5cf6" },
-        { "label": "APAC",          "value": 18, "color": "#ec4899" },
-        { "label": "LATAM",         "value": 5,  "color": "#f59e0b" }
+        {"label": "North America", "value": 48, "color": "#3b82f6"},
+        {"label": "Europe", "value": 29, "color": "#8b5cf6"},
+        {"label": "APAC", "value": 18, "color": "#ec4899"},
+        {"label": "LATAM", "value": 5, "color": "#f59e0b"}
       ],
       "monthly_revenue": [
-        { "label": "Oct", "value": 410 },
-        { "label": "Nov", "value": 425 },
-        { "label": "Dec", "value": 445 }
+        {"label": "Oct", "value": 410},
+        {"label": "Nov", "value": 425},
+        {"label": "Dec", "value": 445}
       ],
       "recent_orders": [
-        { "id": "#10482", "customer": "Acme Corp",     "region": "NA",   "total": "$12,480", "status": "Paid" },
-        { "id": "#10483", "customer": "Globex",        "region": "EU",   "total": "$8,320",  "status": "Paid" },
-        { "id": "#10484", "customer": "Initech",       "region": "NA",   "total": "$6,150",  "status": "Pending" },
-        { "id": "#10485", "customer": "Hooli",         "region": "NA",   "total": "$5,940",  "status": "Paid" },
-        { "id": "#10486", "customer": "Umbrella Corp", "region": "APAC", "total": "$4,220",  "status": "Failed" }
+        {
+          "id": "#10482",
+          "customer": "Acme Corp",
+          "region": "NA",
+          "total": "$12,480",
+          "status": "Paid"
+        },
+        {"id": "#10483", "customer": "Globex", "region": "EU", "total": "$8,320", "status": "Paid"},
+        {
+          "id": "#10484",
+          "customer": "Initech",
+          "region": "NA",
+          "total": "$6,150",
+          "status": "Pending"
+        },
+        {"id": "#10485", "customer": "Hooli", "region": "NA", "total": "$5,940", "status": "Paid"},
+        {
+          "id": "#10486",
+          "customer": "Umbrella Corp",
+          "region": "APAC",
+          "total": "$4,220",
+          "status": "Failed"
+        }
       ]
     }
   }

--- a/shell/src/app/custom-catalog/assembled/examples/sales-schema.json
+++ b/shell/src/app/custom-catalog/assembled/examples/sales-schema.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "root",
+    "component": "Column",
+    "gap": 20,
+    "children": ["hero", "kpi-row", "charts-row", "orders-card"]
+  },
+
+  {
+    "id": "hero",
+    "component": "Column",
+    "gap": 4,
+    "children": ["hero-title", "hero-sub"]
+  },
+  {
+    "id": "hero-title",
+    "component": "Title",
+    "text": { "path": "/period/title" },
+    "level": "h1"
+  },
+  {
+    "id": "hero-sub",
+    "component": "Title",
+    "text": { "path": "/period/date_range" },
+    "level": "h3"
+  },
+
+  {
+    "id": "kpi-row",
+    "component": "Row",
+    "gap": 16,
+    "children": ["card-revenue", "card-customers", "card-aov", "card-churn"]
+  },
+
+  {
+    "id": "card-revenue",
+    "component": "DashboardCard",
+    "title": "Revenue",
+    "subtitle": "Quarter-to-date",
+    "child": "metric-revenue"
+  },
+  {
+    "id": "metric-revenue",
+    "component": "Metric",
+    "label":      { "path": "/kpis/revenue/label" },
+    "value":      { "path": "/kpis/revenue/value" },
+    "trendValue": { "path": "/kpis/revenue/trendValue" },
+    "trend": "up"
+  },
+
+  {
+    "id": "card-customers",
+    "component": "DashboardCard",
+    "title": "New customers",
+    "subtitle": "vs. last year",
+    "child": "metric-customers"
+  },
+  {
+    "id": "metric-customers",
+    "component": "Metric",
+    "label":      { "path": "/kpis/customers/label" },
+    "value":      { "path": "/kpis/customers/value" },
+    "trendValue": { "path": "/kpis/customers/trendValue" },
+    "trend": "up"
+  },
+
+  {
+    "id": "card-aov",
+    "component": "DashboardCard",
+    "title": "Avg order value",
+    "subtitle": "vs. last year",
+    "child": "metric-aov"
+  },
+  {
+    "id": "metric-aov",
+    "component": "Metric",
+    "label":      { "path": "/kpis/aov/label" },
+    "value":      { "path": "/kpis/aov/value" },
+    "trendValue": { "path": "/kpis/aov/trendValue" },
+    "trend": "down"
+  },
+
+  {
+    "id": "card-churn",
+    "component": "DashboardCard",
+    "title": "Churn",
+    "subtitle": "Monthly average",
+    "child": "metric-churn"
+  },
+  {
+    "id": "metric-churn",
+    "component": "Metric",
+    "label":      { "path": "/kpis/churn/label" },
+    "value":      { "path": "/kpis/churn/value" },
+    "trendValue": { "path": "/kpis/churn/trendValue" },
+    "trend": "neutral"
+  },
+
+  {
+    "id": "charts-row",
+    "component": "Row",
+    "gap": 16,
+    "children": ["card-region", "card-monthly"]
+  },
+  {
+    "id": "card-region",
+    "component": "DashboardCard",
+    "title": "Revenue by region",
+    "subtitle": "Share of total",
+    "child": "pie-region"
+  },
+  {
+    "id": "pie-region",
+    "component": "PieChart",
+    "data": { "path": "/revenue_by_region" }
+  },
+  {
+    "id": "card-monthly",
+    "component": "DashboardCard",
+    "title": "Monthly revenue",
+    "subtitle": "Months in this quarter",
+    "child": "bar-monthly"
+  },
+  {
+    "id": "bar-monthly",
+    "component": "BarChart",
+    "data": { "path": "/monthly_revenue" },
+    "color": "#10b981",
+    "valuePrefix": "$",
+    "valueSuffix": "K"
+  },
+
+  {
+    "id": "orders-card",
+    "component": "DashboardCard",
+    "title": "Recent orders",
+    "subtitle": "Top 5 by value this week",
+    "child": "orders-table"
+  },
+  {
+    "id": "orders-table",
+    "component": "DataTable",
+    "columns": [
+      { "key": "id",       "label": "Order" },
+      { "key": "customer", "label": "Customer" },
+      { "key": "region",   "label": "Region" },
+      { "key": "total",    "label": "Total" },
+      { "key": "status",   "label": "Status" }
+    ],
+    "rows": [
+      { "id": "#10482", "customer": "Acme Corp",     "region": "NA",   "total": "$12,480", "status": "Paid" },
+      { "id": "#10483", "customer": "Globex",        "region": "EU",   "total": "$8,320",  "status": "Paid" },
+      { "id": "#10484", "customer": "Initech",       "region": "NA",   "total": "$6,150",  "status": "Pending" },
+      { "id": "#10485", "customer": "Hooli",         "region": "NA",   "total": "$5,940",  "status": "Paid" },
+      { "id": "#10486", "customer": "Umbrella Corp", "region": "APAC", "total": "$4,220",  "status": "Failed" }
+    ]
+  }
+]

--- a/shell/src/app/custom-catalog/assembled/examples/sales-schema.json
+++ b/shell/src/app/custom-catalog/assembled/examples/sales-schema.json
@@ -15,13 +15,13 @@
   {
     "id": "hero-title",
     "component": "Title",
-    "text": { "path": "/period/title" },
+    "text": {"path": "/period/title"},
     "level": "h1"
   },
   {
     "id": "hero-sub",
     "component": "Title",
-    "text": { "path": "/period/date_range" },
+    "text": {"path": "/period/date_range"},
     "level": "h3"
   },
 
@@ -42,9 +42,9 @@
   {
     "id": "metric-revenue",
     "component": "Metric",
-    "label":      { "path": "/kpis/revenue/label" },
-    "value":      { "path": "/kpis/revenue/value" },
-    "trendValue": { "path": "/kpis/revenue/trendValue" },
+    "label": {"path": "/kpis/revenue/label"},
+    "value": {"path": "/kpis/revenue/value"},
+    "trendValue": {"path": "/kpis/revenue/trendValue"},
     "trend": "up"
   },
 
@@ -58,9 +58,9 @@
   {
     "id": "metric-customers",
     "component": "Metric",
-    "label":      { "path": "/kpis/customers/label" },
-    "value":      { "path": "/kpis/customers/value" },
-    "trendValue": { "path": "/kpis/customers/trendValue" },
+    "label": {"path": "/kpis/customers/label"},
+    "value": {"path": "/kpis/customers/value"},
+    "trendValue": {"path": "/kpis/customers/trendValue"},
     "trend": "up"
   },
 
@@ -74,9 +74,9 @@
   {
     "id": "metric-aov",
     "component": "Metric",
-    "label":      { "path": "/kpis/aov/label" },
-    "value":      { "path": "/kpis/aov/value" },
-    "trendValue": { "path": "/kpis/aov/trendValue" },
+    "label": {"path": "/kpis/aov/label"},
+    "value": {"path": "/kpis/aov/value"},
+    "trendValue": {"path": "/kpis/aov/trendValue"},
     "trend": "down"
   },
 
@@ -90,9 +90,9 @@
   {
     "id": "metric-churn",
     "component": "Metric",
-    "label":      { "path": "/kpis/churn/label" },
-    "value":      { "path": "/kpis/churn/value" },
-    "trendValue": { "path": "/kpis/churn/trendValue" },
+    "label": {"path": "/kpis/churn/label"},
+    "value": {"path": "/kpis/churn/value"},
+    "trendValue": {"path": "/kpis/churn/trendValue"},
     "trend": "neutral"
   },
 
@@ -112,7 +112,7 @@
   {
     "id": "pie-region",
     "component": "PieChart",
-    "data": { "path": "/revenue_by_region" }
+    "data": {"path": "/revenue_by_region"}
   },
   {
     "id": "card-monthly",
@@ -124,7 +124,7 @@
   {
     "id": "bar-monthly",
     "component": "BarChart",
-    "data": { "path": "/monthly_revenue" },
+    "data": {"path": "/monthly_revenue"},
     "color": "#10b981",
     "valuePrefix": "$",
     "valueSuffix": "K"
@@ -141,18 +141,36 @@
     "id": "orders-table",
     "component": "DataTable",
     "columns": [
-      { "key": "id",       "label": "Order" },
-      { "key": "customer", "label": "Customer" },
-      { "key": "region",   "label": "Region" },
-      { "key": "total",    "label": "Total" },
-      { "key": "status",   "label": "Status" }
+      {"key": "id", "label": "Order"},
+      {"key": "customer", "label": "Customer"},
+      {"key": "region", "label": "Region"},
+      {"key": "total", "label": "Total"},
+      {"key": "status", "label": "Status"}
     ],
     "rows": [
-      { "id": "#10482", "customer": "Acme Corp",     "region": "NA",   "total": "$12,480", "status": "Paid" },
-      { "id": "#10483", "customer": "Globex",        "region": "EU",   "total": "$8,320",  "status": "Paid" },
-      { "id": "#10484", "customer": "Initech",       "region": "NA",   "total": "$6,150",  "status": "Pending" },
-      { "id": "#10485", "customer": "Hooli",         "region": "NA",   "total": "$5,940",  "status": "Paid" },
-      { "id": "#10486", "customer": "Umbrella Corp", "region": "APAC", "total": "$4,220",  "status": "Failed" }
+      {
+        "id": "#10482",
+        "customer": "Acme Corp",
+        "region": "NA",
+        "total": "$12,480",
+        "status": "Paid"
+      },
+      {"id": "#10483", "customer": "Globex", "region": "EU", "total": "$8,320", "status": "Paid"},
+      {
+        "id": "#10484",
+        "customer": "Initech",
+        "region": "NA",
+        "total": "$6,150",
+        "status": "Pending"
+      },
+      {"id": "#10485", "customer": "Hooli", "region": "NA", "total": "$5,940", "status": "Paid"},
+      {
+        "id": "#10486",
+        "customer": "Umbrella Corp",
+        "region": "APAC",
+        "total": "$4,220",
+        "status": "Failed"
+      }
     ]
   }
 ]

--- a/shell/src/app/custom-catalog/catalog/apis.ts
+++ b/shell/src/app/custom-catalog/catalog/apis.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Flight & Dashboard catalog — `ComponentApi` definitions.
+ *
+ * This catalog assembles two different example trees from the same 11
+ * definitions below:
+ *
+ *   • **Flight Card** — `Row` template-children expand one `FlightCard` per
+ *     element of `/flights`, with each instance's `{ path: … }` bindings
+ *     scoped to its flight. Exercises repeater + action dispatch.
+ *   • **Sales Dashboard** — `DashboardCard`s wrap `Metric`s and charts into
+ *     a KPI grid. Scalar props (titles, KPI labels/values) bind to
+ *     `/period` + `/kpis`; chart data and table rows are inline literals.
+ *
+ * ── What is A2UI? ──────────────────────────────────────────────────────────
+ * A2UI ("Agent-to-UI") is a protocol that lets an LLM agent drive a real UI
+ * by emitting a tree of typed components instead of raw HTML or a single text
+ * blob. The frontend ships a **catalog** of components the agent is allowed
+ * to use; the agent emits JSON describing which components to render, how
+ * they nest, and how they bind to data. The frontend renders them.
+ *
+ * ── What is a ComponentApi? ────────────────────────────────────────────────
+ * It's the contract between the agent and the frontend for a single
+ * component: a `name` the agent writes in the JSON tree, and a zod `schema`
+ * that describes the legal props. At runtime the renderer's `GenericBinder`
+ * uses this schema to resolve path bindings → strings and action unions →
+ * callables before handing `props` to your React code.
+ *
+ * The shared helpers `DynamicStringSchema`, `ChildListSchema`, `ActionSchema`,
+ * and `ComponentIdSchema` come straight from the basic catalog so this custom
+ * catalog inherits identical binding semantics — path bindings, template
+ * children, and action dispatch all Just Work.
+ */
+import {z} from 'zod';
+import type {ComponentApi} from '@a2ui/web_core/v0_9';
+import {
+  // `{ event: { name, context? } } | null` — at runtime the binder resolves
+  // `context` path bindings and hands the renderer a `() => void` callable.
+  ActionSchema,
+  // Either `string[]` (static child IDs) or `{ componentId, path }` template
+  // that repeats one child per element of the bound data-model array.
+  ChildListSchema,
+  // A plain string that must match a sibling component's `id`.
+  ComponentIdSchema,
+  // Either a literal string or `{ path }` | `{ call, args, returnType }`.
+  // The binder resolves these to plain strings before render.
+  DynamicStringSchema,
+  // Either a literal (string/number/boolean/array) or `{ path }` | `{ call }`.
+  // The binder flags any union containing `{ path }` as DYNAMIC and resolves
+  // it to the raw value at render — which is how chart `data` props can bind
+  // to an array in the data model.
+  DynamicValueSchema,
+} from '@a2ui/web_core/v0_9';
+
+/** Shorthand for any prop that should accept an agent's `{ path }` binding. */
+const DynString = DynamicStringSchema;
+
+/**
+ * A plain heading. `text` is a `DynString` so the agent can pass either a
+ * literal or a `{ path }` binding — this is what lets the Sales Dashboard's
+ * hero title read from `/period/title` in the data model, for example.
+ */
+export const TitleApi = {
+  name: 'Title',
+  schema: z
+    .object({
+      text: DynString,
+      level: z.enum(['h1', 'h2', 'h3']).optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * Horizontal layout container.
+ *
+ * `children: ChildListSchema` is the key to v0.9 **template children**:
+ * the agent can pass either a static `["card-1", "card-2"]` array OR a
+ * template like `{ componentId: "flight-card", path: "/flights" }`. In the
+ * template case, the binder expands the single child component into one
+ * instance per element of the bound array, automatically scoping each
+ * instance's path bindings to `/flights[i]`.
+ */
+export const RowApi = {
+  name: 'Row',
+  schema: z
+    .object({
+      children: ChildListSchema,
+      gap: z.number().optional(),
+      align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
+      justify: z
+        .enum(['start', 'center', 'end', 'spaceBetween', 'spaceAround', 'spaceEvenly', 'stretch'])
+        .optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/** Vertical layout container. Same template-children semantics as Row. */
+export const ColumnApi = {
+  name: 'Column',
+  schema: z
+    .object({
+      children: ChildListSchema,
+      gap: z.number().optional(),
+      align: z.enum(['start', 'center', 'end', 'stretch']).optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * A titled card with a single `child` slot. `child: ComponentIdSchema` means
+ * the agent sends the *ID* of another component in the tree — the renderer
+ * resolves it via `buildChild(props.child)`. This is how you keep the tree
+ * flat (every component is a top-level entry with a stable `id`) while
+ * still expressing nested layouts.
+ */
+export const DashboardCardApi = {
+  name: 'DashboardCard',
+  schema: z
+    .object({
+      title: DynString,
+      subtitle: DynString.optional(),
+      child: ComponentIdSchema.optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * A KPI stat block. `value` / `trendValue` are `DynString` so the Sales
+ * Dashboard can drive each metric from `/kpis/*` in the data model while
+ * still letting the agent pass plain strings for the fixed bits.
+ */
+export const MetricApi = {
+  name: 'Metric',
+  schema: z
+    .object({
+      label: DynString,
+      value: DynString,
+      trend: z.enum(['up', 'down', 'neutral']).optional(),
+      trendValue: DynString.optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * Chart data props use `DynamicValueSchema` so the agent can either pass an
+ * inline literal array or a `{ path }` binding into the data model. Per-item
+ * shape (label/value, optional color) is the renderer's contract; we document
+ * it in the renderer rather than encoding it in the schema so the binding
+ * stays transparent.
+ */
+export const PieChartApi = {
+  name: 'PieChart',
+  schema: z
+    .object({
+      data: DynamicValueSchema,
+      innerRadius: z.number().optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * `valuePrefix` / `valueSuffix` are optional formatters applied to the Y
+ * axis and tooltip numbers — e.g. the Sales Dashboard's monthly revenue
+ * chart uses `{ valuePrefix: "$", valueSuffix: "K" }` to render a bar value
+ * of `305` as `"$305K"` without having to change the underlying data shape.
+ */
+export const BarChartApi = {
+  name: 'BarChart',
+  schema: z
+    .object({
+      data: DynamicValueSchema,
+      color: z.string().optional(),
+      valuePrefix: z.string().optional(),
+      valueSuffix: z.string().optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+export const BadgeApi = {
+  name: 'Badge',
+  schema: z
+    .object({
+      text: z.string(),
+      variant: z.enum(['success', 'warning', 'error', 'info', 'neutral']).optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+export const DataTableApi = {
+  name: 'DataTable',
+  schema: z
+    .object({
+      columns: z.array(z.object({key: z.string(), label: z.string()}).strict()),
+      rows: z.array(z.record(z.string(), z.any())),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * Interactive button. `action: ActionSchema` is how v0.9 wires user events
+ * back to the agent: the agent emits `{ event: { name, context } }`, and at
+ * render time the binder hands the React component `props.action` as a
+ * **pre-wired `() => void` callable**. Calling it dispatches the event
+ * (along with the resolved context values) back to the host.
+ */
+export const ButtonApi = {
+  name: 'Button',
+  schema: z
+    .object({
+      child: ComponentIdSchema,
+      variant: z.enum(['primary', 'secondary', 'ghost']).optional(),
+      action: ActionSchema.optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;
+
+/**
+ * A rich flight-result card — the showcase component for the Flight Card
+ * example.
+ *
+ * Every string prop is `DynString`, so the agent can either pass literals
+ * ("SFO") or path bindings (`{ path: "origin" }`) that the binder resolves
+ * at render time against the data model. When the FlightCard is a template
+ * child of a Row bound to `/flights`, each instance's bindings are scoped to
+ * `/flights[i]` and pull that flight's airline, origin, destination, price.
+ *
+ * `action` fires `book_flight` with a context object that itself contains
+ * path bindings — the runtime resolves them to the current flight's values
+ * at click time, so the agent receives the concrete flight the user chose.
+ */
+export const FlightCardApi = {
+  name: 'FlightCard',
+  schema: z
+    .object({
+      airline: DynString,
+      airlineLogo: DynString,
+      flightNumber: DynString,
+      origin: DynString,
+      destination: DynString,
+      date: DynString,
+      departureTime: DynString,
+      arrivalTime: DynString,
+      duration: DynString,
+      status: DynString,
+      statusColor: DynString.optional(),
+      price: DynString,
+      action: ActionSchema.optional(),
+    })
+    .strict(),
+} as const satisfies ComponentApi;

--- a/shell/src/app/custom-catalog/catalog/components/badge/badge.ts
+++ b/shell/src/app/custom-catalog/catalog/components/badge/badge.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {BadgeApi} from '../../apis';
+
+/**
+ * Variant → `{ background, color }` pairs, mapped onto the composer's
+ * semantic status tokens. `info` reuses the brand accent; `neutral` falls
+ * back to a muted divider fill.
+ */
+const VARIANTS: Record<string, {bg: string; color: string}> = {
+  success: {bg: 'var(--cpk-success-bg)', color: 'var(--cpk-success)'},
+  warning: {bg: 'var(--cpk-warning-bg)', color: 'var(--cpk-warning)'},
+  error: {bg: 'var(--cpk-critical-bg)', color: 'var(--cpk-critical)'},
+  info: {bg: 'var(--cpk-accent-bg)', color: 'var(--cpk-accent)'},
+  neutral: {bg: 'var(--cpk-divider)', color: 'var(--cpk-text-secondary)'},
+};
+
+/** `Badge` renderer — a small pill label with a semantic status variant. */
+@Component({
+  selector: 'a2ui-composer-cc-badge',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span class="cc-badge" [style.background]="variant().bg" [style.color]="variant().color">
+      {{ text() }}
+    </span>
+  `,
+  styles: [
+    `
+      .cc-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: var(--cpk-radius-pill);
+        font-size: 0.7rem;
+        font-weight: 500;
+        font-family: var(--cpk-font-body);
+      }
+    `,
+  ],
+})
+export class CcBadge extends CatalogComponent<typeof BadgeApi> {
+  protected readonly text = computed(() => this.props()['text']?.value() ?? '');
+  protected readonly variant = computed(
+    () => VARIANTS[this.props()['variant']?.value() ?? 'neutral'] ?? VARIANTS['neutral'],
+  );
+}

--- a/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.spec.ts
+++ b/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {renderSurface} from '../test-harness';
+
+describe('CcBarChart', () => {
+  it('renders one bar per data item with formatted values', async () => {
+    const {host} = await renderSurface([
+      {
+        id: 'root',
+        component: 'BarChart',
+        color: '#3b82f6',
+        valuePrefix: '$',
+        valueSuffix: 'K',
+        data: [
+          {label: 'Jan', value: 240},
+          {label: 'Feb', value: 305},
+          {label: 'Mar', value: 280},
+        ],
+      },
+    ]);
+
+    const bars = host.querySelectorAll('rect.cc-bar__rect');
+    expect(bars.length).toBe(3);
+
+    // Tallest bar (Feb=305) is the full plot height; others scale below it.
+    const heights = Array.from(bars).map(b => Number(b.getAttribute('height')));
+    expect(Math.max(...heights)).toBeGreaterThan(Math.min(...heights));
+
+    // valuePrefix / valueSuffix decorate the value labels.
+    expect(host.textContent).toContain('$305K');
+    expect(host.textContent).toContain('Feb');
+  });
+});

--- a/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.ts
+++ b/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {BarChartApi} from '../../apis';
+
+interface BarDatum {
+  label: string;
+  value: number;
+}
+
+interface Bar {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  label: string;
+  labelX: number;
+  valueLabel: string;
+  valueY: number;
+}
+
+const SLOT_W = 60;
+const BAR_W = 32;
+const TOP_PAD = 24;
+const PLOT_H = 140;
+const BOTTOM_PAD = 28;
+const CHART_H = TOP_PAD + PLOT_H + BOTTOM_PAD;
+
+/**
+ * `BarChart` renderer — a dependency-free inline `<svg>` vertical bar chart.
+ * Bars scale to the max value; `valuePrefix` / `valueSuffix` decorate the
+ * per-bar value label (e.g. `305` → `$305K`) without touching the underlying
+ * scale. `data` is a `DynamicValue` (inline literal or `{ path }` binding).
+ */
+@Component({
+  selector: 'a2ui-composer-cc-bar-chart',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="cc-bar">
+      <svg
+        class="cc-bar__svg"
+        [attr.viewBox]="'0 0 ' + chartWidth() + ' ' + chartHeight"
+        role="img"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <line
+          class="cc-bar__axis"
+          [attr.x1]="0"
+          [attr.y1]="baselineY"
+          [attr.x2]="chartWidth()"
+          [attr.y2]="baselineY"
+        />
+        @for (bar of bars(); track bar.label) {
+          <rect
+            class="cc-bar__rect"
+            [attr.x]="bar.x"
+            [attr.y]="bar.y"
+            [attr.width]="bar.width"
+            [attr.height]="bar.height"
+            [attr.rx]="4"
+            [attr.fill]="color()"
+          />
+          <text
+            class="cc-bar__value"
+            [attr.x]="bar.labelX"
+            [attr.y]="bar.valueY"
+            text-anchor="middle"
+          >
+            {{ bar.valueLabel }}
+          </text>
+          <text
+            class="cc-bar__label"
+            [attr.x]="bar.labelX"
+            [attr.y]="baselineY + 18"
+            text-anchor="middle"
+          >
+            {{ bar.label }}
+          </text>
+        }
+      </svg>
+    </div>
+  `,
+  styles: [
+    `
+      .cc-bar {
+        width: 100%;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-bar__svg {
+        width: 100%;
+        height: auto;
+      }
+      .cc-bar__axis {
+        stroke: var(--cpk-divider);
+        stroke-width: 1;
+      }
+      .cc-bar__value {
+        fill: var(--cpk-text-primary);
+        font-size: 11px;
+        font-weight: 600;
+      }
+      .cc-bar__label {
+        fill: var(--cpk-text-secondary);
+        font-size: 11px;
+      }
+    `,
+  ],
+})
+export class CcBarChart extends CatalogComponent<typeof BarChartApi> {
+  protected readonly chartHeight = CHART_H;
+  protected readonly baselineY = TOP_PAD + PLOT_H;
+
+  protected readonly color = computed(() => this.props()['color']?.value() ?? 'var(--cpk-accent)');
+
+  private readonly prefix = computed(() => this.props()['valuePrefix']?.value() ?? '');
+  private readonly suffix = computed(() => this.props()['valueSuffix']?.value() ?? '');
+
+  private readonly data = computed<BarDatum[]>(() => {
+    const raw = this.props()['data']?.value();
+    return Array.isArray(raw) ? (raw as BarDatum[]) : [];
+  });
+
+  protected readonly chartWidth = computed(() => Math.max(1, this.data().length) * SLOT_W);
+
+  protected readonly bars = computed<Bar[]>(() => {
+    const data = this.data();
+    const max = data.reduce((m, d) => Math.max(m, Number(d.value) || 0), 0);
+    return data.map((d, i) => {
+      const value = Number(d.value) || 0;
+      const height = max > 0 ? (value / max) * PLOT_H : 0;
+      const x = i * SLOT_W + (SLOT_W - BAR_W) / 2;
+      const y = TOP_PAD + (PLOT_H - height);
+      return {
+        x,
+        y,
+        width: BAR_W,
+        height,
+        label: String(d.label ?? ''),
+        labelX: x + BAR_W / 2,
+        valueLabel: `${this.prefix()}${value}${this.suffix()}`,
+        valueY: y - 6,
+      };
+    });
+  });
+}

--- a/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.ts
+++ b/shell/src/app/custom-catalog/catalog/components/bar-chart/bar-chart.ts
@@ -140,9 +140,9 @@ export class CcBarChart extends CatalogComponent<typeof BarChartApi> {
 
   protected readonly bars = computed<Bar[]>(() => {
     const data = this.data();
-    const max = data.reduce((m, d) => Math.max(m, Number(d.value) || 0), 0);
+    const max = data.reduce((m, d) => Math.max(m, Number(d?.value) || 0), 0);
     return data.map((d, i) => {
-      const value = Number(d.value) || 0;
+      const value = Number(d?.value) || 0;
       const height = max > 0 ? (value / max) * PLOT_H : 0;
       const x = i * SLOT_W + (SLOT_W - BAR_W) / 2;
       const y = TOP_PAD + (PLOT_H - height);
@@ -151,7 +151,7 @@ export class CcBarChart extends CatalogComponent<typeof BarChartApi> {
         y,
         width: BAR_W,
         height,
-        label: String(d.label ?? ''),
+        label: String(d?.label ?? ''),
         labelX: x + BAR_W / 2,
         valueLabel: `${this.prefix()}${value}${this.suffix()}`,
         valueY: y - 6,

--- a/shell/src/app/custom-catalog/catalog/components/button/button.ts
+++ b/shell/src/app/custom-catalog/catalog/components/button/button.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed, inject, signal} from '@angular/core';
+import {CatalogComponent, ComponentHostComponent, A2uiRendererService} from '@a2ui/angular/v0_9';
+import {DataContext, type Action} from '@a2ui/web_core/v0_9';
+import {ButtonApi} from '../../apis';
+
+/**
+ * `Button` renderer — an action button that renders its `child` component as
+ * the label. `action` is an `ActionSchema`; the binder hands us the raw action
+ * object which we resolve + dispatch through the surface. After activation the
+ * button latches into a "Done" state (mirrors the React `ActionButton`).
+ */
+@Component({
+  selector: 'a2ui-composer-cc-button',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ComponentHostComponent],
+  template: `
+    <button
+      type="button"
+      class="cc-button"
+      [class.cc-button--done]="done()"
+      [disabled]="done()"
+      (click)="handleAction()"
+    >
+      @if (done()) {
+        <svg
+          class="cc-button__check"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        <span>Done</span>
+      } @else if (child()) {
+        <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()" />
+      } @else {
+        <span>Click</span>
+      }
+    </button>
+  `,
+  styles: [
+    `
+      .cc-button {
+        width: 100%;
+        padding: 10px 16px;
+        border-radius: var(--cpk-radius-card);
+        border: 1px solid var(--cpk-border);
+        background: var(--cpk-surface-elevated);
+        color: var(--cpk-text-primary);
+        font-size: 0.85rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-button--done {
+        border-color: var(--cpk-success);
+        background: var(--cpk-success-bg);
+        color: var(--cpk-success);
+        cursor: default;
+      }
+    `,
+  ],
+})
+export class CcButton extends CatalogComponent<typeof ButtonApi> {
+  private readonly rendererService = inject(A2uiRendererService);
+  private readonly surface = computed(() =>
+    this.rendererService.surfaceGroup.getSurface(this.surfaceId()),
+  );
+
+  protected readonly child = computed(() => this.props()['child']?.value());
+  protected readonly action = computed(() => this.props()['action']?.value());
+  protected readonly done = signal(false);
+
+  handleAction(): void {
+    if (this.done()) return;
+    const action = this.action();
+    const surface = this.surface();
+    if (action && surface) {
+      const dc = new DataContext(surface, this.dataContextPath());
+      surface.dispatchAction(dc.resolveAction(action as Action), this.componentId());
+    }
+    this.done.set(true);
+  }
+}

--- a/shell/src/app/custom-catalog/catalog/components/column/column.ts
+++ b/shell/src/app/custom-catalog/catalog/components/column/column.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent, ComponentHostComponent} from '@a2ui/angular/v0_9';
+import {ColumnApi} from '../../apis';
+
+const ALIGN_MAP: Record<string, string> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  stretch: 'stretch',
+};
+
+/**
+ * `Column` renderer — a vertical flex container. Same template-children
+ * semantics as `Row`: the binder resolves `children` into `{ id, basePath }`
+ * references, one host per child.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-column',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ComponentHostComponent],
+  template: `
+    <div class="cc-column" [style.gap.px]="gap()" [style.alignItems]="alignItems()">
+      @for (child of children(); track child.basePath + '/' + child.id) {
+        <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()" />
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .cc-column {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class CcColumn extends CatalogComponent<typeof ColumnApi> {
+  protected readonly children = computed(() => this.props()['children']?.value() ?? []);
+  protected readonly gap = computed(() => this.props()['gap']?.value() ?? 12);
+  protected readonly alignItems = computed(
+    () => ALIGN_MAP[this.props()['align']?.value() ?? 'stretch'] ?? 'stretch',
+  );
+}

--- a/shell/src/app/custom-catalog/catalog/components/dashboard-card/dashboard-card.ts
+++ b/shell/src/app/custom-catalog/catalog/components/dashboard-card/dashboard-card.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent, ComponentHostComponent} from '@a2ui/angular/v0_9';
+import {DashboardCardApi} from '../../apis';
+
+/**
+ * `DashboardCard` renderer — a titled card wrapping a single `child`
+ * component (resolved from a component-id reference into `{ id, basePath }`).
+ * Declares its own flex behaviour so multiple cards distribute evenly in a
+ * `Row`.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-dashboard-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ComponentHostComponent],
+  template: `
+    <div class="cc-card">
+      <div class="cc-card__header">
+        <div class="cc-card__title">{{ title() }}</div>
+        @if (subtitle() != null) {
+          <div class="cc-card__subtitle">{{ subtitle() }}</div>
+        }
+      </div>
+      @if (child()) {
+        <a2ui-v09-component-host [componentKey]="child()!" [surfaceId]="surfaceId()" />
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .cc-card {
+        background: var(--cpk-surface-elevated);
+        border-radius: var(--cpk-radius-card);
+        border: 1px solid var(--cpk-border);
+        padding: 20px;
+        box-shadow: var(--cpk-shadow-card);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        flex: 1 1 0;
+        min-width: 0;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-card__title {
+        font-weight: 600;
+        font-size: 0.9rem;
+        color: var(--cpk-text-primary);
+      }
+      .cc-card__subtitle {
+        font-size: 0.75rem;
+        color: var(--cpk-text-secondary);
+        margin-top: 2px;
+      }
+    `,
+  ],
+})
+export class CcDashboardCard extends CatalogComponent<typeof DashboardCardApi> {
+  protected readonly title = computed(() => String(this.props()['title']?.value() ?? ''));
+  protected readonly subtitle = computed(() => {
+    const v = this.props()['subtitle']?.value();
+    return v != null ? String(v) : null;
+  });
+  protected readonly child = computed(() => this.props()['child']?.value());
+}

--- a/shell/src/app/custom-catalog/catalog/components/dashboard-card/dashboard-card.ts
+++ b/shell/src/app/custom-catalog/catalog/components/dashboard-card/dashboard-card.ts
@@ -33,7 +33,7 @@ import {DashboardCardApi} from '../../apis';
     <div class="cc-card">
       <div class="cc-card__header">
         <div class="cc-card__title">{{ title() }}</div>
-        @if (subtitle() != null) {
+        @if (subtitle() !== null) {
           <div class="cc-card__subtitle">{{ subtitle() }}</div>
         }
       </div>

--- a/shell/src/app/custom-catalog/catalog/components/data-table/data-table.ts
+++ b/shell/src/app/custom-catalog/catalog/components/data-table/data-table.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {DataTableApi} from '../../apis';
+
+interface TableColumn {
+  key: string;
+  label: string;
+}
+
+/**
+ * `DataTable` renderer — renders `columns` (`{ key, label }[]`) as headers and
+ * `rows` (`Record<string, unknown>[]`) as cells, keyed by column key. Scrolls
+ * horizontally inside its own container so wide tables never overflow the page.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-data-table',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="cc-table-wrap">
+      <table class="cc-table">
+        <thead>
+          <tr>
+            @for (col of columns(); track col.key) {
+              <th>{{ col.label }}</th>
+            }
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of rows(); track $index) {
+            <tr>
+              @for (col of columns(); track col.key) {
+                <td>{{ cell(row, col.key) }}</td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+  `,
+  styles: [
+    `
+      .cc-table-wrap {
+        overflow-x: auto;
+        width: 100%;
+      }
+      .cc-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.8rem;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-table th {
+        text-align: left;
+        padding: 8px 12px;
+        border-bottom: 2px solid var(--cpk-border);
+        color: var(--cpk-text-secondary);
+        font-weight: 600;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .cc-table td {
+        padding: 8px 12px;
+        color: var(--cpk-text-primary);
+        border-bottom: 1px solid var(--cpk-divider);
+      }
+    `,
+  ],
+})
+export class CcDataTable extends CatalogComponent<typeof DataTableApi> {
+  protected readonly columns = computed(
+    () => (this.props()['columns']?.value() ?? []) as TableColumn[],
+  );
+  protected readonly rows = computed(
+    () => (this.props()['rows']?.value() ?? []) as Record<string, unknown>[],
+  );
+
+  protected cell(row: Record<string, unknown>, key: string): string {
+    return String(row[key] ?? '');
+  }
+}

--- a/shell/src/app/custom-catalog/catalog/components/data-table/data-table.ts
+++ b/shell/src/app/custom-catalog/catalog/components/data-table/data-table.ts
@@ -85,14 +85,20 @@ interface TableColumn {
   ],
 })
 export class CcDataTable extends CatalogComponent<typeof DataTableApi> {
-  protected readonly columns = computed(
-    () => (this.props()['columns']?.value() ?? []) as TableColumn[],
-  );
-  protected readonly rows = computed(
-    () => (this.props()['rows']?.value() ?? []) as Record<string, unknown>[],
-  );
+  protected readonly columns = computed(() => {
+    const raw = this.props()['columns']?.value();
+    return (Array.isArray(raw) ? (raw as TableColumn[]) : []).filter(
+      c => c && typeof c === 'object',
+    );
+  });
+  protected readonly rows = computed(() => {
+    const raw = this.props()['rows']?.value();
+    return (Array.isArray(raw) ? (raw as Record<string, unknown>[]) : []).filter(
+      r => r && typeof r === 'object',
+    );
+  });
 
   protected cell(row: Record<string, unknown>, key: string): string {
-    return String(row[key] ?? '');
+    return row ? String(row[key] ?? '') : '';
   }
 }

--- a/shell/src/app/custom-catalog/catalog/components/flight-card/flight-card.spec.ts
+++ b/shell/src/app/custom-catalog/catalog/components/flight-card/flight-card.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {renderSurface} from '../test-harness';
+
+describe('CcFlightCard', () => {
+  it('renders its bound text values resolved from the data model', async () => {
+    const {host} = await renderSurface(
+      [
+        {
+          id: 'root',
+          component: 'FlightCard',
+          airline: {path: '/flight/airline'},
+          airlineLogo: '',
+          flightNumber: {path: '/flight/flightNumber'},
+          origin: {path: '/flight/origin'},
+          destination: {path: '/flight/destination'},
+          date: 'Jul 14, 2026',
+          departureTime: '08:15',
+          arrivalTime: '16:42',
+          duration: '5h 27m',
+          status: 'On Time',
+          price: {path: '/flight/price'},
+          action: {event: {name: 'book_flight', context: {}}},
+        },
+      ],
+      {
+        flight: {
+          airline: 'United Airlines',
+          flightNumber: 'UA 482',
+          origin: 'SFO',
+          destination: 'JFK',
+          price: '$342',
+        },
+      },
+    );
+
+    expect(host.textContent).toContain('United Airlines');
+    expect(host.textContent).toContain('UA 482');
+    expect(host.textContent).toContain('SFO');
+    expect(host.textContent).toContain('JFK');
+    expect(host.textContent).toContain('$342');
+
+    // Empty airlineLogo must NOT emit an <img> (broken-URL fallback).
+    expect(host.querySelector('img')).toBeNull();
+  });
+
+  it('dispatches its action through the surface on Select', async () => {
+    const {host, actionHandler, fixture} = await renderSurface([
+      {
+        id: 'root',
+        component: 'FlightCard',
+        airline: 'United Airlines',
+        airlineLogo: '',
+        flightNumber: 'UA 482',
+        origin: 'SFO',
+        destination: 'JFK',
+        date: 'Jul 14, 2026',
+        departureTime: '08:15',
+        arrivalTime: '16:42',
+        duration: '5h 27m',
+        status: 'On Time',
+        price: '$342',
+        action: {event: {name: 'book_flight', context: {}}},
+      },
+    ]);
+
+    const cta = host.querySelector('.cc-flight__cta') as HTMLButtonElement;
+    expect(cta).not.toBeNull();
+    expect(cta.textContent?.trim()).toBe('Select');
+
+    cta.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(actionHandler).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'book_flight', sourceComponentId: 'root'}),
+    );
+    // CTA latches into its done state.
+    expect(cta.textContent?.trim()).toBe('Selected');
+  });
+});

--- a/shell/src/app/custom-catalog/catalog/components/flight-card/flight-card.ts
+++ b/shell/src/app/custom-catalog/catalog/components/flight-card/flight-card.ts
@@ -1,0 +1,266 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed, inject, signal} from '@angular/core';
+import {CatalogComponent, A2uiRendererService} from '@a2ui/angular/v0_9';
+import {DataContext, type Action} from '@a2ui/web_core/v0_9';
+import {FlightCardApi} from '../../apis';
+
+/**
+ * Map `status` text → a visual dot colour. Bypassed when the agent sets an
+ * explicit `statusColor`.
+ */
+const STATUS_COLORS: Record<string, string> = {
+  'On Time': 'var(--cpk-success)',
+  Delayed: 'var(--cpk-warning)',
+  Cancelled: 'var(--cpk-critical)',
+};
+
+/**
+ * `FlightCard` renderer — the showcase card. Every string prop is a
+ * `DynString` the binder has already resolved (literal or scoped path
+ * binding), so we render values directly. The "Select" CTA resolves and
+ * dispatches the `book_flight` action, then latches to "Selected".
+ */
+@Component({
+  selector: 'a2ui-composer-cc-flight-card',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="cc-flight">
+      <div class="cc-flight__head">
+        <div class="cc-flight__airline">
+          @if (airlineLogo()) {
+            <img
+              class="cc-flight__logo"
+              [src]="airlineLogo()"
+              [alt]="airline()"
+              (error)="onLogoError($event)"
+            />
+          }
+          <span class="cc-flight__airline-name">{{ airline() }}</span>
+        </div>
+        <span class="cc-flight__price">{{ price() }}</span>
+      </div>
+
+      <div class="cc-flight__meta">
+        <span>{{ flightNumber() }}</span>
+        <span>{{ date() }}</span>
+      </div>
+
+      <hr class="cc-flight__rule" />
+
+      <div class="cc-flight__times">
+        <span class="cc-flight__time">{{ departureTime() }}</span>
+        <span class="cc-flight__duration">{{ duration() }}</span>
+        <span class="cc-flight__time">{{ arrivalTime() }}</span>
+      </div>
+
+      <div class="cc-flight__route">
+        <span>{{ origin() }}</span>
+        <span class="cc-flight__arrow">→</span>
+        <span>{{ destination() }}</span>
+      </div>
+
+      <div class="cc-flight__foot">
+        <hr class="cc-flight__rule" />
+        <div class="cc-flight__status">
+          <span class="cc-flight__dot" [style.background]="dotColor()"></span>
+          <span class="cc-flight__status-text">{{ status() }}</span>
+        </div>
+        <button
+          type="button"
+          class="cc-flight__cta"
+          [class.cc-flight__cta--done]="done()"
+          [disabled]="done()"
+          (click)="handleAction()"
+        >
+          {{ done() ? 'Selected' : 'Select' }}
+        </button>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .cc-flight {
+        border: 1px solid var(--cpk-border);
+        border-radius: var(--cpk-radius-lg);
+        padding: 20px;
+        background: var(--cpk-surface-elevated);
+        color: var(--cpk-text-primary);
+        min-width: 260px;
+        max-width: 340px;
+        flex: 1 1 260px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        box-shadow: var(--cpk-shadow-card);
+        font-family: var(--cpk-font-body);
+      }
+      .cc-flight__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .cc-flight__airline {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .cc-flight__logo {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        object-fit: contain;
+      }
+      .cc-flight__airline-name {
+        font-weight: 600;
+        font-size: 0.95rem;
+      }
+      .cc-flight__price {
+        font-weight: 700;
+        font-size: 1.15rem;
+      }
+      .cc-flight__meta {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.8rem;
+        color: var(--cpk-text-secondary);
+      }
+      .cc-flight__rule {
+        border: none;
+        border-top: 1px solid var(--cpk-divider);
+        margin: 0;
+        width: 100%;
+      }
+      .cc-flight__times {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .cc-flight__time {
+        font-weight: 700;
+        font-size: 1.1rem;
+      }
+      .cc-flight__duration {
+        font-size: 0.75rem;
+        color: var(--cpk-text-secondary);
+      }
+      .cc-flight__route {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.95rem;
+        font-weight: 600;
+      }
+      .cc-flight__arrow {
+        color: var(--cpk-text-secondary);
+      }
+      .cc-flight__foot {
+        margin-top: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .cc-flight__status {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .cc-flight__dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        display: inline-block;
+      }
+      .cc-flight__status-text {
+        font-size: 0.8rem;
+        color: var(--cpk-text-secondary);
+      }
+      .cc-flight__cta {
+        width: 100%;
+        padding: 10px 16px;
+        border-radius: var(--cpk-radius-card);
+        border: 1px solid var(--cpk-border);
+        background: var(--cpk-surface-elevated);
+        color: var(--cpk-text-primary);
+        font-size: 0.85rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-flight__cta--done {
+        border-color: var(--cpk-success);
+        background: var(--cpk-success-bg);
+        color: var(--cpk-success);
+        cursor: default;
+      }
+    `,
+  ],
+})
+export class CcFlightCard extends CatalogComponent<typeof FlightCardApi> {
+  private readonly rendererService = inject(A2uiRendererService);
+  private readonly surface = computed(() =>
+    this.rendererService.surfaceGroup.getSurface(this.surfaceId()),
+  );
+
+  protected readonly airline = computed(() => String(this.props()['airline']?.value() ?? ''));
+  protected readonly airlineLogo = computed(() =>
+    String(this.props()['airlineLogo']?.value() ?? ''),
+  );
+  protected readonly flightNumber = computed(() =>
+    String(this.props()['flightNumber']?.value() ?? ''),
+  );
+  protected readonly origin = computed(() => String(this.props()['origin']?.value() ?? ''));
+  protected readonly destination = computed(() =>
+    String(this.props()['destination']?.value() ?? ''),
+  );
+  protected readonly date = computed(() => String(this.props()['date']?.value() ?? ''));
+  protected readonly departureTime = computed(() =>
+    String(this.props()['departureTime']?.value() ?? ''),
+  );
+  protected readonly arrivalTime = computed(() =>
+    String(this.props()['arrivalTime']?.value() ?? ''),
+  );
+  protected readonly duration = computed(() => String(this.props()['duration']?.value() ?? ''));
+  protected readonly status = computed(() => String(this.props()['status']?.value() ?? ''));
+  protected readonly price = computed(() => String(this.props()['price']?.value() ?? ''));
+  protected readonly dotColor = computed(() => {
+    const explicit = this.props()['statusColor']?.value();
+    if (typeof explicit === 'string' && explicit) return explicit;
+    return STATUS_COLORS[this.status()] ?? 'var(--cpk-success)';
+  });
+
+  protected readonly action = computed(() => this.props()['action']?.value());
+  protected readonly done = signal(false);
+
+  onLogoError(event: Event): void {
+    // Hide a broken airline logo rather than show the browser broken-image glyph.
+    (event.target as HTMLElement).style.display = 'none';
+  }
+
+  handleAction(): void {
+    if (this.done()) return;
+    const action = this.action();
+    const surface = this.surface();
+    if (action && surface) {
+      const dc = new DataContext(surface, this.dataContextPath());
+      surface.dispatchAction(dc.resolveAction(action as Action), this.componentId());
+    }
+    this.done.set(true);
+  }
+}

--- a/shell/src/app/custom-catalog/catalog/components/metric/metric.ts
+++ b/shell/src/app/custom-catalog/catalog/components/metric/metric.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {MetricApi} from '../../apis';
+
+const TREND_COLORS: Record<string, string> = {
+  up: 'var(--cpk-success)',
+  down: 'var(--cpk-critical)',
+  neutral: 'var(--cpk-text-secondary)',
+};
+
+const TREND_ICONS: Record<string, string> = {
+  up: '↑',
+  down: '↓',
+  neutral: '→',
+};
+
+/**
+ * `Metric` renderer — a KPI stat block: uppercase label, large value, and an
+ * optional coloured trend indicator. `label`, `value`, `trendValue` are
+ * `DynString`, resolved to strings by the binder.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-metric',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="cc-metric">
+      <span class="cc-metric__label">{{ label() }}</span>
+      <div class="cc-metric__row">
+        <span class="cc-metric__value">{{ value() }}</span>
+        @if (trend() && trendValue()) {
+          <span class="cc-metric__trend" [style.color]="trendColor()">
+            {{ trendIcon() }} {{ trendValue() }}
+          </span>
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .cc-metric {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-metric__label {
+        font-size: 0.75rem;
+        color: var(--cpk-text-secondary);
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .cc-metric__row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+      }
+      .cc-metric__value {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--cpk-text-primary);
+        letter-spacing: -0.02em;
+      }
+      .cc-metric__trend {
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+    `,
+  ],
+})
+export class CcMetric extends CatalogComponent<typeof MetricApi> {
+  protected readonly label = computed(() => String(this.props()['label']?.value() ?? ''));
+  protected readonly value = computed(() => String(this.props()['value']?.value() ?? ''));
+  protected readonly trend = computed(() => this.props()['trend']?.value());
+  protected readonly trendValue = computed(() => {
+    const v = this.props()['trendValue']?.value();
+    return v != null ? String(v) : '';
+  });
+  protected readonly trendColor = computed(
+    () => TREND_COLORS[this.trend() ?? 'neutral'] ?? 'var(--cpk-text-secondary)',
+  );
+  protected readonly trendIcon = computed(() => TREND_ICONS[this.trend() ?? 'neutral'] ?? '→');
+}

--- a/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.spec.ts
+++ b/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {renderSurface} from '../test-harness';
+
+describe('CcPieChart', () => {
+  it('renders one svg slice path per data item', async () => {
+    const {host} = await renderSurface([
+      {
+        id: 'root',
+        component: 'PieChart',
+        innerRadius: 40,
+        data: [
+          {label: 'North', value: 45},
+          {label: 'South', value: 25},
+          {label: 'East', value: 20},
+          {label: 'West', value: 10},
+        ],
+      },
+    ]);
+
+    const paths = host.querySelectorAll('svg path');
+    expect(paths.length).toBe(4);
+
+    // Every slice emits a non-empty arc path.
+    paths.forEach(p => expect(p.getAttribute('d')?.length ?? 0).toBeGreaterThan(0));
+
+    // Legend echoes each labelled datum.
+    const legend = host.querySelectorAll('.cc-pie__legend-item');
+    expect(legend.length).toBe(4);
+    expect(host.textContent).toContain('North');
+  });
+});

--- a/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
+++ b/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
@@ -1,0 +1,172 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {PieChartApi} from '../../apis';
+
+interface PieDatum {
+  label: string;
+  value: number;
+  color?: string;
+}
+
+interface PieSlice {
+  path: string;
+  color: string;
+  label: string;
+  value: number;
+}
+
+/** Categorical palette; the brand indigo leads, then a balanced spread. */
+const PALETTE = ['#4355b9', '#8b5cf6', '#ec4899', '#f59e0b', '#10b981', '#6366f1'];
+
+const CENTER = 100;
+const OUTER_R = 80;
+
+/**
+ * `PieChart` renderer — a dependency-free inline `<svg>` pie / donut. Slice
+ * arc paths are computed from the resolved `data` array; `innerRadius`
+ * (default 40) turns it into a donut. `data` is a `DynamicValue`, so the
+ * binder yields either an inline literal array or a `{ path }`-bound array.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-pie-chart',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="cc-pie">
+      <svg
+        class="cc-pie__svg"
+        viewBox="0 0 200 200"
+        role="img"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        @for (slice of slices(); track slice.label) {
+          <path [attr.d]="slice.path" [attr.fill]="slice.color" />
+        }
+      </svg>
+      @if (slices().length) {
+        <ul class="cc-pie__legend">
+          @for (slice of slices(); track slice.label) {
+            <li class="cc-pie__legend-item">
+              <span class="cc-pie__swatch" [style.background]="slice.color"></span>
+              <span class="cc-pie__legend-label">{{ slice.label }}</span>
+              <span class="cc-pie__legend-value">{{ slice.value }}</span>
+            </li>
+          }
+        </ul>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .cc-pie {
+        display: flex;
+        align-items: center;
+        gap: var(--cpk-space-4);
+        flex-wrap: wrap;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-pie__svg {
+        width: 160px;
+        height: 160px;
+        flex: 0 0 auto;
+      }
+      .cc-pie__legend {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .cc-pie__legend-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 0.8rem;
+        color: var(--cpk-text-secondary);
+      }
+      .cc-pie__swatch {
+        width: 10px;
+        height: 10px;
+        border-radius: 2px;
+        flex: 0 0 auto;
+      }
+      .cc-pie__legend-label {
+        color: var(--cpk-text-primary);
+      }
+      .cc-pie__legend-value {
+        margin-left: auto;
+        font-variant-numeric: tabular-nums;
+      }
+    `,
+  ],
+})
+export class CcPieChart extends CatalogComponent<typeof PieChartApi> {
+  protected readonly innerRadius = computed(() => this.props()['innerRadius']?.value() ?? 40);
+
+  private readonly data = computed<PieDatum[]>(() => {
+    const raw = this.props()['data']?.value();
+    return Array.isArray(raw) ? (raw as PieDatum[]) : [];
+  });
+
+  protected readonly slices = computed<PieSlice[]>(() => {
+    const data = this.data();
+    const innerR = this.innerRadius();
+    const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+    if (total <= 0) return [];
+
+    const slices: PieSlice[] = [];
+    let cursor = 0;
+    data.forEach((d, i) => {
+      const value = Number(d.value) || 0;
+      const start = (cursor / total) * 360;
+      cursor += value;
+      let end = (cursor / total) * 360;
+      // Keep a lone full-circle slice visible (an exact 360° arc is a no-op).
+      if (end - start >= 360) end = start + 359.999;
+      slices.push({
+        path: this.arc(start, end, innerR),
+        color: d.color ?? PALETTE[i % PALETTE.length],
+        label: String(d.label ?? ''),
+        value,
+      });
+    });
+    return slices;
+  });
+
+  private point(r: number, angleDeg: number): {x: number; y: number} {
+    const rad = ((angleDeg - 90) * Math.PI) / 180;
+    return {x: CENTER + r * Math.cos(rad), y: CENTER + r * Math.sin(rad)};
+  }
+
+  private arc(start: number, end: number, innerR: number): string {
+    const largeArc = end - start > 180 ? 1 : 0;
+    const oStart = this.point(OUTER_R, start);
+    const oEnd = this.point(OUTER_R, end);
+    const iEnd = this.point(innerR, end);
+    const iStart = this.point(innerR, start);
+    const f = (n: number) => n.toFixed(2);
+    return (
+      `M ${f(oStart.x)} ${f(oStart.y)} ` +
+      `A ${OUTER_R} ${OUTER_R} 0 ${largeArc} 1 ${f(oEnd.x)} ${f(oEnd.y)} ` +
+      `L ${f(iEnd.x)} ${f(iEnd.y)} ` +
+      `A ${innerR} ${innerR} 0 ${largeArc} 0 ${f(iStart.x)} ${f(iStart.y)} Z`
+    );
+  }
+}

--- a/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
+++ b/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
@@ -49,12 +49,7 @@ const OUTER_R = 80;
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="cc-pie">
-      <svg
-        class="cc-pie__svg"
-        viewBox="0 0 200 200"
-        role="img"
-        preserveAspectRatio="xMidYMid meet"
-      >
+      <svg class="cc-pie__svg" viewBox="0 0 200 200" role="img" preserveAspectRatio="xMidYMid meet">
         @for (slice of slices(); track slice.label) {
           <path [attr.d]="slice.path" [attr.fill]="slice.color" />
         }

--- a/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
+++ b/shell/src/app/custom-catalog/catalog/components/pie-chart/pie-chart.ts
@@ -128,13 +128,13 @@ export class CcPieChart extends CatalogComponent<typeof PieChartApi> {
   protected readonly slices = computed<PieSlice[]>(() => {
     const data = this.data();
     const innerR = this.innerRadius();
-    const total = data.reduce((sum, d) => sum + (Number(d.value) || 0), 0);
+    const total = data.reduce((sum, d) => sum + (Number(d?.value) || 0), 0);
     if (total <= 0) return [];
 
     const slices: PieSlice[] = [];
     let cursor = 0;
     data.forEach((d, i) => {
-      const value = Number(d.value) || 0;
+      const value = Number(d?.value) || 0;
       const start = (cursor / total) * 360;
       cursor += value;
       let end = (cursor / total) * 360;
@@ -142,8 +142,8 @@ export class CcPieChart extends CatalogComponent<typeof PieChartApi> {
       if (end - start >= 360) end = start + 359.999;
       slices.push({
         path: this.arc(start, end, innerR),
-        color: d.color ?? PALETTE[i % PALETTE.length],
-        label: String(d.label ?? ''),
+        color: d?.color ?? PALETTE[i % PALETTE.length],
+        label: String(d?.label ?? ''),
         value,
       });
     });

--- a/shell/src/app/custom-catalog/catalog/components/row/row.spec.ts
+++ b/shell/src/app/custom-catalog/catalog/components/row/row.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {renderSurface} from '../test-harness';
+
+describe('CcRow', () => {
+  it('renders one component host per child', async () => {
+    const {host} = await renderSurface([
+      {id: 'root', component: 'Row', children: ['t1', 't2', 't3'], gap: 16},
+      {id: 't1', component: 'Title', text: 'One', level: 'h3'},
+      {id: 't2', component: 'Title', text: 'Two', level: 'h3'},
+      {id: 't3', component: 'Title', text: 'Three', level: 'h3'},
+    ]);
+
+    const row = host.querySelector('.cc-row');
+    expect(row).not.toBeNull();
+
+    const childHosts = row!.querySelectorAll(':scope > a2ui-v09-component-host');
+    expect(childHosts.length).toBe(3);
+
+    expect(host.textContent).toContain('One');
+    expect(host.textContent).toContain('Two');
+    expect(host.textContent).toContain('Three');
+  });
+});

--- a/shell/src/app/custom-catalog/catalog/components/row/row.ts
+++ b/shell/src/app/custom-catalog/catalog/components/row/row.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent, ComponentHostComponent} from '@a2ui/angular/v0_9';
+import {RowApi} from '../../apis';
+
+const JUSTIFY_MAP: Record<string, string> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  spaceBetween: 'space-between',
+  spaceAround: 'space-around',
+  spaceEvenly: 'space-evenly',
+  stretch: 'stretch',
+};
+
+const ALIGN_MAP: Record<string, string> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  stretch: 'stretch',
+};
+
+/**
+ * `Row` renderer — a horizontal flex container. `children` is a
+ * `ChildListSchema`; the binder resolves it (static array or template
+ * repeater) into a list of `{ id, basePath }` child references which we
+ * render one-per-child through `<a2ui-v09-component-host>`.
+ */
+@Component({
+  selector: 'a2ui-composer-cc-row',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ComponentHostComponent],
+  template: `
+    <div
+      class="cc-row"
+      [style.gap.px]="gap()"
+      [style.alignItems]="alignItems()"
+      [style.justifyContent]="justifyContent()"
+    >
+      @for (child of children(); track child.basePath + '/' + child.id) {
+        <a2ui-v09-component-host [componentKey]="child" [surfaceId]="surfaceId()" />
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .cc-row {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class CcRow extends CatalogComponent<typeof RowApi> {
+  protected readonly children = computed(() => this.props()['children']?.value() ?? []);
+  protected readonly gap = computed(() => this.props()['gap']?.value() ?? 16);
+  protected readonly alignItems = computed(
+    () => ALIGN_MAP[this.props()['align']?.value() ?? 'stretch'] ?? 'stretch',
+  );
+  protected readonly justifyContent = computed(
+    () => JUSTIFY_MAP[this.props()['justify']?.value() ?? 'start'] ?? 'flex-start',
+  );
+}

--- a/shell/src/app/custom-catalog/catalog/components/test-harness.ts
+++ b/shell/src/app/custom-catalog/catalog/components/test-harness.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared TestBed harness for the dashboard catalog specs.
+ *
+ * Builds a real A2UI surface (create → updateComponents → optional
+ * updateDataModel), renders it through `<a2ui-v09-surface>`, and returns the
+ * host element plus the action-handler spy. This mirrors the runtime wiring
+ * exactly, so bindings, template children, and action dispatch all exercise
+ * the same code paths as production.
+ */
+import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {vi} from 'vitest';
+import {A2UI_RENDERER_CONFIG, A2uiRendererService, SurfaceComponent} from '@a2ui/angular/v0_9';
+import type {A2uiClientAction} from '@a2ui/web_core/v0_9';
+import {buildDashboardCatalog, DASHBOARD_CATALOG_ID} from '../dashboard-catalog';
+
+/** Minimal host that embeds a single A2UI surface. */
+@Component({
+  selector: 'a2ui-composer-cc-test-host',
+  standalone: true,
+  imports: [SurfaceComponent],
+  template: `<a2ui-v09-surface [surfaceId]="surfaceId()" />`,
+})
+export class CatalogTestHost {
+  readonly surfaceId = signal('t');
+}
+
+export interface HarnessResult {
+  fixture: ComponentFixture<CatalogTestHost>;
+  host: HTMLElement;
+  actionHandler: ReturnType<typeof vi.fn>;
+  service: A2uiRendererService;
+}
+
+const SURFACE_ID = 't';
+
+/**
+ * Renders the given flat component list on a fresh surface.
+ *
+ * @param components The flat A2UI component list (`{ id, component, ...props }`).
+ * @param dataModel Optional root data-model object for `{ path }` bindings.
+ */
+export async function renderSurface(
+  components: Record<string, unknown>[],
+  dataModel?: Record<string, unknown>,
+): Promise<HarnessResult> {
+  const actionHandler = vi.fn<(action: A2uiClientAction) => void>();
+
+  TestBed.configureTestingModule({
+    imports: [CatalogTestHost],
+    providers: [
+      provideZonelessChangeDetection(),
+      A2uiRendererService,
+      {
+        provide: A2UI_RENDERER_CONFIG,
+        useValue: {catalogs: [buildDashboardCatalog()], actionHandler},
+      },
+    ],
+  });
+
+  const service = TestBed.inject(A2uiRendererService);
+
+  const messages: unknown[] = [
+    {version: 'v0.9', createSurface: {surfaceId: SURFACE_ID, catalogId: DASHBOARD_CATALOG_ID}},
+  ];
+  if (dataModel) {
+    messages.push({version: 'v0.9', updateDataModel: {surfaceId: SURFACE_ID, path: '/', value: dataModel}});
+  }
+  messages.push({version: 'v0.9', updateComponents: {surfaceId: SURFACE_ID, components}});
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  service.processMessages(messages as any);
+
+  const fixture = TestBed.createComponent(CatalogTestHost);
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+
+  return {fixture, host: fixture.nativeElement as HTMLElement, actionHandler, service};
+}

--- a/shell/src/app/custom-catalog/catalog/components/test-harness.ts
+++ b/shell/src/app/custom-catalog/catalog/components/test-harness.ts
@@ -80,7 +80,10 @@ export async function renderSurface(
     {version: 'v0.9', createSurface: {surfaceId: SURFACE_ID, catalogId: DASHBOARD_CATALOG_ID}},
   ];
   if (dataModel) {
-    messages.push({version: 'v0.9', updateDataModel: {surfaceId: SURFACE_ID, path: '/', value: dataModel}});
+    messages.push({
+      version: 'v0.9',
+      updateDataModel: {surfaceId: SURFACE_ID, path: '/', value: dataModel},
+    });
   }
   messages.push({version: 'v0.9', updateComponents: {surfaceId: SURFACE_ID, components}});
 

--- a/shell/src/app/custom-catalog/catalog/components/title/title.ts
+++ b/shell/src/app/custom-catalog/catalog/components/title/title.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ChangeDetectionStrategy, Component, computed} from '@angular/core';
+import {CatalogComponent} from '@a2ui/angular/v0_9';
+import {TitleApi} from '../../apis';
+
+/**
+ * `Title` renderer — a plain heading. `text` is a `DynString`, so the binder
+ * resolves any `{ path }` binding to a string before we see it; `level`
+ * selects the semantic heading tag (h1/h2/h3).
+ */
+@Component({
+  selector: 'a2ui-composer-cc-title',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @switch (level()) {
+      @case ('h1') {
+        <h1 class="cc-title cc-h1">{{ text() }}</h1>
+      }
+      @case ('h3') {
+        <h3 class="cc-title cc-h3">{{ text() }}</h3>
+      }
+      @default {
+        <h2 class="cc-title cc-h2">{{ text() }}</h2>
+      }
+    }
+  `,
+  styles: [
+    `
+      .cc-title {
+        margin: 0;
+        font-weight: 600;
+        color: var(--cpk-text-primary);
+        letter-spacing: -0.01em;
+        font-family: var(--cpk-font-body);
+      }
+      .cc-h1 {
+        font-size: 1.75rem;
+      }
+      .cc-h2 {
+        font-size: 1.25rem;
+      }
+      .cc-h3 {
+        font-size: 1rem;
+      }
+    `,
+  ],
+})
+export class CcTitle extends CatalogComponent<typeof TitleApi> {
+  protected readonly text = computed(() => String(this.props()['text']?.value() ?? ''));
+  protected readonly level = computed(() => this.props()['level']?.value() ?? 'h2');
+}

--- a/shell/src/app/custom-catalog/catalog/dashboard-catalog.ts
+++ b/shell/src/app/custom-catalog/catalog/dashboard-catalog.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Flight & Dashboard catalog — Angular assembly.
+ *
+ * Pairs each of the 11 `ComponentApi` contracts from `./apis` with its native
+ * Angular renderer, plus the shared `BASIC_FUNCTIONS` from the basic catalog,
+ * so this custom catalog inherits identical path-binding, template-children,
+ * and action-dispatch semantics. The result is registered with the A2UI
+ * renderer under `copilotkit://app-dashboard-catalog` and referenced by that
+ * `catalogId` in `createSurface` messages.
+ */
+import {AngularCatalog, BASIC_FUNCTIONS} from '@a2ui/angular/v0_9';
+
+import {
+  BadgeApi,
+  BarChartApi,
+  ButtonApi,
+  ColumnApi,
+  DashboardCardApi,
+  DataTableApi,
+  FlightCardApi,
+  MetricApi,
+  PieChartApi,
+  RowApi,
+  TitleApi,
+} from './apis';
+
+import {CcBadge} from './components/badge/badge';
+import {CcBarChart} from './components/bar-chart/bar-chart';
+import {CcButton} from './components/button/button';
+import {CcColumn} from './components/column/column';
+import {CcDashboardCard} from './components/dashboard-card/dashboard-card';
+import {CcDataTable} from './components/data-table/data-table';
+import {CcFlightCard} from './components/flight-card/flight-card';
+import {CcMetric} from './components/metric/metric';
+import {CcPieChart} from './components/pie-chart/pie-chart';
+import {CcRow} from './components/row/row';
+import {CcTitle} from './components/title/title';
+
+/** Public catalog id advertised in `createSurface` messages. */
+export const DASHBOARD_CATALOG_ID = 'copilotkit://app-dashboard-catalog';
+
+/**
+ * Builds the Angular Flight & Dashboard catalog: 11 component definitions,
+ * each `{ name, schema }` contract merged with its Angular `component` class.
+ */
+export function buildDashboardCatalog(): AngularCatalog {
+  return new AngularCatalog(
+    DASHBOARD_CATALOG_ID,
+    [
+      {...TitleApi, component: CcTitle},
+      {...RowApi, component: CcRow},
+      {...ColumnApi, component: CcColumn},
+      {...DashboardCardApi, component: CcDashboardCard},
+      {...MetricApi, component: CcMetric},
+      {...PieChartApi, component: CcPieChart},
+      {...BarChartApi, component: CcBarChart},
+      {...BadgeApi, component: CcBadge},
+      {...DataTableApi, component: CcDataTable},
+      {...ButtonApi, component: CcButton},
+      {...FlightCardApi, component: CcFlightCard},
+    ],
+    BASIC_FUNCTIONS,
+  );
+}

--- a/shell/src/app/shell/composer-shell/composer-shell.ng.html
+++ b/shell/src/app/shell/composer-shell/composer-shell.ng.html
@@ -120,6 +120,21 @@
       </a>
       <a
         mat-list-item
+        routerLink="/theater"
+        routerLinkActive="active-nav-item"
+        aria-label="Theater"
+        matTooltip="Theater"
+        matTooltipPosition="right"
+        [matTooltipDisabled]="!isCollapsed()"
+        (click)="ensureCollapsed()"
+      >
+        <mat-icon matListItemIcon aria-hidden="true">movie</mat-icon>
+        @if (!isCollapsed()) {
+          <span class="nav-label">Theater</span>
+        }
+      </a>
+      <a
+        mat-list-item
         routerLink="/settings"
         routerLinkActive="active-nav-item"
         aria-label="Settings"

--- a/shell/src/app/shell/composer-shell/composer-shell.ng.html
+++ b/shell/src/app/shell/composer-shell/composer-shell.ng.html
@@ -105,6 +105,21 @@
       </a>
       <a
         mat-list-item
+        routerLink="/custom-catalog"
+        routerLinkActive="active-nav-item"
+        aria-label="Custom Catalog"
+        matTooltip="Custom Catalog"
+        matTooltipPosition="right"
+        [matTooltipDisabled]="!isCollapsed()"
+        (click)="ensureCollapsed()"
+      >
+        <mat-icon matListItemIcon aria-hidden="true">dashboard_customize</mat-icon>
+        @if (!isCollapsed()) {
+          <span class="nav-label">Custom Catalog</span>
+        }
+      </a>
+      <a
+        mat-list-item
         routerLink="/settings"
         routerLinkActive="active-nav-item"
         aria-label="Settings"

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -284,16 +284,16 @@ describe('ComposerShell Layout', () => {
 
   it('renders Material icons inside navigation list items', async () => {
     const icons = await harness.getNavListIconsText();
-    expect(icons).toEqual(['construction', 'widgets', 'settings']);
+    expect(icons).toEqual(['construction', 'widgets', 'dashboard_customize', 'settings']);
   });
 
   it('enables tooltips on navigation items and hides labels when collapsed initially', async () => {
-    expect(await harness.getNavListTooltipsDisabled()).toEqual([false, false, false]);
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([false, false, false, false]);
     expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(0);
     await harness.clickHamburgerButton();
     expect(await harness.isSidenavCollapsed()).toBe(false);
-    expect(await harness.getNavListTooltipsDisabled()).toEqual([true, true, true]);
-    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(3);
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([true, true, true, true]);
+    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(4);
   });
 
   it('sets explicit aria-label attributes on navigation links and connects hamburger button to sidenav', () => {
@@ -301,7 +301,12 @@ describe('ComposerShell Layout', () => {
     const ariaLabels = navLinks.map((link: unknown) =>
       (link as Element).getAttribute('aria-label'),
     );
-    expect(ariaLabels).toEqual(['Composer Workspace', 'Components Gallery', 'Settings']);
+    expect(ariaLabels).toEqual([
+      'Composer Workspace',
+      'Components Gallery',
+      'Custom Catalog',
+      'Settings',
+    ]);
 
     const sidenavEl = fixture.nativeElement.querySelector('mat-sidenav');
     expect(sidenavEl.getAttribute('id')).toBe('composer-sidenav');
@@ -315,10 +320,15 @@ describe('ComposerShell Layout', () => {
     const rlaAttrs = navLinks.map((link: unknown) =>
       (link as Element).getAttribute('routerLinkActive'),
     );
-    expect(rlaAttrs).toEqual(['active-nav-item', 'active-nav-item', 'active-nav-item']);
+    expect(rlaAttrs).toEqual([
+      'active-nav-item',
+      'active-nav-item',
+      'active-nav-item',
+      'active-nav-item',
+    ]);
 
     const rlaDirectives = fixture.debugElement.queryAll(By.directive(RouterLinkActive));
-    expect(rlaDirectives.length).toBe(3);
+    expect(rlaDirectives.length).toBe(4);
     const rlaInstances = rlaDirectives.map(de => de.injector.get(RouterLinkActive));
     expect(rlaInstances[0].routerLinkActiveOptions).toEqual({exact: true});
 

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -276,7 +276,7 @@ describe('ComposerShell Layout', () => {
 
   it('applies aria-hidden attribute to purely decorative MatIcon elements across the composer shell', async () => {
     const hiddenAttrs = await harness.getIconsAriaHidden();
-    expect(hiddenAttrs.length).toBe(7);
+    expect(hiddenAttrs.length).toBe(8);
     hiddenAttrs.forEach(attr => {
       expect(attr).toBe('true');
     });

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -276,7 +276,7 @@ describe('ComposerShell Layout', () => {
 
   it('applies aria-hidden attribute to purely decorative MatIcon elements across the composer shell', async () => {
     const hiddenAttrs = await harness.getIconsAriaHidden();
-    expect(hiddenAttrs.length).toBe(6);
+    expect(hiddenAttrs.length).toBe(7);
     hiddenAttrs.forEach(attr => {
       expect(attr).toBe('true');
     });
@@ -284,16 +284,16 @@ describe('ComposerShell Layout', () => {
 
   it('renders Material icons inside navigation list items', async () => {
     const icons = await harness.getNavListIconsText();
-    expect(icons).toEqual(['construction', 'widgets', 'dashboard_customize', 'settings']);
+    expect(icons).toEqual(['construction', 'widgets', 'dashboard_customize', 'movie', 'settings']);
   });
 
   it('enables tooltips on navigation items and hides labels when collapsed initially', async () => {
-    expect(await harness.getNavListTooltipsDisabled()).toEqual([false, false, false, false]);
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([false, false, false, false, false]);
     expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(0);
     await harness.clickHamburgerButton();
     expect(await harness.isSidenavCollapsed()).toBe(false);
-    expect(await harness.getNavListTooltipsDisabled()).toEqual([true, true, true, true]);
-    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(4);
+    expect(await harness.getNavListTooltipsDisabled()).toEqual([true, true, true, true, true]);
+    expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(5);
   });
 
   it('sets explicit aria-label attributes on navigation links and connects hamburger button to sidenav', () => {
@@ -305,6 +305,7 @@ describe('ComposerShell Layout', () => {
       'Composer Workspace',
       'Components Gallery',
       'Custom Catalog',
+      'Theater',
       'Settings',
     ]);
 
@@ -325,10 +326,11 @@ describe('ComposerShell Layout', () => {
       'active-nav-item',
       'active-nav-item',
       'active-nav-item',
+      'active-nav-item',
     ]);
 
     const rlaDirectives = fixture.debugElement.queryAll(By.directive(RouterLinkActive));
-    expect(rlaDirectives.length).toBe(4);
+    expect(rlaDirectives.length).toBe(5);
     const rlaInstances = rlaDirectives.map(de => de.injector.get(RouterLinkActive));
     expect(rlaInstances[0].routerLinkActiveOptions).toEqual({exact: true});
 

--- a/shell/src/app/styles/_cpk-fallbacks.scss
+++ b/shell/src/app/styles/_cpk-fallbacks.scss
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standalone fallbacks for the `--cpk-*` design tokens.
+//
+// The tokens themselves are defined by the shell theme layer. These pages are
+// authored against that layer, but each one has to render correctly on its own
+// when the theme layer is not present -- otherwise every padding, radius and
+// colour collapses and the page reviews as broken.
+//
+// Consumers reference a token as `var(--cpk-x, var(--cpk-fb-x))`, so the real
+// token always wins when it exists and these values apply only in its absence.
+// Nothing here shadows or overrides the theme.
+
+@mixin light {
+  // Spacing
+  --cpk-fb-space-1: 4px;
+  --cpk-fb-space-2: 8px;
+  --cpk-fb-space-3: 12px;
+  --cpk-fb-space-4: 16px;
+  --cpk-fb-space-5: 24px;
+
+  // Radii
+  --cpk-fb-radius-card: 8px;
+  --cpk-fb-radius-lg: 16px;
+  --cpk-fb-radius-pill: 9999px;
+
+  // Type
+  --cpk-fb-font-body: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
+  --cpk-fb-font-mono: 'Spline Sans Mono', ui-monospace, monospace;
+
+  // Surfaces
+  --cpk-fb-surface-elevated: #ffffff;
+  --cpk-fb-surface-sunken: rgba(0, 0, 0, 0.04);
+  --cpk-fb-glass-bg-hover: rgba(255, 255, 255, 0.62);
+  --cpk-fb-shadow-card: 0px 6px 6px -2px rgba(1, 5, 7, 0.08);
+
+  // Lines
+  --cpk-fb-border: #cfcfe0;
+  --cpk-fb-divider: #dbdbe5;
+
+  // Text
+  --cpk-fb-text-primary: #010507;
+  --cpk-fb-text-secondary: #57575b;
+
+  // Accent
+  --cpk-fb-accent: #4355b9;
+  --cpk-fb-accent-bg: rgba(67, 85, 185, 0.1);
+
+  // Status
+  --cpk-fb-success: #1e7d4f;
+  --cpk-fb-success-bg: rgba(30, 125, 79, 0.12);
+  --cpk-fb-warning: #9a5b00;
+  --cpk-fb-warning-bg: rgba(154, 91, 0, 0.14);
+  --cpk-fb-critical: #ba1a1a;
+  --cpk-fb-critical-bg: rgba(186, 26, 26, 0.1);
+}
+
+@mixin dark {
+  --cpk-fb-surface-elevated: #201f20;
+  --cpk-fb-surface-sunken: rgba(255, 255, 255, 0.06);
+  --cpk-fb-glass-bg-hover: rgba(58, 58, 68, 0.6);
+  --cpk-fb-shadow-card: 0px 6px 10px -2px rgba(0, 0, 0, 0.5);
+
+  --cpk-fb-border: rgba(255, 255, 255, 0.16);
+  --cpk-fb-divider: rgba(255, 255, 255, 0.1);
+
+  --cpk-fb-text-primary: #f4f2f7;
+  --cpk-fb-text-secondary: #bcbbc6;
+
+  --cpk-fb-accent: #bac3ff;
+  --cpk-fb-accent-bg: rgba(186, 195, 255, 0.16);
+
+  --cpk-fb-success: #6fdfa0;
+  --cpk-fb-success-bg: rgba(111, 223, 160, 0.16);
+  --cpk-fb-warning: #ffc078;
+  --cpk-fb-warning-bg: rgba(255, 192, 120, 0.16);
+  --cpk-fb-critical: #ffb4ab;
+  --cpk-fb-critical-bg: rgba(255, 180, 171, 0.16);
+}

--- a/shell/src/app/theater/recordings.ts
+++ b/shell/src/app/theater/recordings.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Theater recordings — recorded A2UI v0.9 message streams for playback.
+ *
+ * Built programmatically from the same flight/sales example assets the
+ * Assembled Components page uses, so recordings never drift from the catalog
+ * and add no duplicate fixtures. Each recording is the sequence a real agent
+ * would emit: `createSurface` → `updateComponents(tree)` → one
+ * `updateDataModel` per data state, so replaying it shows the surface get
+ * built and then evolve across states.
+ *
+ * Messages carry a canonical placeholder `surfaceId: 'session'`; the Theater
+ * playback engine rewrites it to a live surface id at replay time.
+ */
+import {DASHBOARD_CATALOG_ID} from '../custom-catalog/catalog/dashboard-catalog';
+import salesSchema from '../custom-catalog/assembled/examples/sales-schema.json';
+import salesData from '../custom-catalog/assembled/examples/sales-data.json';
+import flightSchema from '../custom-catalog/assembled/examples/flight-schema.json';
+import flightData from '../custom-catalog/assembled/examples/flight-data.json';
+
+/** Canonical surface id in recordings; rewritten to a live id at replay. */
+export const RECORDING_SURFACE_ID = 'session';
+
+/** One recorded A2UI v0.9 protocol message. */
+export interface TheaterMessage {
+  version: 'v0.9';
+  [key: string]: unknown;
+}
+
+/** A named data state of a demo (`[{name, data}]` example files). */
+interface DataState {
+  name: string;
+  data: Record<string, unknown>;
+}
+
+/** A recorded session: an ordered stream of A2UI messages plus metadata. */
+export interface TheaterRecording {
+  id: string;
+  label: string;
+  icon: string;
+  description: string;
+  messages: TheaterMessage[];
+}
+
+/**
+ * Assembles a recording from a component tree and a list of data states:
+ * createSurface, then updateComponents, then one updateDataModel per state.
+ */
+function buildRecording(
+  id: string,
+  label: string,
+  icon: string,
+  description: string,
+  components: unknown[],
+  states: DataState[],
+): TheaterRecording {
+  const surfaceId = RECORDING_SURFACE_ID;
+  const messages: TheaterMessage[] = [
+    {version: 'v0.9', createSurface: {surfaceId, catalogId: DASHBOARD_CATALOG_ID}},
+    {version: 'v0.9', updateComponents: {surfaceId, components}},
+    ...states.map(state => ({
+      version: 'v0.9' as const,
+      updateDataModel: {surfaceId, path: '/', op: 'replace', value: state.data},
+    })),
+  ];
+  return {id, label, icon, description, messages};
+}
+
+export const RECORDINGS: TheaterRecording[] = [
+  buildRecording(
+    'sales',
+    'Sales Dashboard',
+    'insights',
+    'A KPI dashboard built from one tree, then re-bound across four quarters of data.',
+    salesSchema as unknown[],
+    salesData as DataState[],
+  ),
+  buildRecording(
+    'flight',
+    'Flight Search',
+    'flight',
+    'A Row of FlightCards expanded from a bound array, re-bound as the results change.',
+    flightSchema as unknown[],
+    flightData as DataState[],
+  ),
+];

--- a/shell/src/app/theater/theater.ng.html
+++ b/shell/src/app/theater/theater.ng.html
@@ -1,0 +1,158 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<div class="th-page">
+  <header class="th-header">
+    <div class="th-intro">
+      <h1 class="th-title">Theater</h1>
+      <p class="th-subtitle">
+        Replay a recorded A2UI v0.9 message stream into a live surface — watch the UI get built and
+        re-bound, message by message.
+      </p>
+    </div>
+    <mat-button-toggle-group
+      class="th-recording-switch"
+      [value]="activeRecordingId()"
+      (change)="selectRecording($event.value)"
+      aria-label="Recording"
+      hideSingleSelectionIndicator
+    >
+      @for (rec of recordings; track rec.id) {
+        <mat-button-toggle [value]="rec.id">
+          <mat-icon aria-hidden="true">{{ rec.icon }}</mat-icon>
+          <span class="th-recording-label">{{ rec.label }}</span>
+        </mat-button-toggle>
+      }
+    </mat-button-toggle-group>
+  </header>
+
+  <div class="th-body">
+    <section class="th-left">
+      <div class="th-stage">
+        <div class="th-pane-label">Surface</div>
+        <div class="th-surface-scroll">
+          @if (step() === 0) {
+            <div class="th-empty">
+              <mat-icon class="th-empty-icon" aria-hidden="true">movie</mat-icon>
+              <p class="th-empty-text">
+                Press play to replay {{ totalSteps() }} messages of “{{ activeRecording().label }}”.
+              </p>
+            </div>
+          }
+          <a2ui-v09-surface [surfaceId]="playbackSurfaceId()"></a2ui-v09-surface>
+        </div>
+      </div>
+
+      <div class="th-transport">
+        <div class="th-controls">
+          <button
+            type="button"
+            mat-icon-button
+            aria-label="Reset"
+            [disabled]="step() === 0"
+            (click)="reset()"
+          >
+            <mat-icon>restart_alt</mat-icon>
+          </button>
+          <button
+            type="button"
+            mat-icon-button
+            aria-label="Step back"
+            [disabled]="step() === 0"
+            (click)="stepBack()"
+          >
+            <mat-icon>chevron_left</mat-icon>
+          </button>
+          <button
+            type="button"
+            mat-icon-button
+            class="th-play"
+            [attr.aria-label]="isPlaying() ? 'Pause' : 'Play'"
+            (click)="togglePlay()"
+          >
+            <mat-icon>{{ isPlaying() ? 'pause' : 'play_arrow' }}</mat-icon>
+          </button>
+          <button
+            type="button"
+            mat-icon-button
+            aria-label="Step forward"
+            [disabled]="step() === totalSteps()"
+            (click)="stepForward()"
+          >
+            <mat-icon>chevron_right</mat-icon>
+          </button>
+          <span class="th-step-readout">{{ step() }} / {{ totalSteps() }}</span>
+        </div>
+        <div class="th-progress" role="progressbar" [attr.aria-valuenow]="step()" [attr.aria-valuemax]="totalSteps()">
+          <div class="th-progress-fill" [style.width.%]="progress()"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="th-inspector">
+      <mat-button-toggle-group
+        class="th-inspector-tabs"
+        [value]="inspectorTab()"
+        (change)="setInspectorTab($event.value)"
+        aria-label="Inspector"
+        hideSingleSelectionIndicator
+      >
+        <mat-button-toggle value="events">Events</mat-button-toggle>
+        <mat-button-toggle value="data">Data</mat-button-toggle>
+        <mat-button-toggle value="config">Config</mat-button-toggle>
+      </mat-button-toggle-group>
+
+      <div class="th-inspector-body">
+        @switch (inspectorTab()) {
+          @case ('events') {
+            <ol class="th-events">
+              @for (event of events(); track event.index) {
+                <li>
+                  <button
+                    type="button"
+                    class="th-event"
+                    [class.active]="event.index === currentIndex()"
+                    [class.applied]="event.index <= currentIndex()"
+                    (click)="seek(event.index + 1)"
+                  >
+                    <span class="th-event-num">{{ event.index + 1 }}</span>
+                    <span class="th-event-type th-type-{{ event.type }}">{{ event.type }}</span>
+                    <span class="th-event-summary">{{ event.summary }}</span>
+                  </button>
+                </li>
+              }
+            </ol>
+          }
+          @case ('data') {
+            <pre class="th-code"><code>{{ currentData() }}</code></pre>
+          }
+          @case ('config') {
+            <dl class="th-config">
+              <dt>Recording</dt>
+              <dd>{{ config().label }}</dd>
+              <dt>Surface id</dt>
+              <dd><code>{{ config().surfaceId }}</code></dd>
+              <dt>Catalog id</dt>
+              <dd><code>{{ config().catalogId }}</code></dd>
+              <dt>Messages</dt>
+              <dd>{{ config().totalSteps }}</dd>
+            </dl>
+          }
+        }
+      </div>
+    </section>
+  </div>
+</div>

--- a/shell/src/app/theater/theater.ng.html
+++ b/shell/src/app/theater/theater.ng.html
@@ -96,7 +96,12 @@
           </button>
           <span class="th-step-readout">{{ step() }} / {{ totalSteps() }}</span>
         </div>
-        <div class="th-progress" role="progressbar" [attr.aria-valuenow]="step()" [attr.aria-valuemax]="totalSteps()">
+        <div
+          class="th-progress"
+          role="progressbar"
+          [attr.aria-valuenow]="step()"
+          [attr.aria-valuemax]="totalSteps()"
+        >
           <div class="th-progress-fill" [style.width.%]="progress()"></div>
         </div>
       </div>
@@ -144,9 +149,13 @@
               <dt>Recording</dt>
               <dd>{{ config().label }}</dd>
               <dt>Surface id</dt>
-              <dd><code>{{ config().surfaceId }}</code></dd>
+              <dd>
+                <code>{{ config().surfaceId }}</code>
+              </dd>
               <dt>Catalog id</dt>
-              <dd><code>{{ config().catalogId }}</code></dd>
+              <dd>
+                <code>{{ config().catalogId }}</code>
+              </dd>
               <dt>Messages</dt>
               <dd>{{ config().totalSteps }}</dd>
             </dl>

--- a/shell/src/app/theater/theater.scss
+++ b/shell/src/app/theater/theater.scss
@@ -1,0 +1,345 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: block;
+  height: 100%;
+  box-sizing: border-box;
+  color: var(--cpk-text-primary);
+  font-family: var(--cpk-font-body);
+}
+
+.th-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: var(--cpk-space-4);
+  padding: var(--cpk-space-5);
+  box-sizing: border-box;
+}
+
+.th-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--cpk-space-5);
+  flex-wrap: wrap;
+}
+
+.th-title {
+  margin: 0 0 var(--cpk-space-1);
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.th-subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--cpk-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.th-recording-switch,
+.th-inspector-tabs {
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-pill);
+  overflow: hidden;
+  background: var(--cpk-surface-elevated);
+  flex: 0 0 auto;
+
+  ::ng-deep .mat-button-toggle-label-content {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cpk-space-2);
+    line-height: 36px;
+    padding: 0 var(--cpk-space-4);
+  }
+
+  ::ng-deep .mat-button-toggle {
+    color: var(--cpk-text-secondary);
+  }
+
+  ::ng-deep .mat-button-toggle-checked {
+    background: var(--cpk-accent-bg);
+    color: var(--cpk-accent);
+  }
+
+  ::ng-deep mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.th-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: var(--cpk-space-4);
+
+  @media (max-width: 900px) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: minmax(280px, auto);
+  }
+}
+
+.th-left {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: var(--cpk-space-4);
+}
+
+.th-stage {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-lg);
+  background: var(--cpk-surface-elevated);
+  box-shadow: var(--cpk-shadow-card);
+  overflow: hidden;
+}
+
+.th-pane-label {
+  flex: 0 0 auto;
+  padding: var(--cpk-space-3) var(--cpk-space-4);
+  border-bottom: 1px solid var(--cpk-divider);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--cpk-text-secondary);
+}
+
+.th-surface-scroll {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--cpk-space-5);
+}
+
+.th-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--cpk-space-3);
+  color: var(--cpk-text-secondary);
+  text-align: center;
+  pointer-events: none;
+}
+
+.th-empty-icon {
+  font-size: 40px;
+  width: 40px;
+  height: 40px;
+  opacity: 0.5;
+}
+
+.th-empty-text {
+  margin: 0;
+  max-width: 40ch;
+  font-size: 0.9rem;
+}
+
+.th-transport {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cpk-space-2);
+  padding: var(--cpk-space-3) var(--cpk-space-4);
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-lg);
+  background: var(--cpk-surface-elevated);
+  box-shadow: var(--cpk-shadow-card);
+}
+
+.th-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--cpk-space-1);
+}
+
+.th-play {
+  color: var(--cpk-accent);
+}
+
+.th-step-readout {
+  margin-left: auto;
+  font-family: var(--cpk-font-mono);
+  font-size: 0.8125rem;
+  color: var(--cpk-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.th-progress {
+  height: 4px;
+  border-radius: 9999px;
+  background: var(--cpk-divider);
+  overflow: hidden;
+}
+
+.th-progress-fill {
+  height: 100%;
+  background: var(--cpk-accent);
+  transition: width 0.2s ease;
+}
+
+.th-inspector {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: var(--cpk-space-3);
+  border: 1px solid var(--cpk-border);
+  border-radius: var(--cpk-radius-lg);
+  background: var(--cpk-surface-elevated);
+  box-shadow: var(--cpk-shadow-card);
+  padding: var(--cpk-space-3);
+  box-sizing: border-box;
+}
+
+.th-inspector-tabs {
+  align-self: flex-start;
+}
+
+.th-inspector-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.th-events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.th-event {
+  display: flex;
+  align-items: center;
+  gap: var(--cpk-space-2);
+  width: 100%;
+  text-align: left;
+  padding: var(--cpk-space-2) var(--cpk-space-2);
+  border: 1px solid transparent;
+  border-radius: var(--cpk-radius-md, 8px);
+  background: transparent;
+  color: var(--cpk-text-secondary);
+  font-family: var(--cpk-font-body);
+  font-size: 0.8rem;
+  cursor: pointer;
+  opacity: 0.6;
+
+  &:hover {
+    background: var(--cpk-glass-bg-hover);
+  }
+
+  &.applied {
+    opacity: 1;
+    color: var(--cpk-text-primary);
+  }
+
+  &.active {
+    background: var(--cpk-accent-bg);
+    border-color: var(--cpk-accent);
+  }
+}
+
+.th-event-num {
+  flex: 0 0 auto;
+  width: 18px;
+  text-align: right;
+  font-family: var(--cpk-font-mono);
+  font-size: 0.72rem;
+  color: var(--cpk-text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.th-event-type {
+  flex: 0 0 auto;
+  font-family: var(--cpk-font-mono);
+  font-size: 0.68rem;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--cpk-divider);
+  color: var(--cpk-text-secondary);
+}
+
+.th-type-createSurface {
+  background: var(--cpk-accent-bg);
+  color: var(--cpk-accent);
+}
+
+.th-type-updateComponents {
+  background: var(--cpk-success-bg);
+  color: var(--cpk-success);
+}
+
+.th-type-updateDataModel {
+  background: var(--cpk-warning-bg);
+  color: var(--cpk-warning);
+}
+
+.th-event-summary {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.th-code {
+  margin: 0;
+  padding: var(--cpk-space-3);
+  overflow: auto;
+  font-family: var(--cpk-font-mono);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--cpk-text-primary);
+  white-space: pre;
+}
+
+.th-config {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--cpk-space-2) var(--cpk-space-4);
+  font-size: 0.8125rem;
+
+  dt {
+    color: var(--cpk-text-secondary);
+    font-weight: 600;
+  }
+
+  dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+
+    code {
+      font-family: var(--cpk-font-mono);
+      font-size: 0.75rem;
+    }
+  }
+}

--- a/shell/src/app/theater/theater.scss
+++ b/shell/src/app/theater/theater.scss
@@ -14,20 +14,30 @@
  * limitations under the License.
  */
 
+@use '../styles/cpk-fallbacks' as cpk-fallbacks;
+
+// Render correctly even when the shell theme layer is absent.
+:host {
+  @include cpk-fallbacks.light;
+}
+
+:host-context(.dark-theme) {
+  @include cpk-fallbacks.dark;
+}
 :host {
   display: block;
   height: 100%;
   box-sizing: border-box;
-  color: var(--cpk-text-primary);
-  font-family: var(--cpk-font-body);
+  color: var(--cpk-text-primary, var(--cpk-fb-text-primary));
+  font-family: var(--cpk-font-body, var(--cpk-fb-font-body));
 }
 
 .th-page {
   display: flex;
   flex-direction: column;
   height: 100%;
-  gap: var(--cpk-space-4);
-  padding: var(--cpk-space-5);
+  gap: var(--cpk-space-4, var(--cpk-fb-space-4));
+  padding: var(--cpk-space-5, var(--cpk-fb-space-5));
   box-sizing: border-box;
 }
 
@@ -35,12 +45,12 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--cpk-space-5);
+  gap: var(--cpk-space-5, var(--cpk-fb-space-5));
   flex-wrap: wrap;
 }
 
 .th-title {
-  margin: 0 0 var(--cpk-space-1);
+  margin: 0 0 var(--cpk-space-1, var(--cpk-fb-space-1));
   font-size: 1.5rem;
   font-weight: 600;
 }
@@ -48,34 +58,34 @@
 .th-subtitle {
   margin: 0;
   max-width: 62ch;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   font-size: 0.875rem;
   line-height: 1.5;
 }
 
 .th-recording-switch,
 .th-inspector-tabs {
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-pill);
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-pill, var(--cpk-fb-radius-pill));
   overflow: hidden;
-  background: var(--cpk-surface-elevated);
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
   flex: 0 0 auto;
 
   ::ng-deep .mat-button-toggle-label-content {
     display: inline-flex;
     align-items: center;
-    gap: var(--cpk-space-2);
+    gap: var(--cpk-space-2, var(--cpk-fb-space-2));
     line-height: 36px;
-    padding: 0 var(--cpk-space-4);
+    padding: 0 var(--cpk-space-4, var(--cpk-fb-space-4));
   }
 
   ::ng-deep .mat-button-toggle {
-    color: var(--cpk-text-secondary);
+    color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   }
 
   ::ng-deep .mat-button-toggle-checked {
-    background: var(--cpk-accent-bg);
-    color: var(--cpk-accent);
+    background: var(--cpk-accent-bg, var(--cpk-fb-accent-bg));
+    color: var(--cpk-accent, var(--cpk-fb-accent));
   }
 
   ::ng-deep mat-icon {
@@ -90,7 +100,7 @@
   min-height: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
-  gap: var(--cpk-space-4);
+  gap: var(--cpk-space-4, var(--cpk-fb-space-4));
 
   @media (max-width: 900px) {
     grid-template-columns: minmax(0, 1fr);
@@ -102,7 +112,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  gap: var(--cpk-space-4);
+  gap: var(--cpk-space-4, var(--cpk-fb-space-4));
 }
 
 .th-stage {
@@ -110,22 +120,22 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-lg);
-  background: var(--cpk-surface-elevated);
-  box-shadow: var(--cpk-shadow-card);
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-lg, var(--cpk-fb-radius-lg));
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
+  box-shadow: var(--cpk-shadow-card, var(--cpk-fb-shadow-card));
   overflow: hidden;
 }
 
 .th-pane-label {
   flex: 0 0 auto;
-  padding: var(--cpk-space-3) var(--cpk-space-4);
-  border-bottom: 1px solid var(--cpk-divider);
+  padding: var(--cpk-space-3, var(--cpk-fb-space-3)) var(--cpk-space-4, var(--cpk-fb-space-4));
+  border-bottom: 1px solid var(--cpk-divider, var(--cpk-fb-divider));
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
 }
 
 .th-surface-scroll {
@@ -133,7 +143,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: var(--cpk-space-5);
+  padding: var(--cpk-space-5, var(--cpk-fb-space-5));
 }
 
 .th-empty {
@@ -143,8 +153,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: var(--cpk-space-3);
-  color: var(--cpk-text-secondary);
+  gap: var(--cpk-space-3, var(--cpk-fb-space-3));
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   text-align: center;
   pointer-events: none;
 }
@@ -166,42 +176,42 @@
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  gap: var(--cpk-space-2);
-  padding: var(--cpk-space-3) var(--cpk-space-4);
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-lg);
-  background: var(--cpk-surface-elevated);
-  box-shadow: var(--cpk-shadow-card);
+  gap: var(--cpk-space-2, var(--cpk-fb-space-2));
+  padding: var(--cpk-space-3, var(--cpk-fb-space-3)) var(--cpk-space-4, var(--cpk-fb-space-4));
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-lg, var(--cpk-fb-radius-lg));
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
+  box-shadow: var(--cpk-shadow-card, var(--cpk-fb-shadow-card));
 }
 
 .th-controls {
   display: flex;
   align-items: center;
-  gap: var(--cpk-space-1);
+  gap: var(--cpk-space-1, var(--cpk-fb-space-1));
 }
 
 .th-play {
-  color: var(--cpk-accent);
+  color: var(--cpk-accent, var(--cpk-fb-accent));
 }
 
 .th-step-readout {
   margin-left: auto;
-  font-family: var(--cpk-font-mono);
+  font-family: var(--cpk-font-mono, var(--cpk-fb-font-mono));
   font-size: 0.8125rem;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   font-variant-numeric: tabular-nums;
 }
 
 .th-progress {
   height: 4px;
   border-radius: 9999px;
-  background: var(--cpk-divider);
+  background: var(--cpk-divider, var(--cpk-fb-divider));
   overflow: hidden;
 }
 
 .th-progress-fill {
   height: 100%;
-  background: var(--cpk-accent);
+  background: var(--cpk-accent, var(--cpk-fb-accent));
   transition: width 0.2s ease;
 }
 
@@ -209,12 +219,12 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  gap: var(--cpk-space-3);
-  border: 1px solid var(--cpk-border);
-  border-radius: var(--cpk-radius-lg);
-  background: var(--cpk-surface-elevated);
-  box-shadow: var(--cpk-shadow-card);
-  padding: var(--cpk-space-3);
+  gap: var(--cpk-space-3, var(--cpk-fb-space-3));
+  border: 1px solid var(--cpk-border, var(--cpk-fb-border));
+  border-radius: var(--cpk-radius-lg, var(--cpk-fb-radius-lg));
+  background: var(--cpk-surface-elevated, var(--cpk-fb-surface-elevated));
+  box-shadow: var(--cpk-shadow-card, var(--cpk-fb-shadow-card));
+  padding: var(--cpk-space-3, var(--cpk-fb-space-3));
   box-sizing: border-box;
 }
 
@@ -240,31 +250,31 @@
 .th-event {
   display: flex;
   align-items: center;
-  gap: var(--cpk-space-2);
+  gap: var(--cpk-space-2, var(--cpk-fb-space-2));
   width: 100%;
   text-align: left;
-  padding: var(--cpk-space-2) var(--cpk-space-2);
+  padding: var(--cpk-space-2, var(--cpk-fb-space-2)) var(--cpk-space-2, var(--cpk-fb-space-2));
   border: 1px solid transparent;
   border-radius: var(--cpk-radius-md, 8px);
   background: transparent;
-  color: var(--cpk-text-secondary);
-  font-family: var(--cpk-font-body);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
+  font-family: var(--cpk-font-body, var(--cpk-fb-font-body));
   font-size: 0.8rem;
   cursor: pointer;
   opacity: 0.6;
 
   &:hover {
-    background: var(--cpk-glass-bg-hover);
+    background: var(--cpk-glass-bg-hover, var(--cpk-fb-glass-bg-hover));
   }
 
   &.applied {
     opacity: 1;
-    color: var(--cpk-text-primary);
+    color: var(--cpk-text-primary, var(--cpk-fb-text-primary));
   }
 
   &.active {
-    background: var(--cpk-accent-bg);
-    border-color: var(--cpk-accent);
+    background: var(--cpk-accent-bg, var(--cpk-fb-accent-bg));
+    border-color: var(--cpk-accent, var(--cpk-fb-accent));
   }
 }
 
@@ -272,35 +282,35 @@
   flex: 0 0 auto;
   width: 18px;
   text-align: right;
-  font-family: var(--cpk-font-mono);
+  font-family: var(--cpk-font-mono, var(--cpk-fb-font-mono));
   font-size: 0.72rem;
-  color: var(--cpk-text-secondary);
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
   font-variant-numeric: tabular-nums;
 }
 
 .th-event-type {
   flex: 0 0 auto;
-  font-family: var(--cpk-font-mono);
+  font-family: var(--cpk-font-mono, var(--cpk-fb-font-mono));
   font-size: 0.68rem;
   padding: 1px 6px;
   border-radius: 4px;
-  background: var(--cpk-divider);
-  color: var(--cpk-text-secondary);
+  background: var(--cpk-divider, var(--cpk-fb-divider));
+  color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
 }
 
 .th-type-createSurface {
-  background: var(--cpk-accent-bg);
-  color: var(--cpk-accent);
+  background: var(--cpk-accent-bg, var(--cpk-fb-accent-bg));
+  color: var(--cpk-accent, var(--cpk-fb-accent));
 }
 
 .th-type-updateComponents {
-  background: var(--cpk-success-bg);
-  color: var(--cpk-success);
+  background: var(--cpk-success-bg, var(--cpk-fb-success-bg));
+  color: var(--cpk-success, var(--cpk-fb-success));
 }
 
 .th-type-updateDataModel {
-  background: var(--cpk-warning-bg);
-  color: var(--cpk-warning);
+  background: var(--cpk-warning-bg, var(--cpk-fb-warning-bg));
+  color: var(--cpk-warning, var(--cpk-fb-warning));
 }
 
 .th-event-summary {
@@ -312,12 +322,12 @@
 
 .th-code {
   margin: 0;
-  padding: var(--cpk-space-3);
+  padding: var(--cpk-space-3, var(--cpk-fb-space-3));
   overflow: auto;
-  font-family: var(--cpk-font-mono);
+  font-family: var(--cpk-font-mono, var(--cpk-fb-font-mono));
   font-size: 0.75rem;
   line-height: 1.5;
-  color: var(--cpk-text-primary);
+  color: var(--cpk-text-primary, var(--cpk-fb-text-primary));
   white-space: pre;
 }
 
@@ -325,11 +335,11 @@
   margin: 0;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: var(--cpk-space-2) var(--cpk-space-4);
+  gap: var(--cpk-space-2, var(--cpk-fb-space-2)) var(--cpk-space-4, var(--cpk-fb-space-4));
   font-size: 0.8125rem;
 
   dt {
-    color: var(--cpk-text-secondary);
+    color: var(--cpk-text-secondary, var(--cpk-fb-text-secondary));
     font-weight: 600;
   }
 
@@ -338,7 +348,7 @@
     overflow-wrap: anywhere;
 
     code {
-      font-family: var(--cpk-font-mono);
+      font-family: var(--cpk-font-mono, var(--cpk-fb-font-mono));
       font-size: 0.75rem;
     }
   }

--- a/shell/src/app/theater/theater.spec.ts
+++ b/shell/src/app/theater/theater.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {provideZonelessChangeDetection} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {A2uiRendererService} from '@a2ui/angular/v0_9';
+import {Theater} from './theater';
+import {RECORDINGS} from './recordings';
+
+interface TheaterInternals {
+  activeRecordingId: () => string;
+  activeRecording: () => {id: string; label: string; messages: unknown[]};
+  totalSteps: () => number;
+  step: () => number;
+  playbackSurfaceId: () => string;
+  isPlaying: () => boolean;
+  inspectorTab: () => string;
+  currentIndex: () => number;
+  events: () => Array<{index: number; type: string; summary: string}>;
+  currentData: () => string;
+  config: () => {surfaceId: string; catalogId: string; label: string; totalSteps: number};
+  reset: () => void;
+  stepBack: () => void;
+  stepForward: () => void;
+  togglePlay: () => void;
+  seek: (n: number) => void;
+  selectRecording: (id: string) => void;
+  setInspectorTab: (t: string) => void;
+}
+
+describe('Theater', () => {
+  let fixture: ComponentFixture<Theater>;
+  let component: TheaterInternals;
+  let renderer: A2uiRendererService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Theater],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Theater);
+    component = fixture.componentInstance as unknown as TheaterInternals;
+    renderer = fixture.debugElement.injector.get(A2uiRendererService);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('opens on the first recording, parked at step 0', () => {
+    expect(component.activeRecordingId()).toBe(RECORDINGS[0].id);
+    expect(component.step()).toBe(0);
+    expect(component.currentIndex()).toBe(-1);
+  });
+
+  it('lists every message on the timeline with the right types', () => {
+    const events = component.events();
+    expect(events).toHaveLength(component.totalSteps());
+    expect(events[0].type).toBe('createSurface');
+    expect(events[1].type).toBe('updateComponents');
+    expect(events[2].type).toBe('updateDataModel');
+  });
+
+  it('stepping forward applies createSurface and builds the playback surface', () => {
+    component.stepForward();
+    expect(component.step()).toBe(1);
+    expect(renderer.surfaceGroup.getSurface(component.playbackSurfaceId())).toBeTruthy();
+  });
+
+  it('rewinding starts a fresh surface generation', () => {
+    component.seek(3);
+    const beforeId = component.playbackSurfaceId();
+    component.seek(1);
+    expect(component.playbackSurfaceId()).not.toBe(beforeId);
+    expect(component.step()).toBe(1);
+  });
+
+  it('surfaces the effective data model at the playhead', () => {
+    expect(component.currentData()).toBe('{}');
+    component.seek(component.totalSteps());
+    expect(component.currentData()).toContain('kpis');
+  });
+
+  it('reset returns to a blank step 0', () => {
+    component.seek(component.totalSteps());
+    component.reset();
+    expect(component.step()).toBe(0);
+    expect(component.isPlaying()).toBe(false);
+  });
+
+  it('switching recordings resets to step 0', () => {
+    component.seek(2);
+    const other = RECORDINGS.find(r => r.id !== component.activeRecordingId())!;
+    component.selectRecording(other.id);
+    expect(component.activeRecordingId()).toBe(other.id);
+    expect(component.step()).toBe(0);
+  });
+
+  it('config reports the recording surface + catalog ids', () => {
+    const cfg = component.config();
+    expect(cfg.catalogId).toBe('copilotkit://app-dashboard-catalog');
+    expect(cfg.totalSteps).toBe(component.totalSteps());
+    expect(cfg.surfaceId).toBe(component.playbackSurfaceId());
+  });
+
+  it('plays through to the end and stops', () => {
+    vi.useFakeTimers();
+    const total = component.totalSteps();
+    component.togglePlay();
+    expect(component.isPlaying()).toBe(true);
+
+    vi.advanceTimersByTime(900 * (total + 1));
+
+    expect(component.step()).toBe(total);
+    expect(component.isPlaying()).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('toggles inspector tabs', () => {
+    expect(component.inspectorTab()).toBe('events');
+    component.setInspectorTab('data');
+    expect(component.inspectorTab()).toBe('data');
+  });
+});

--- a/shell/src/app/theater/theater.ts
+++ b/shell/src/app/theater/theater.ts
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import {MatButtonModule} from '@angular/material/button';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {MatIconModule} from '@angular/material/icon';
+import {A2uiRendererService, A2UI_RENDERER_CONFIG, SurfaceComponent} from '@a2ui/angular/v0_9';
+import {buildDashboardCatalog} from '../custom-catalog/catalog/dashboard-catalog';
+import {RECORDINGS, type TheaterMessage, type TheaterRecording} from './recordings';
+import {formatJson} from '../utils/json';
+
+/** Which inspector face is showing. */
+type InspectorTab = 'events' | 'data' | 'config';
+
+/** Recognised A2UI message kinds for timeline labelling. */
+type MessageType = 'createSurface' | 'updateComponents' | 'updateDataModel' | 'message';
+
+/** One row of the message timeline. */
+interface TimelineEvent {
+  index: number;
+  type: MessageType;
+  summary: string;
+}
+
+/** Autoplay cadence — one message applied per tick. */
+const PLAYBACK_INTERVAL_MS = 900;
+
+/**
+ * Theater route. Replays a recorded A2UI v0.9 message stream into a live native
+ * surface, message by message, with transport controls, a clickable timeline,
+ * and an Events/Data/Config inspector.
+ *
+ * Playback is generation-based to avoid the stale-`createSurface` trap: forward
+ * stepping applies the next message incrementally; rewinding starts a fresh
+ * surface generation (`theater-<gen>`) and replays from the start. Each
+ * message's `surfaceId` is rewritten to the live generation at replay.
+ */
+@Component({
+  selector: 'a2ui-composer-theater',
+  standalone: true,
+  imports: [MatButtonModule, MatButtonToggleModule, MatIconModule, SurfaceComponent],
+  templateUrl: './theater.ng.html',
+  styleUrl: './theater.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    A2uiRendererService,
+    {
+      provide: A2UI_RENDERER_CONFIG,
+      useFactory: () => ({
+        catalogs: [buildDashboardCatalog()],
+        actionHandler: (action: unknown) => console.info('[theater] action dispatched', action),
+      }),
+    },
+  ],
+})
+export class Theater {
+  private readonly renderer = inject(A2uiRendererService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly recordings = RECORDINGS;
+  protected readonly activeRecordingId = signal<string>(RECORDINGS[0].id);
+  protected readonly activeRecording = computed<TheaterRecording>(
+    () => this.recordings.find(r => r.id === this.activeRecordingId()) ?? this.recordings[0],
+  );
+  protected readonly totalSteps = computed(() => this.activeRecording().messages.length);
+
+  /** Number of messages applied so far (0..totalSteps). */
+  protected readonly step = signal<number>(0);
+  private appliedStep = 0;
+  private gen = 0;
+  protected readonly playbackSurfaceId = signal<string>('theater-0');
+
+  protected readonly isPlaying = signal<boolean>(false);
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  protected readonly inspectorTab = signal<InspectorTab>('events');
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.stopTimer());
+  }
+
+  // ---------------------------------------------------------------- transport
+
+  protected reset(): void {
+    this.pause();
+    this.seek(0);
+  }
+
+  protected stepBack(): void {
+    this.pause();
+    this.seek(this.step() - 1);
+  }
+
+  protected stepForward(): void {
+    this.seek(this.step() + 1);
+  }
+
+  protected togglePlay(): void {
+    if (this.isPlaying()) {
+      this.pause();
+      return;
+    }
+    // Restart from the beginning if we're parked at the end.
+    if (this.step() >= this.totalSteps()) this.seek(0);
+    this.isPlaying.set(true);
+    this.timer = setInterval(() => {
+      if (this.step() >= this.totalSteps()) {
+        this.pause();
+        return;
+      }
+      this.seek(this.step() + 1);
+    }, PLAYBACK_INTERVAL_MS);
+  }
+
+  private pause(): void {
+    this.isPlaying.set(false);
+    this.stopTimer();
+  }
+
+  private stopTimer(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Moves the playhead to `target` (clamped), rebuilding on a rewind. */
+  protected seek(target: number): void {
+    const clamped = Math.max(0, Math.min(target, this.totalSteps()));
+    const messages = this.activeRecording().messages;
+    if (clamped < this.appliedStep) {
+      this.gen += 1;
+      this.playbackSurfaceId.set(`theater-${this.gen}`);
+      this.appliedStep = 0;
+      this.applyRange(messages, 0, clamped);
+    } else if (clamped > this.appliedStep) {
+      this.applyRange(messages, this.appliedStep, clamped);
+    }
+    this.appliedStep = clamped;
+    this.step.set(clamped);
+  }
+
+  private applyRange(messages: TheaterMessage[], from: number, to: number): void {
+    const surfaceId = this.playbackSurfaceId();
+    for (let i = from; i < to; i++) {
+      this.renderer.processMessages([this.withSurfaceId(messages[i], surfaceId)] as never);
+    }
+  }
+
+  /** Clones a message with its sub-message `surfaceId` rewritten to `surfaceId`. */
+  private withSurfaceId(msg: TheaterMessage, surfaceId: string): TheaterMessage {
+    const clone: TheaterMessage = {...msg};
+    for (const key of ['createSurface', 'updateComponents', 'updateDataModel'] as const) {
+      const sub = clone[key];
+      if (sub && typeof sub === 'object') {
+        clone[key] = {...(sub as Record<string, unknown>), surfaceId};
+      }
+    }
+    return clone;
+  }
+
+  protected selectRecording(id: string): void {
+    if (id === this.activeRecordingId()) return;
+    this.pause();
+    this.activeRecordingId.set(id);
+    // Start the new recording blank on a fresh generation.
+    this.gen += 1;
+    this.playbackSurfaceId.set(`theater-${this.gen}`);
+    this.appliedStep = 0;
+    this.step.set(0);
+  }
+
+  protected setInspectorTab(tab: InspectorTab): void {
+    this.inspectorTab.set(tab);
+  }
+
+  // ---------------------------------------------------------------- inspector
+
+  /** Index of the currently-applied message (`step - 1`), or -1 if none. */
+  protected readonly currentIndex = computed(() => this.step() - 1);
+
+  protected readonly progress = computed(() => {
+    const total = this.totalSteps();
+    return total > 0 ? (this.step() / total) * 100 : 0;
+  });
+
+  protected readonly events = computed<TimelineEvent[]>(() =>
+    this.activeRecording().messages.map((message, index) => ({
+      index,
+      type: this.messageType(message),
+      summary: this.messageSummary(message),
+    })),
+  );
+
+  /** The effective data model at the playhead (last applied `updateDataModel`). */
+  protected readonly currentData = computed<string>(() => {
+    const messages = this.activeRecording().messages;
+    let value: unknown = {};
+    for (let i = 0; i < this.step(); i++) {
+      const update = messages[i]['updateDataModel'] as {value?: unknown} | undefined;
+      if (update && 'value' in update) value = update.value;
+    }
+    return formatJson(value);
+  });
+
+  protected readonly config = computed(() => {
+    const recording = this.activeRecording();
+    const create = recording.messages[0]?.['createSurface'] as {catalogId?: string} | undefined;
+    return {
+      surfaceId: this.playbackSurfaceId(),
+      catalogId: create?.catalogId ?? '—',
+      label: recording.label,
+      totalSteps: recording.messages.length,
+    };
+  });
+
+  private messageType(msg: TheaterMessage): MessageType {
+    if (msg['createSurface']) return 'createSurface';
+    if (msg['updateComponents']) return 'updateComponents';
+    if (msg['updateDataModel']) return 'updateDataModel';
+    return 'message';
+  }
+
+  private messageSummary(msg: TheaterMessage): string {
+    if (msg['createSurface']) return 'Create surface';
+    const update = msg['updateComponents'] as {components?: unknown[]} | undefined;
+    if (update) return `Update components (${update.components?.length ?? 0})`;
+    if (msg['updateDataModel']) return 'Update data model';
+    return 'Message';
+  }
+}

--- a/shell/src/app/theater/theater.ts
+++ b/shell/src/app/theater/theater.ts
@@ -87,7 +87,6 @@ export class Theater {
 
   /** Number of messages applied so far (0..totalSteps). */
   protected readonly step = signal<number>(0);
-  private appliedStep = 0;
   private gen = 0;
   protected readonly playbackSurfaceId = signal<string>('theater-0');
 
@@ -145,50 +144,52 @@ export class Theater {
     }
   }
 
-  /** Moves the playhead to `target` (clamped), rebuilding on a rewind. */
+  /**
+   * Moves the playhead to `target` (clamped). Always replays the prefix
+   * `[0, target)` as a single batch onto a fresh surface generation: this
+   * keeps `createSurface` + `updateComponents` (+ data) in one
+   * `processMessages` call — the form the native renderer renders correctly —
+   * and creates the surface in the same synchronous tick the template switches
+   * to its id, so there is no mount-before-create gap. Old generations linger
+   * harmlessly in the service.
+   */
   protected seek(target: number): void {
     const clamped = Math.max(0, Math.min(target, this.totalSteps()));
-    const messages = this.activeRecording().messages;
-    if (clamped < this.appliedStep) {
-      this.gen += 1;
-      this.playbackSurfaceId.set(`theater-${this.gen}`);
-      this.appliedStep = 0;
-      this.applyRange(messages, 0, clamped);
-    } else if (clamped > this.appliedStep) {
-      this.applyRange(messages, this.appliedStep, clamped);
+    this.gen += 1;
+    const surfaceId = `theater-${this.gen}`;
+    this.playbackSurfaceId.set(surfaceId);
+    const batch = this.activeRecording()
+      .messages.slice(0, clamped)
+      .map(message => this.toNativeMessage(message, surfaceId));
+    if (batch.length > 0) {
+      this.renderer.processMessages(batch as never);
     }
-    this.appliedStep = clamped;
     this.step.set(clamped);
   }
 
-  private applyRange(messages: TheaterMessage[], from: number, to: number): void {
-    const surfaceId = this.playbackSurfaceId();
-    for (let i = from; i < to; i++) {
-      this.renderer.processMessages([this.withSurfaceId(messages[i], surfaceId)] as never);
-    }
-  }
-
-  /** Clones a message with its sub-message `surfaceId` rewritten to `surfaceId`. */
-  private withSurfaceId(msg: TheaterMessage, surfaceId: string): TheaterMessage {
-    const clone: TheaterMessage = {...msg};
+  /**
+   * Converts a recorded v0.9 envelope into the unwrapped message the native
+   * renderer expects: drops the top-level `version` field (the native
+   * `processMessages` takes bare `{createSurface|updateComponents|
+   * updateDataModel: {...}}`, as the Assembled/Reference pages send) and
+   * rewrites the sub-message `surfaceId` to the live generation.
+   */
+  private toNativeMessage(msg: TheaterMessage, surfaceId: string): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
     for (const key of ['createSurface', 'updateComponents', 'updateDataModel'] as const) {
-      const sub = clone[key];
+      const sub = msg[key];
       if (sub && typeof sub === 'object') {
-        clone[key] = {...(sub as Record<string, unknown>), surfaceId};
+        out[key] = {...(sub as Record<string, unknown>), surfaceId};
       }
     }
-    return clone;
+    return out;
   }
 
   protected selectRecording(id: string): void {
     if (id === this.activeRecordingId()) return;
     this.pause();
     this.activeRecordingId.set(id);
-    // Start the new recording blank on a fresh generation.
-    this.gen += 1;
-    this.playbackSurfaceId.set(`theater-${this.gen}`);
-    this.appliedStep = 0;
-    this.step.set(0);
+    this.seek(0); // fresh generation, blank surface
   }
 
   protected setInspectorTab(tab: InspectorTab): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5936,6 +5936,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "a2ui-composer-shell@workspace:shell"
   dependencies:
+    "@a2ui/angular": "npm:0.10.4"
+    "@a2ui/web_core": "npm:0.10.5"
     "@analogjs/vite-plugin-angular": "npm:2.6.3"
     "@angular-devkit/build-angular": "npm:22.0.7"
     "@angular/animations": "npm:22.0.7"
@@ -5975,6 +5977,7 @@ __metadata:
     typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.65.0"
     vitest: "npm:4.1.10"
+    zod: "npm:3.25.76"
   languageName: unknown
   linkType: soft
 
@@ -13495,6 +13498,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod@npm:3.25.76, zod@npm:^3.25.76":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
 "zod@npm:4.4.2":
   version: 4.4.2
   resolution: "zod@npm:4.4.2"
@@ -13506,12 +13516,5 @@ __metadata:
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.76":
-  version: 3.25.76
-  resolution: "zod@npm:3.25.76"
-  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
A "theater" that replays a recorded A2UI message stream into a live native surface, message by message — useful for demoing and debugging how a surface builds up over a generation.

> **Depends on #121 (Custom Catalog).** This branch is stacked on #121, so the foundation commits appear in this diff until #121 merges. The Theater-specific changes are the last 4 commits: `theater/**` plus the `/theater` route + nav entry.

### What
- **`/theater` route** with a playback component and a generation-based playback engine.
- Recordings derived from the flight and sales example surfaces.
- Renders natively via `@a2ui/angular` (no iframe); replays the message prefix as a batch so the native surface renders correctly at each step.

### Why
Makes the incremental, message-by-message nature of A2UI surfaces visible — a useful lens for demos and for debugging streamed generations.

### Testing
`ng build` (lint + AOT) green on a clean build; `theater` + `composer-shell` unit tests pass (25 specs).

---
Contributed by CopilotKit.

## Screenshots

`/theater` — A2UI message-stream playback:

| Light | Dark |
|---|---|
| <img src="https://raw.githubusercontent.com/jerelvelarde/a2ui-composer/jerel/pr-media/media/v2-theater-light.png" width="420"> | <img src="https://raw.githubusercontent.com/jerelvelarde/a2ui-composer/jerel/pr-media/media/v2-theater-dark.png" width="420"> |

