### PR TITLE
Configure Monaco editor to render overflow widgets in a custom body-l…

### DIFF
--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -175,7 +175,7 @@ for (const config of CONFIGS) {
       await page.goto(`/?renderer=${config.rendererUrl}`);
       await expect(page.locator('.workspace-container')).toBeVisible();
 
-      const editorLocator = page.locator('.monaco-editor');
+      const editorLocator = page.locator('a2ui-composer-monaco-editor .monaco-editor').first();
       await expect(editorLocator).toBeVisible();
 
       await page.waitForFunction(() => {

--- a/shell/e2e/user-journey.e2e.ts
+++ b/shell/e2e/user-journey.e2e.ts
@@ -58,7 +58,7 @@ test.describe('E2E Workspace User Journey', () => {
     await page.waitForLoadState('load');
 
     // 7. Wait for Monaco to load and enter malformed JSON
-    const editorLocator = page.locator('.monaco-editor');
+    const editorLocator = page.locator('a2ui-composer-monaco-editor .monaco-editor').first();
     await expect(editorLocator).toBeVisible();
 
     await page.waitForFunction(() => {

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -171,11 +171,19 @@ export class MonacoEditor {
     });
 
     let destroyed = false;
+    const overflowWidgetsDomNode =
+      typeof document !== 'undefined' ? document.createElement('div') : undefined;
+    if (overflowWidgetsDomNode) {
+      overflowWidgetsDomNode.className = 'monaco-editor monaco-overflow-widgets';
+      document.body.appendChild(overflowWidgetsDomNode);
+    }
+
     this.destroyRef.onDestroy(() => {
       destroyed = true;
       if (this.editor) {
         this.editor.dispose();
       }
+      overflowWidgetsDomNode?.remove();
     });
 
     afterNextRender(() => {
@@ -197,6 +205,8 @@ export class MonacoEditor {
 
         const editor = monacoInstance.editor.create(this.editorContainer().nativeElement, {
           model,
+          fixedOverflowWidgets: true,
+          overflowWidgetsDomNode,
           theme: this.monacoTheme(),
           automaticLayout: true,
           minimap: {enabled: false},


### PR DESCRIPTION
…evel DOM node.

This prevents overflow widgets (such as autocomplete suggestions and hovers) from being clipped by the editor's container boundaries. It enables fixedOverflowWidgets and appends a dedicated container to the document body, which is cleaned up when the component is destroyed.

BUG=538679840


https://screencast.googleplex.com/cast/NDY2MTA0MTI0MDczNTc0NHxhZGQwYzk2Yi0xOQ

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
