### PR TITLE
Use declare interface for property renaming safety across IPC contracts

### DIFF
--- a/bridge/src/angular/angular-bridge.ts
+++ b/bridge/src/angular/angular-bridge.ts
@@ -32,9 +32,10 @@ import {
 import {Catalog, ComponentApi} from '@a2ui/web_core/v0_9';
 import {
   a2uiBridge,
+  ThemePreference,
   RendererProcessor,
   SurfaceStateSubscription,
-  ThemePreference,
+  CatalogDetails,
   type ComponentUsages,
 } from '../preview-bridge.js';
 
@@ -94,7 +95,7 @@ export class A2uiSandboxConnection implements OnDestroy {
         if (catalogs) {
           for (const catalog of catalogs) {
             if (catalog) {
-              (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
+              (catalog as unknown as CatalogDetails).id = catalogId;
             }
           }
         }
@@ -116,7 +117,7 @@ export class A2uiSandboxConnection implements OnDestroy {
    * Disposes active bridge connections and releases event listener subscriptions
    * to prevent memory leaks and observer bloat in high-frequency test runs.
    */
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.rendererConnection?.unsubscribe();
     this.rendererConnection = null;
   }

--- a/bridge/src/bridge-message.ts
+++ b/bridge/src/bridge-message.ts
@@ -137,6 +137,7 @@ export declare interface RenderA2uiItem {
 /** Minimal catalog definition representation used by the Preview Bridge. */
 export declare interface CatalogDetails {
   catalogId?: string;
+  id?: string;
   $id?: string;
   [key: string]: unknown;
 }

--- a/bridge/src/bridge-message.ts
+++ b/bridge/src/bridge-message.ts
@@ -39,19 +39,17 @@ export enum ThemePreference {
 }
 
 /** Payload for SET_THEME message type. */
-export interface SetThemePayload {
+export declare interface SetThemePayload {
   theme: ThemePreference;
 }
 
 /**
  * Represents a message structure transmitted across the Preview Bridge iframe boundary.
  *
- * NOTE: To prevent compilers from renaming properties during minification in
- * production builds, all properties of this message must be constructed using
- * quoted keys (e.g. {'type': ...}) and accessed using bracket notation (e.g.
- * message['type']) when communicating across compilation boundaries.
+ * NOTE: Declared as a `declare interface` so `tsickle` generates compiler `@externs`
+ * definitions for JSCompiler (Closure Compiler), preventing property renaming across frame boundaries.
  */
-export interface BridgeMessage {
+export declare interface BridgeMessage {
   /** The unique type identifier representing the event. */
   type: PreviewBridgeMessageType;
   /** Optional payload data associated with the message event. */
@@ -61,65 +59,65 @@ export interface BridgeMessage {
 }
 
 /** Payload for CONSOLE_LOG message type. */
-export interface ConsoleLogPayload {
+export declare interface ConsoleLogPayload {
   level: string;
   message: string;
   stack?: string;
 }
 
 /** Base interface for all surface layout commands containing surfaceId. */
-export interface BaseSurfaceDetails {
+export declare interface BaseSurfaceDetails {
   surfaceId: string;
 }
 
 /** Inner details for DATA_MODEL_CHANGE payload. */
-export interface UpdateDataModelDetails extends BaseSurfaceDetails {
+export declare interface UpdateDataModelDetails extends BaseSurfaceDetails {
   path?: string;
   value: unknown;
 }
 
 /** Payload for DATA_MODEL_CHANGE message type. */
-export interface DataModelChangePayload {
+export declare interface DataModelChangePayload {
   updateDataModel: UpdateDataModelDetails;
 }
 
 /** Payload for SET_BLOCKING_STATE message type. */
-export interface SetBlockingStatePayload {
+export declare interface SetBlockingStatePayload {
   blocked: boolean;
   message?: string;
 }
 
 /** Details for error in A2UI_CATALOG handshake. */
-export interface CatalogErrorDetails {
+export declare interface CatalogErrorDetails {
   message: string;
 }
 
 /** Payload for A2UI_CATALOG message type. */
-export interface CatalogHandshakePayload {
+export declare interface CatalogHandshakePayload {
   error?: CatalogErrorDetails;
   [key: string]: unknown;
 }
 
 /** Payload for SEND_TO_SERVER message type. */
-export interface SendToServerPayload {
+export declare interface SendToServerPayload {
   version: string;
   action: unknown;
 }
 
 /** Inner details for createSurface command in RENDER_A2UI payload. */
-export interface CreateSurfaceDetails extends BaseSurfaceDetails {
+export declare interface CreateSurfaceDetails extends BaseSurfaceDetails {
   catalogId: string;
   sendDataModel?: boolean;
 }
 
 /** Layout command structure containing createSurface in RENDER_A2UI payload. */
-export interface CreateSurfaceCommand {
+export declare interface CreateSurfaceCommand {
   createSurface?: CreateSurfaceDetails;
   [key: string]: unknown;
 }
 
 /** Inner details for updateComponents command in RENDER_A2UI payload. */
-export interface UpdateComponentsDetails extends BaseSurfaceDetails {
+export declare interface UpdateComponentsDetails extends BaseSurfaceDetails {
   components: unknown[];
 }
 
@@ -127,7 +125,7 @@ export interface UpdateComponentsDetails extends BaseSurfaceDetails {
 export type DeleteSurfaceDetails = BaseSurfaceDetails;
 
 /** Represents a single layout command item inside the RENDER_A2UI array. */
-export interface RenderA2uiItem {
+export declare interface RenderA2uiItem {
   version: string;
   createSurface?: CreateSurfaceDetails;
   updateComponents?: UpdateComponentsDetails;
@@ -137,14 +135,14 @@ export interface RenderA2uiItem {
 }
 
 /** Minimal catalog definition representation used by the Preview Bridge. */
-export interface CatalogDetails {
+export declare interface CatalogDetails {
   catalogId?: string;
   $id?: string;
   [key: string]: unknown;
 }
 
 /** Represents a component instance definition in the A2UI layout tree. */
-export interface A2uiComponentInstance {
+export declare interface A2uiComponentInstance {
   component: string;
   id?: string;
   [key: string]: unknown;

--- a/bridge/src/instrumentation-overrides.ts
+++ b/bridge/src/instrumentation-overrides.ts
@@ -169,14 +169,12 @@ function overrideConsoleMethods(sender: TelemetrySender): void {
         const errorArg = args.find(arg => arg instanceof Error);
         const stack = errorArg ? (errorArg as Error).stack : undefined;
 
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
         sender.sendMessage({
-          'type': PreviewBridgeMessageType.CONSOLE_LOG,
-          'payload': {
-            'level': method,
-            'message': message,
-            'stack': stack,
+          type: PreviewBridgeMessageType.CONSOLE_LOG,
+          payload: {
+            level: method,
+            message: message,
+            stack: stack,
           },
         });
       } catch (err) {
@@ -201,14 +199,12 @@ function overrideWindowError(sender: TelemetrySender): void {
     error: Error | undefined,
   ): boolean => {
     try {
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
       sender.sendMessage({
-        'type': PreviewBridgeMessageType.CONSOLE_LOG,
-        'payload': {
-          'level': 'error',
-          'message': String(message),
-          'stack': error ? error.stack : `${source || ''}:${lineno || 0}:${colno || 0}`,
+        type: PreviewBridgeMessageType.CONSOLE_LOG,
+        payload: {
+          level: 'error',
+          message: String(message),
+          stack: error ? error.stack : `${source || ''}:${lineno || 0}:${colno || 0}`,
         },
       });
     } catch (err) {
@@ -235,14 +231,12 @@ function overrideUnhandledRejection(sender: TelemetrySender): void {
       const message = event.reason instanceof Error ? event.reason.message : String(event.reason);
       const stack = event.reason instanceof Error ? event.reason.stack : undefined;
 
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
       sender.sendMessage({
-        'type': PreviewBridgeMessageType.CONSOLE_LOG,
-        'payload': {
-          'level': 'error',
-          'message': `Unhandled Rejection: ${message}`,
-          'stack': stack,
+        type: PreviewBridgeMessageType.CONSOLE_LOG,
+        payload: {
+          level: 'error',
+          message: `Unhandled Rejection: ${message}`,
+          stack: stack,
         },
       });
     } catch (err) {

--- a/bridge/src/lit/lit-bridge.ts
+++ b/bridge/src/lit/lit-bridge.ts
@@ -20,16 +20,17 @@ import {ContextProvider} from '@lit/context';
 import {Context} from '@a2ui/lit/v0_9';
 import {
   MessageProcessor,
+  SurfaceModel,
   Catalog,
   ComponentApi,
-  SurfaceModel,
   A2uiClientAction,
 } from '@a2ui/web_core/v0_9';
 import type {MarkdownRenderer} from '@a2ui/web_core/types/types';
 import {
   a2uiBridge,
-  SurfaceStateSubscription,
   ThemePreference,
+  SurfaceStateSubscription,
+  CatalogDetails,
   type ComponentUsages,
 } from '../preview-bridge.js';
 
@@ -133,7 +134,7 @@ export class A2uiSandboxRoot extends LitElement {
       onCatalogResolved: catalogId => {
         for (const catalog of (this.constructor as typeof A2uiSandboxRoot).catalogs) {
           if (catalog) {
-            (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
+            (catalog as unknown as CatalogDetails).id = catalogId;
           }
         }
       },

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -27,6 +27,7 @@ import {
   SetThemePayload,
   DataModelChangePayload,
   CreateSurfaceCommand,
+  CatalogDetails,
   ThemePreference,
 } from './bridge-message';
 export * from './bridge-message';
@@ -55,7 +56,7 @@ export type {
  * A framework-agnostic processor interface that handles A2UI protocol payloads.
  * Exposes a single method to process raw incoming action arrays.
  */
-export interface RendererProcessor {
+export declare interface RendererProcessor {
   /**
    * Processes the incoming message payload array.
    * @param payload The array of A2UI protocol commands.
@@ -242,10 +243,8 @@ export class PreviewBridge {
     // bootstrapping and attached its active renderer. This guarantees that the
     // parent receives the ready signal when the sandbox is truly capable of mounting
     // surfaces, structurally eliminating the inter-frame timing race conditions.
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
     this.sendMessage({
-      'type': PreviewBridgeMessageType.RENDERER_READY,
+      type: PreviewBridgeMessageType.RENDERER_READY,
     });
 
     const attachConnection = {
@@ -321,13 +320,11 @@ export class PreviewBridge {
    * @param [version='v0.9'] The A2UI protocol specification version.
    */
   sendAction(action: unknown, version = 'v0.9'): void {
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
     this.sendMessage({
-      'type': PreviewBridgeMessageType.SEND_TO_SERVER,
-      'payload': {
-        'version': version,
-        'action': action,
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {
+        version: version,
+        action: action,
       },
     });
   }
@@ -344,21 +341,19 @@ export class PreviewBridge {
     if (event.source !== window.parent && event.source !== window) return;
 
     const data = event.data as BridgeMessage;
-    // NOTE: Bracket notation is used to access properties on the parsed postMessage event
-    // to prevent compilers from renaming these property accesses during minification.
-    if (!data || typeof data !== 'object' || !data['type']) return;
+    if (!data || typeof data !== 'object' || !data.type) return;
 
-    switch (data['type']) {
+    switch (data.type) {
       case PreviewBridgeMessageType.SET_BLOCKING_STATE:
-        this.handleSetBlockingState(data['payload']);
+        this.handleSetBlockingState(data.payload);
         break;
 
       case PreviewBridgeMessageType.DATA_MODEL_CHANGE:
-        this.handleIncomingDataModelChange(data['payload']);
+        this.handleIncomingDataModelChange(data.payload);
         break;
 
       case PreviewBridgeMessageType.RENDER_A2UI:
-        this.dispatchRenderA2ui(data['payload'] !== undefined ? data['payload'] : data);
+        this.dispatchRenderA2ui(data.payload !== undefined ? data.payload : data);
         break;
 
       case PreviewBridgeMessageType.GET_CATALOG:
@@ -370,11 +365,11 @@ export class PreviewBridge {
         break;
 
       case PreviewBridgeMessageType.SET_THEME:
-        this.handleSetTheme(data['payload']);
+        this.handleSetTheme(data.payload);
         break;
 
       default:
-        console.warn(`PreviewBridge: Unrecognized incoming message type: ${data['type']}`);
+        console.warn(`PreviewBridge: Unrecognized incoming message type: ${data.type}`);
     }
   };
 
@@ -383,8 +378,8 @@ export class PreviewBridge {
    */
   private handleSetTheme(payload: unknown): void {
     const payloadObj = payload as SetThemePayload | undefined;
-    if (payloadObj && Object.values(ThemePreference).includes(payloadObj['theme'])) {
-      const theme = payloadObj['theme'];
+    if (payloadObj && Object.values(ThemePreference).includes(payloadObj.theme)) {
+      const theme = payloadObj.theme;
       this.applyThemeToDom(theme);
       if (this.activeRenderer?.config.onThemeChange) {
         try {
@@ -402,11 +397,9 @@ export class PreviewBridge {
    * Handles incoming blocking overlay requests.
    */
   private handleSetBlockingState(payload: unknown): void {
-    // NOTE: Bracket notation is used to access properties on cross-frame message payloads
-    // to prevent compilers from renaming these properties during production minification.
     const payloadObj = payload as SetBlockingStatePayload | undefined;
-    const blocked = !!(payloadObj && payloadObj['blocked']);
-    const messageStr = payloadObj && payloadObj['message'];
+    const blocked = !!(payloadObj && payloadObj.blocked);
+    const messageStr = payloadObj && payloadObj.message;
     this.handleBlockingOverlay(blocked, messageStr);
   }
 
@@ -414,15 +407,12 @@ export class PreviewBridge {
    * Dynamic interceptor mapping incoming state changes back into a standard render lifecycle payload.
    */
   private handleIncomingDataModelChange(payload: unknown): void {
-    // NOTE: Bracket notation is used to access properties on cross-frame message payloads
-    // to prevent compilers from renaming these properties during production minification.
     const payloadObj = payload as DataModelChangePayload | undefined;
-    if (payloadObj && payloadObj['updateDataModel']) {
-      // prettier-ignore
+    if (payloadObj && payloadObj.updateDataModel) {
       const renderPayload = [
         {
-          'version': 'v0.9',
-          'updateDataModel': payloadObj['updateDataModel'],
+          version: 'v0.9',
+          updateDataModel: payloadObj.updateDataModel,
         },
       ];
       this.dispatchRenderA2ui(renderPayload);
@@ -498,14 +488,14 @@ export class PreviewBridge {
 
       let hasCreateSurface = false;
       let surfaceId: string | undefined;
-      const createSurface = createSurfaceCommand && createSurfaceCommand['createSurface'];
+      const createSurface = createSurfaceCommand && createSurfaceCommand.createSurface;
       if (createSurface) {
         hasCreateSurface = true;
-        const catalogId = createSurface['catalogId'];
+        const catalogId = createSurface.catalogId;
         if (catalogId) {
           this.notifyCatalogResolved(catalogId);
         }
-        surfaceId = createSurface['surfaceId'];
+        surfaceId = createSurface.surfaceId;
         if (surfaceId) {
           // Track the surface BEFORE processing. If a subsequent command in
           // the payload has a typo and throws an error, we still want to
@@ -535,13 +525,11 @@ export class PreviewBridge {
     const {processor, config, activeSurfaceIds} = this.activeRenderer;
     for (const surfaceId of activeSurfaceIds) {
       try {
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
         processor.processMessages([
           {
-            'version': 'v0.9',
-            'deleteSurface': {
-              'surfaceId': surfaceId,
+            version: 'v0.9',
+            deleteSurface: {
+              surfaceId: surfaceId,
             },
           } as A2uiMessage,
         ]);
@@ -586,14 +574,12 @@ export class PreviewBridge {
 
         try {
           const modelSub = surface.dataModel.subscribe('', (newValue: unknown) => {
-            // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-            // prettier-ignore
             this.sendMessage({
-              'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,
-              'payload': {
-                'updateDataModel': {
-                  'surfaceId': surface.id,
-                  'value': newValue,
+              type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
+              payload: {
+                updateDataModel: {
+                  surfaceId: surface.id,
+                  value: newValue,
                 },
               },
             });
@@ -687,11 +673,9 @@ export class PreviewBridge {
         });
 
         button.addEventListener('click', () => {
-          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-          // prettier-ignore
           this.sendMessage({
-            'type': PreviewBridgeMessageType.FORCE_UNBLOCK,
-            'payload': {},
+            type: PreviewBridgeMessageType.FORCE_UNBLOCK,
+            payload: {},
           });
           this.handleBlockingOverlay(false);
         });
@@ -806,30 +790,25 @@ export class PreviewBridge {
 
       const catalog = this.parseCatalogData(resolved.rawData);
 
-      const catalogId = (catalog as Record<string, unknown> | undefined)?.['catalogId'] as
-        string | undefined;
+      const catalogId = (catalog as CatalogDetails | undefined)?.catalogId;
       if (catalogId) {
         this.notifyCatalogResolved(catalogId);
       }
 
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
       this.sendMessage({
-        'type': PreviewBridgeMessageType.A2UI_CATALOG,
-        'payload': catalog,
+        type: PreviewBridgeMessageType.A2UI_CATALOG,
+        payload: catalog,
       });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       if (resolved?.isInMemory) {
         console.error('PreviewBridge: Error processing/parsing in-memory catalog:', error);
       }
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
       this.sendMessage({
-        'type': PreviewBridgeMessageType.A2UI_CATALOG,
-        'payload': {
-          'error': {
-            'message': errorMessage,
+        type: PreviewBridgeMessageType.A2UI_CATALOG,
+        payload: {
+          error: {
+            message: errorMessage,
           },
         },
       });
@@ -848,11 +827,9 @@ export class PreviewBridge {
         console.error('PreviewBridge: Error invoking getComponentUsages:', error);
       }
     }
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
     this.sendMessage({
-      'type': PreviewBridgeMessageType.COMPONENT_USAGES,
-      'payload': usages,
+      type: PreviewBridgeMessageType.COMPONENT_USAGES,
+      payload: usages,
     });
   }
 

--- a/bridge/src/react/react-bridge.ts
+++ b/bridge/src/react/react-bridge.ts
@@ -17,12 +17,12 @@
 import {useState, useEffect} from 'react';
 import {
   MessageProcessor,
+  SurfaceModel,
   Catalog,
   ComponentApi,
-  SurfaceModel,
   A2uiClientAction,
 } from '@a2ui/web_core/v0_9';
-import {a2uiBridge, ThemePreference, type ComponentUsages} from '../preview-bridge.js';
+import {a2uiBridge, ThemePreference, CatalogDetails, ComponentUsages} from '../preview-bridge.js';
 
 export interface UseA2uiSandboxResult<C extends ComponentApi = ComponentApi> {
   /** The reactive dynamic surface drawing model representing the active canvas. */
@@ -68,7 +68,7 @@ export function useA2uiSandbox<C extends ComponentApi = ComponentApi>(
       onCatalogResolved: catalogId => {
         for (const catalog of catalogs) {
           if (catalog) {
-            (catalog as unknown as Record<string, unknown>)['id'] = catalogId;
+            (catalog as unknown as CatalogDetails).id = catalogId;
           }
         }
       },

--- a/bridge/src/render-config.ts
+++ b/bridge/src/render-config.ts
@@ -19,7 +19,7 @@ import {ThemePreference} from './bridge-message';
  * A lightweight, framework-agnostic representation of an observable data model stream.
  * Enables subscribing to reactive updates on component value states.
  */
-export interface DataModelObservable {
+export declare interface DataModelObservable {
   /**
    * Subscribes a callback function to be notified of data model updates.
    *
@@ -33,7 +33,7 @@ export interface DataModelObservable {
 /**
  * Represents an active component surface instance rendered within a sandbox container.
  */
-export interface SurfaceInstance {
+export declare interface SurfaceInstance {
   /** The unique identifier of the surface, corresponding to a Composer surface layout. */
   id: string;
   /** The reactive data model observable facilitating component value synchronization. */
@@ -43,7 +43,7 @@ export interface SurfaceInstance {
 /**
  * A framework-agnostic structural interface representing a collection or group of rendering surfaces.
  */
-export interface SurfaceGroupLike {
+export declare interface SurfaceGroupLike {
   /** An observable stream emitting notifications when a new surface instance is created. */
   onSurfaceCreated: {
     /**
@@ -57,7 +57,7 @@ export interface SurfaceGroupLike {
 }
 
 /** Represents a usage sample for a component, including its UI tree and optional data model. */
-export interface ComponentUsage {
+export declare interface ComponentUsage {
   /** The component tree definition array. */
   usage: Record<string, unknown>[];
   /** Optional initial data model state for the surface. */
@@ -68,7 +68,7 @@ export interface ComponentUsage {
 export type ComponentUsages = Record<string, ComponentUsage>;
 
 /** Configuration and lifecycle callbacks for attaching a renderer. */
-export interface RendererConfig {
+export declare interface RendererConfig {
   /** The reactive surface group model to connect for data synchronization. */
   surfaceGroup: SurfaceGroupLike;
   /** Invoked with the dynamic surfaceId when a new surface layout is built. */
@@ -88,7 +88,7 @@ export interface RendererConfig {
 }
 
 /** A subscription handle to detach a renderer and clean up connections. */
-export interface SurfaceStateSubscription {
+export declare interface SurfaceStateSubscription {
   /** Unsubscribes the renderer and cleans up all active bridge bindings. */
   unsubscribe(): void;
 }

--- a/shell/e2e/gallery.e2e.ts
+++ b/shell/e2e/gallery.e2e.ts
@@ -57,7 +57,6 @@ test.describe('Components Gallery User Journey', () => {
     // 3. Redirected to /gallery and layout loads successfully
     await page.waitForURL('**/gallery');
     await expect(page.locator('.gallery-container')).toBeVisible();
-    await expect(page.getByRole('heading', {name: 'No Component Selected'})).toBeVisible();
 
     // 4. Verify component catalog navigation is visible
     const navItems = page.locator('.catalog-list').getByRole('button');
@@ -67,10 +66,7 @@ test.describe('Components Gallery User Journey', () => {
     const firstComponentName = (await navItems.first().textContent())?.trim();
     expect(firstComponentName).toBeTruthy();
 
-    // 5. Click the first component
-    await navItems.first().click();
-
-    // 6. Assert details pane is updated
+    // 5. Assert first component is automatically selected upon gallery navigation and details pane is updated
     await expect(page.getByRole('heading', {name: firstComponentName!, exact: true})).toBeVisible();
 
     // Assert card headers are visible

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -402,9 +402,7 @@ export class ChatCoordinator {
    */
   private runCatalogComponentSchemaCheck(parsedBlocks: unknown[]): void {
     const catalog = this.catalogManagement.activeCatalog();
-    const componentsObj = catalog
-      ? (catalog['components'] as Record<string, unknown> | undefined)
-      : undefined;
+    const componentsObj = catalog?.components;
     const componentHealMap: Record<string, string> = {};
 
     if (componentsObj) {
@@ -429,30 +427,30 @@ export class ChatCoordinator {
         continue;
       }
       const bObj = block as RenderA2uiItem;
-      const updateComponents = bObj['updateComponents'];
+      const updateComponents = bObj.updateComponents;
       if (
         !updateComponents ||
         typeof updateComponents !== 'object' ||
-        !Array.isArray(updateComponents['components'])
+        !Array.isArray(updateComponents.components)
       ) {
         continue;
       }
 
       const cleanedComponents: unknown[] = [];
-      for (const comp of updateComponents['components']) {
+      for (const comp of updateComponents.components) {
         if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
           cleanedComponents.push(comp);
           continue;
         }
 
         const compObj = comp as A2uiComponentInstance;
-        let compType = compObj['component'] as string;
+        let compType = compObj.component;
 
         // legacy property "name" fallback: heal to "component" key mapping
-        if (compObj['name'] && !compObj['component']) {
+        if (compObj['name'] && !compObj.component) {
           this.chatState.setPipelineStatus(PipelineStatus.HEALING);
           compType = compObj['name'] as string;
-          compObj['component'] = compType;
+          compObj.component = compType;
           delete compObj['name'];
         }
 
@@ -506,12 +504,12 @@ export class ChatCoordinator {
         // Recursively strip out dynamic mock setups configuration fields
         const cleanedComp = this.sanitizeComponentObject(compObj);
         // Restore corrected element name
-        cleanedComp['component'] = targetType;
+        cleanedComp.component = targetType;
         cleanedComponents.push(cleanedComp);
       }
 
       // Commit sanitized array back in-place
-      updateComponents['components'] = cleanedComponents;
+      updateComponents.components = cleanedComponents;
     }
   }
 

--- a/shell/src/app/chat/llm-client/llm-client.ts
+++ b/shell/src/app/chat/llm-client/llm-client.ts
@@ -29,7 +29,7 @@ export enum MessageRole {
   ERROR = 'error',
 }
 
-export interface Attachment {
+export declare interface Attachment {
   readonly name: string;
   readonly mimeType: string;
   readonly data: string; // base64 string
@@ -40,7 +40,7 @@ export interface Attachment {
  * context. Serves as the primary turn record container passing communication
  * boundaries.
  */
-export interface LlmMessage {
+export declare interface LlmMessage {
   /**
    * The semantic role of the message originator (e.g. system, user, model).
    * Restricts boundary to system, user, or model origin context.

--- a/shell/src/app/chat/state-sync/state-sync.spec.ts
+++ b/shell/src/app/chat/state-sync/state-sync.spec.ts
@@ -88,7 +88,7 @@ describe('StateSync Autosave Draft Integrations', () => {
 
     // Eagerly flush Angular change detection effect bindings instantly upon
     // setup to prevent microtask leaks
-    TestBed.flushEffects();
+    TestBed.tick();
   });
 
   afterEach(() => {
@@ -113,7 +113,7 @@ describe('StateSync Autosave Draft Integrations', () => {
 
   it('triggers history sync after 300ms debouncing, appending a new node', () => {
     service.updateDraft('[{"version": "v0.9"}]');
-    TestBed.flushEffects(); // Flush toObservable event boundaries instantly!
+    TestBed.tick(); // Flush toObservable event boundaries instantly!
 
     vi.advanceTimersByTime(150);
     expect(chatStateMock.setChatHistory).not.toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('StateSync Autosave Draft Integrations', () => {
     ]);
 
     service.updateDraft('[{"version": "v0.9", "updated": true}]');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     vi.advanceTimersByTime(300);
 
@@ -164,7 +164,7 @@ describe('StateSync Autosave Draft Integrations', () => {
     ]);
 
     service.updateDraft('[{"version": "v0.9", "post-turn": true}]');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     vi.advanceTimersByTime(300);
 
@@ -199,7 +199,7 @@ describe('StateSync Autosave Draft Integrations', () => {
     ]);
 
     service.updateDraft('[{"version": "v0.9", "components": []}]');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     vi.advanceTimersByTime(300);
 
@@ -227,7 +227,7 @@ describe('StateSync Autosave Draft Integrations', () => {
 
   it('commits layouts from LLM synchronously, suppressing history syncs', () => {
     service.commitLayoutFromLlm('{"version": "v0.9", "from-llm": true}');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(service.hydrateActiveDraft()).toBe('{"version": "v0.9", "from-llm": true}');
 
@@ -256,7 +256,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']';
 
       service.updateDraft(dirtyLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -280,7 +280,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']}}]';
 
       service.updateDraft(dirtyLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -297,7 +297,7 @@ describe('StateSync Autosave Draft Integrations', () => {
       const badLayout = '[ {"version": "v0.9"}, corrupt... ]';
 
       service.updateDraft(badLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -321,7 +321,7 @@ describe('StateSync Autosave Draft Integrations', () => {
           ']}}]';
 
         service.updateDraft(dirtyLayout);
-        TestBed.flushEffects();
+        TestBed.tick();
 
         vi.advanceTimersByTime(300);
 
@@ -348,7 +348,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']}}]';
 
       service.updateDraft(dirtyLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -366,7 +366,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']}}]';
 
       service.updateDraft(dirtyLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -384,7 +384,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']}}]';
 
       service.updateDraft(arrayLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -403,7 +403,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         ']}}]';
 
       service.updateDraft(dirtyLayout);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -416,7 +416,7 @@ describe('StateSync Autosave Draft Integrations', () => {
 
     it('returns empty string when sanitizing empty or whitespace layout', () => {
       service.updateDraft('   ');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -431,7 +431,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         '[{"version": "v0.9", "updateComponents": {"surfaceId": "s-1", "components": []}}, "primitive-element"]';
 
       service.updateDraft(arrayWithPrimitive);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -444,7 +444,7 @@ describe('StateSync Autosave Draft Integrations', () => {
 
     it('returns empty array when all layout lines are sanitized to null', () => {
       service.updateDraft('[{"registerMockRules": true}]');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -459,7 +459,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         '[{"version": "v0.9", "updateComponents": {"surfaceId": "s-1", "components": "not-an-array"}}]';
 
       service.updateDraft(invalidComponents);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       vi.advanceTimersByTime(300);
 
@@ -485,7 +485,7 @@ describe('StateSync Autosave Draft Integrations', () => {
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
       const newService = TestBed.inject(StateSync);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(newService.activeDraft()).toContain('material_catalog.json');
       expect(newService.activeDraft()).not.toContain('Book a Car');
@@ -496,7 +496,7 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       service.updateDraft('{"version": "dirty"}');
       expect(service.activeDraft()).toBe('{"version": "dirty"}');
@@ -511,20 +511,20 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/basic_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
       expect(service.activeDraft()).toBe(CAR_BOOKING);
 
       // User has typed some layout (dirty) matching basic catalog
       service.updateDraft(
         '[{"version": "v0.9", "createSurface": {"surfaceId": "sample-surface", "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json", "sendDataModel": true}}, {"version": "v0.9", "updateComponents": {"components": []}}]',
       );
-      TestBed.flushEffects();
+      TestBed.tick();
 
       // Catalog changes to material
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       // Expect draft to be reset to material initial draft because the old draft was basic catalog
       expect(service.activeDraft()).toContain('material_catalog.json');
@@ -536,7 +536,7 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
       const materialInitialDraft = service.activeDraft();
       expect(materialInitialDraft).toContain('material_catalog.json');
 
@@ -545,14 +545,14 @@ describe('StateSync Autosave Draft Integrations', () => {
       parsedDraft.push({version: 'v0.9', updateComponents: {components: [{id: 'foo'}]}});
       const editedMaterialDraft = JSON.stringify(parsedDraft, null, 2);
       service.updateDraft(editedMaterialDraft);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       // Trigger a catalog change with the same catalog ID (e.g. metadata refresh)
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
         title: 'New Title', // different title, same catalogId
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       // Expect draft NOT to be reset, preserving user changes
       expect(service.activeDraft()).toBe(editedMaterialDraft);
@@ -562,18 +562,18 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const singleObjectDraft =
         '{"version": "v0.9", "createSurface": {"surfaceId": "sample-surface", "catalogId": "https://a2ui.org/specification/v0_9/material_catalog.json", "sendDataModel": true}}';
       service.updateDraft(singleObjectDraft);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
         title: 'New Title',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.activeDraft()).toBe(singleObjectDraft);
     });
@@ -582,18 +582,18 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const arrayDraft =
         '[{"version": "v0.9", "createSurface": {"surfaceId": "sample-surface", "catalogId": "https://a2ui.org/specification/v0_9/material_catalog.json", "sendDataModel": true}}]';
       service.updateDraft(arrayDraft);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
         title: 'New Title',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.activeDraft()).toBe(arrayDraft);
     });
@@ -602,16 +602,16 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       service.updateDraft('{"version": "v0.9", "updateComponents": {"components": []}}');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
         title: 'New Title',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.activeDraft()).toContain('material_catalog.json');
       expect(service.activeDraft()).not.toContain('updateComponents');
@@ -621,16 +621,16 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       service.updateDraft('   ');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       catalogManagementMock.activeCatalog.set({
         catalogId: 'https://a2ui.org/specification/v0_9/material_catalog.json',
         title: 'New Title',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.activeDraft()).toContain('material_catalog.json');
     });
@@ -639,7 +639,7 @@ describe('StateSync Autosave Draft Integrations', () => {
       catalogManagementMock.activeCatalog.set({
         catalogId: '',
       });
-      TestBed.flushEffects();
+      TestBed.tick();
       service.updateDraft('{"version": "dirty"}');
 
       service.flushDraft();

--- a/shell/src/app/chat/state-sync/state-sync.ts
+++ b/shell/src/app/chat/state-sync/state-sync.ts
@@ -73,7 +73,7 @@ export class StateSync {
     effect(() => {
       const catalog = this.catalogManagement.activeCatalog();
       if (catalog) {
-        const catalogId = (catalog['catalogId'] as string) || (catalog['$id'] as string) || '';
+        const catalogId = catalog.catalogId || catalog.$id || '';
         untracked(() => {
           const currentDraft = this._activeDraft();
           const draftCatalogId = this.getCatalogIdFromDraft(currentDraft);
@@ -122,9 +122,7 @@ export class StateSync {
    */
   flushDraft(): void {
     const catalog = this.catalogManagement.activeCatalog();
-    const catalogId = catalog
-      ? (catalog['catalogId'] as string) || (catalog['$id'] as string) || ''
-      : '';
+    const catalogId = catalog ? catalog.catalogId || catalog.$id || '' : '';
     this._activeDraft.set(this.getInitialDraft(catalogId));
   }
 
@@ -135,15 +133,13 @@ export class StateSync {
     if (!catalogId) {
       return '';
     }
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
-    const draftObj = [
+    const draftObj: RenderA2uiItem[] = [
       {
-        'version': 'v0.9',
-        'createSurface': {
-          'surfaceId': 'sample-surface',
-          'catalogId': catalogId,
-          'sendDataModel': true,
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'sample-surface',
+          catalogId: catalogId,
+          sendDataModel: true,
         },
       },
     ];
@@ -159,26 +155,15 @@ export class StateSync {
       const parsed = JSON.parse(trimmed);
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
-          const createSurface =
-            item && typeof item === 'object'
-              ? (item as Record<string, unknown>)['createSurface']
-              : undefined;
-          if (
-            createSurface &&
-            typeof createSurface === 'object' &&
-            (createSurface as Record<string, unknown>)['catalogId']
-          ) {
-            return (createSurface as Record<string, unknown>)['catalogId'] as string;
+          const itemObj = item as RenderA2uiItem;
+          if (itemObj?.createSurface?.catalogId) {
+            return itemObj.createSurface.catalogId;
           }
         }
       } else if (parsed && typeof parsed === 'object') {
-        const createSurface = (parsed as Record<string, unknown>)['createSurface'];
-        if (
-          createSurface &&
-          typeof createSurface === 'object' &&
-          (createSurface as Record<string, unknown>)['catalogId']
-        ) {
-          return (createSurface as Record<string, unknown>)['catalogId'] as string;
+        const parsedObj = parsed as RenderA2uiItem;
+        if (parsedObj?.createSurface?.catalogId) {
+          return parsedObj.createSurface.catalogId;
         }
       }
     } catch (e) {

--- a/shell/src/app/gallery/gallery.scss
+++ b/shell/src/app/gallery/gallery.scss
@@ -238,7 +238,14 @@
 }
 
 .hidden-frame {
-  display: none;
+  visibility: hidden;
+  position: absolute;
+  left: -9999px;
+  top: -9999px;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .usage-loading-spinner {

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -864,7 +864,7 @@ describe('Gallery Component', () => {
     });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to send A2UI render payload on RENDERER_READY:',
+      'Failed to parse component usage JSON:',
       expect.any(Error),
     );
     expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
@@ -970,5 +970,32 @@ describe('Gallery Component', () => {
     expect(rawJson).toContain('"components":');
     expect(rawJson).toContain('"id":"root"');
     expect(rawJson).toContain('"component":"Column"');
+  });
+
+  it('catches payload dispatch errors in dispatchSelectedComponentPayload and logs them via console.error without rethrowing', () => {
+    catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
+    fixture.detectChanges();
+    TestBed.tick();
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(
+      fixture.componentInstance as unknown as Record<string, () => unknown>,
+      'buildA2UIPayload',
+    ).mockImplementation(() => {
+      throw new Error('Test dispatch error');
+    });
+
+    expect(() => {
+      (fixture.componentInstance as unknown as Record<string, () => void>)[
+        'dispatchSelectedComponentPayload'
+      ]();
+    }).not.toThrow();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to parse component usage JSON:',
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -19,10 +19,11 @@ import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {signal} from '@angular/core';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {ReplaySubject} from 'rxjs';
 import {Gallery} from './gallery';
 import {GalleryHarness} from './test/gallery.harness';
 import {GalleryCatalog, CategorizedComponents} from './services/gallery-catalog';
-import {type ComponentUsage} from 'a2ui-bridge';
+import {PreviewBridgeMessageType, type ComponentUsage} from 'a2ui-bridge';
 import {CatalogManagement} from '../storage/catalog-management/catalog-management';
 import {ParsedProperty} from './schema/catalog-schema-resolver';
 import {Catalog} from '../storage/models/catalog-storage.model';
@@ -68,6 +69,7 @@ class MockHostCommunication {
   sendRenderA2UI = vi.fn();
   registerIframe = vi.fn();
   sendTheme = vi.fn();
+  readonly messageStream$ = new ReplaySubject<unknown>(1);
 }
 
 class MockStartupResolution {
@@ -409,7 +411,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     // Since 'Column' is in the default mock catalog, it should wrap it
     expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
@@ -449,7 +451,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
       {
@@ -472,7 +474,7 @@ describe('Gallery Component', () => {
   it('does not dispatch rendering payload if selectedComponentPreset is null or usage is not an array', async () => {
     catalogServiceMock.selectedComponentPreset.set(null);
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
   });
@@ -483,7 +485,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: mockComponents, data: mockData});
     catalogServiceMock.selectedComponentUsage.set(JSON.stringify(mockComponents));
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
       {
@@ -530,7 +532,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
       {
@@ -581,7 +583,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect((fixture.componentInstance as unknown as TestFriendlyGallery).catalogId()).toBe(
       'https://a2ui.org/fallback_catalog.json',
@@ -615,7 +617,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     // Should safely proceed without throwing errors and render unwrapped
     expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalled();
@@ -636,7 +638,7 @@ describe('Gallery Component', () => {
     catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
     catalogServiceMock.selectedComponentUsage.set('[{"id":"target","component":"Text"}]');
     fixture.detectChanges();
-    TestBed.flushEffects();
+    TestBed.tick();
 
     expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
   });
@@ -779,5 +781,194 @@ describe('Gallery Component', () => {
         },
       },
     ]);
+  });
+
+  it('builds A2UI payload array using buildA2UIPayload helper method', () => {
+    const preset = {
+      usage: [{id: 'target', component: 'Text', text: 'Hello'}],
+      data: {key: 'val'},
+    };
+    const payload = (
+      fixture.componentInstance as unknown as Record<
+        string,
+        (preset: unknown, catalogUrl: string) => unknown
+      >
+    )['buildA2UIPayload'](preset, 'https://a2ui.org/default_catalog.json');
+
+    expect(payload).toEqual([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/default_catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              align: 'center',
+              justify: 'center',
+              children: ['target'],
+            },
+            {id: 'target', component: 'Text', text: 'Hello'},
+          ],
+        },
+      },
+      {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'gallery-preview',
+          value: {key: 'val'},
+        },
+      },
+    ]);
+  });
+
+  it('re-dispatches preview payload when RENDERER_READY message is received on messageStream$', () => {
+    catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
+    fixture.detectChanges();
+    TestBed.tick();
+
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: Date.now(),
+    });
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledTimes(1);
+  });
+
+  it('catches payload construction errors in RENDERER_READY listener without breaking subscription', () => {
+    catalogServiceMock.selectedComponentPreset.set({usage: [{id: 'target', component: 'Text'}]});
+    fixture.detectChanges();
+    TestBed.tick();
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(fixture.componentInstance, 'buildA2UIPayload').mockImplementationOnce(() => {
+      throw new Error('Payload construction error');
+    });
+
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: Date.now(),
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to send A2UI render payload on RENDERER_READY:',
+      expect.any(Error),
+    );
+    expect(hostCommunicationMock.sendRenderA2UI).not.toHaveBeenCalled();
+
+    // Subsequent RENDERER_READY messages should still be handled
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: Date.now(),
+    });
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('dispatches preview payload when default component auto-selection sets selectedComponentPreset', () => {
+    hostCommunicationMock.sendRenderA2UI.mockClear();
+
+    catalogServiceMock.selectedComponentPreset.set({
+      usage: [{id: 'target', component: 'Button'}],
+    });
+    fixture.detectChanges();
+    TestBed.tick();
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalledWith([
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: 'https://a2ui.org/default_catalog.json',
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: [
+            {
+              id: 'root',
+              component: 'Column',
+              align: 'center',
+              justify: 'center',
+              children: ['target'],
+            },
+            {id: 'target', component: 'Button'},
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('verifies JSON stringified postMessage payload key structure contains required protocol fields', () => {
+    writeTextSpy.mockResolvedValue(undefined);
+    catalogServiceMock.selectedComponentKey.set('Button');
+    const mockUsage = [{id: 'target', component: 'Button'}];
+    const mockData = {count: 1};
+    catalogServiceMock.selectedComponentPreset.set({
+      usage: mockUsage,
+      data: mockData,
+    });
+    catalogServiceMock.selectedComponentUsage.set(JSON.stringify(mockUsage));
+    fixture.detectChanges();
+
+    (fixture.componentInstance as unknown as TestFriendlyGallery).copyToClipboard();
+
+    expect(writeTextSpy).toHaveBeenCalled();
+    const copiedPayloadString = writeTextSpy.mock.calls[0][0] as string;
+    const parsedPayload = JSON.parse(copiedPayloadString);
+
+    expect(parsedPayload[0]).toHaveProperty('version');
+    expect(parsedPayload[0]).toHaveProperty('createSurface');
+    expect(parsedPayload[0].createSurface).toHaveProperty('surfaceId');
+    expect(parsedPayload[0].createSurface).toHaveProperty('catalogId');
+
+    expect(parsedPayload[1]).toHaveProperty('version');
+    expect(parsedPayload[1]).toHaveProperty('updateComponents');
+    expect(parsedPayload[1].updateComponents).toHaveProperty('surfaceId');
+    expect(parsedPayload[1].updateComponents).toHaveProperty('components');
+
+    expect(parsedPayload[2]).toHaveProperty('version');
+    expect(parsedPayload[2]).toHaveProperty('updateDataModel');
+    expect(parsedPayload[2].updateDataModel).toHaveProperty('surfaceId');
+    expect(parsedPayload[2].updateDataModel).toHaveProperty('value');
+  });
+
+  it('verifies JSON stringified postMessage payload contains exact quoted keys', () => {
+    catalogServiceMock.selectedComponentPreset.set({
+      usage: [{id: 'target', component: 'Text'}],
+    });
+    fixture.detectChanges();
+    TestBed.tick();
+
+    expect(hostCommunicationMock.sendRenderA2UI).toHaveBeenCalled();
+    const payload = hostCommunicationMock.sendRenderA2UI.mock.calls[0][0];
+    const rawJson = JSON.stringify(payload);
+
+    expect(rawJson).toContain('"version":"v0.9"');
+    expect(rawJson).toContain('"createSurface":');
+    expect(rawJson).toContain('"surfaceId":"gallery-preview"');
+    expect(rawJson).toContain('"catalogId":');
+    expect(rawJson).toContain('"updateComponents":');
+    expect(rawJson).toContain('"components":');
+    expect(rawJson).toContain('"id":"root"');
+    expect(rawJson).toContain('"component":"Column"');
   });
 });

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -74,11 +74,7 @@ export class Gallery implements OnInit, OnDestroy {
         takeUntilDestroyed(),
       )
       .subscribe(() => {
-        try {
-          this.dispatchSelectedComponentPayload();
-        } catch (e) {
-          console.error('Failed to send A2UI render payload on RENDERER_READY:', e);
-        }
+        this.dispatchSelectedComponentPayload();
       });
 
     effect(() => {
@@ -133,7 +129,6 @@ export class Gallery implements OnInit, OnDestroy {
       this.hostCommunication.sendRenderA2UI(payload);
     } catch (e) {
       console.error('Failed to parse component usage JSON:', e);
-      throw e;
     }
   }
 

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -23,6 +23,8 @@ import {
   OnInit,
   OnDestroy,
 } from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {filter} from 'rxjs/operators';
 import {JsonPipe} from '@angular/common';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatListModule} from '@angular/material/list';
@@ -36,6 +38,7 @@ import {CatalogManagement} from '../storage/catalog-management/catalog-managemen
 import {RenderedFrame} from '../preview/rendered/rendered-frame';
 import {HostCommunication} from '../shell/host-communication/host-communication';
 import {formatJson} from '../utils/json';
+import {PreviewBridgeMessageType, ComponentUsage, RenderA2uiItem} from 'a2ui-bridge';
 
 /**
  * Displays a split visual catalog gallery enabling search, interactive component selection,
@@ -65,60 +68,73 @@ export class Gallery implements OnInit, OnDestroy {
   private readonly hostCommunication = inject(HostCommunication);
 
   constructor() {
-    effect(() => {
-      const preset = this.catalogService.selectedComponentPreset();
-      if (!preset || !preset.usage || !Array.isArray(preset.usage)) return;
-
-      try {
-        const componentsArray = preset.usage;
-        const dataObj = preset.data;
-
-        const catalog = this.catalogManagement.activeCatalog();
-        const catalogId = this.catalogId();
-        if (!catalog || !catalogId) return;
-
-        const componentsPayload = this.getComponentsPayload(componentsArray);
-
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
-        const cmd1 = {
-          'version': 'v0.9',
-          'createSurface': {
-            'surfaceId': 'gallery-preview',
-            'catalogId': catalogId,
-          },
-        };
-
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
-        const cmd2 = {
-          'version': 'v0.9',
-          'updateComponents': {
-            'surfaceId': 'gallery-preview',
-            'components': componentsPayload,
-          },
-        };
-
-        const payload: unknown[] = [cmd1, cmd2];
-
-        if (dataObj !== undefined) {
-          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-          // prettier-ignore
-          const cmd3 = {
-            'version': 'v0.9',
-            'updateDataModel': {
-              'surfaceId': 'gallery-preview',
-              'value': dataObj,
-            },
-          };
-          payload.push(cmd3);
+    this.hostCommunication.messageStream$
+      .pipe(
+        filter(envelope => envelope?.type === PreviewBridgeMessageType.RENDERER_READY),
+        takeUntilDestroyed(),
+      )
+      .subscribe(() => {
+        try {
+          this.dispatchSelectedComponentPayload();
+        } catch (e) {
+          console.error('Failed to send A2UI render payload on RENDERER_READY:', e);
         }
+      });
 
-        this.hostCommunication.sendRenderA2UI(payload);
-      } catch (e) {
-        console.error('Failed to parse component usage JSON:', e);
-      }
+    effect(() => {
+      this.dispatchSelectedComponentPayload();
     });
+  }
+
+  private buildA2UIPayload(preset: ComponentUsage, catalogId: string): RenderA2uiItem[] {
+    const payload: RenderA2uiItem[] = [
+      {
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: catalogId,
+        },
+      },
+      {
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: this.getComponentsPayload(preset.usage),
+        },
+      },
+    ];
+
+    const dataObj = preset.data;
+    if (dataObj !== undefined) {
+      const cmd3: RenderA2uiItem = {
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'gallery-preview',
+          value: dataObj,
+        },
+      };
+      payload.push(cmd3);
+    }
+
+    return payload;
+  }
+
+  private dispatchSelectedComponentPayload(): void {
+    const preset = this.catalogService.selectedComponentPreset();
+    if (!preset || !preset.usage || !Array.isArray(preset.usage)) return;
+
+    try {
+      const catalog = this.catalogManagement.activeCatalog();
+      const catalogId = this.catalogId();
+      if (!catalog || !catalogId) return;
+
+      const payload = this.buildA2UIPayload(preset, catalogId);
+
+      this.hostCommunication.sendRenderA2UI(payload);
+    } catch (e) {
+      console.error('Failed to parse component usage JSON:', e);
+      throw e;
+    }
   }
 
   ngOnInit(): void {
@@ -147,7 +163,7 @@ export class Gallery implements OnInit, OnDestroy {
   protected readonly catalogId = computed<string | null>(() => {
     const catalog = this.catalogManagement.activeCatalog();
     if (!catalog) return null;
-    return ((catalog['catalogId'] as string) || (catalog['$id'] as string)) ?? null;
+    return catalog.catalogId || catalog.$id || null;
   });
 
   /** The table column names mapped by MatTable. */
@@ -164,8 +180,8 @@ export class Gallery implements OnInit, OnDestroy {
     const key = this.selectedComponentKey();
     const catalog = this.catalogManagement.activeCatalog();
     const comp =
-      key && catalog && catalog['components']
-        ? (catalog['components'] as Record<string, Record<string, unknown>>)[key]
+      key && catalog && catalog.components
+        ? (catalog.components as Record<string, Record<string, unknown>>)[key]
         : null;
     return comp && typeof comp['description'] === 'string' ? (comp['description'] as string) : '';
   });
@@ -179,15 +195,15 @@ export class Gallery implements OnInit, OnDestroy {
     this.catalogService.selectComponent(key);
   }
 
-  private getComponentsPayload(componentsArray: unknown[]): unknown[] {
+  private getComponentsPayload(
+    componentsArray: Record<string, unknown>[],
+  ): Record<string, unknown>[] {
     const catalog = this.catalogManagement.activeCatalog();
     if (!catalog) {
       return componentsArray;
     }
 
-    const componentsObj = catalog
-      ? (catalog['components'] as Record<string, unknown> | undefined)
-      : undefined;
+    const componentsObj = catalog.components;
     const componentKeys = Object.keys(componentsObj || {});
     // Support prefixed columns by checking if exactly 'column' or ends with 'column' (case-insensitive).
     // Prioritize exact match.
@@ -241,50 +257,12 @@ export class Gallery implements OnInit, OnDestroy {
     }
 
     try {
-      const components = preset.usage;
-      const dataObj = preset.data;
-
       const catalogId = this.catalogId();
       if (!catalogId) {
         return;
       }
 
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
-      const createSurfaceCmd = {
-        'version': 'v0.9',
-        'createSurface': {
-          'surfaceId': 'gallery-preview',
-          'catalogId': catalogId,
-        },
-      };
-
-      const componentsPayload = this.getComponentsPayload(components as unknown[]);
-
-      // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-      // prettier-ignore
-      const updateComponentsCmd = {
-        'version': 'v0.9',
-        'updateComponents': {
-          'surfaceId': 'gallery-preview',
-          'components': componentsPayload,
-        },
-      };
-
-      const commands: unknown[] = [createSurfaceCmd, updateComponentsCmd];
-
-      if (dataObj !== undefined) {
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
-        commands.push({
-          'version': 'v0.9',
-          'updateDataModel': {
-            'surfaceId': 'gallery-preview',
-            'value': dataObj,
-          },
-        });
-      }
-
+      const commands = this.buildA2UIPayload(preset, catalogId);
       const payload = formatJson(commands);
 
       if (!navigator.clipboard) {

--- a/shell/src/app/gallery/services/default-presets.ts
+++ b/shell/src/app/gallery/services/default-presets.ts
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import {ComponentUsages} from 'a2ui-bridge';
+
 /**
  * Pre-defined rich visual component rendering presets.
  * Maps component types to A2UI structures/configurations.
  */
-export const DEFAULT_PRESETS: Record<string, unknown> = {
+export const DEFAULT_PRESETS: ComponentUsages = {
   AudioPlayer: {
     usage: [
       {

--- a/shell/src/app/gallery/services/gallery-catalog.spec.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.spec.ts
@@ -139,6 +139,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Text');
 
     const preset = service.selectedComponentPreset();
@@ -186,6 +187,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('CustomComp');
 
     const preset = service.selectedComponentPreset();
@@ -221,6 +223,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('CustomComp');
 
     const preset = service.selectedComponentPreset();
@@ -251,6 +254,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('CustomComp');
 
     const preset = service.selectedComponentPreset();
@@ -304,6 +308,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('ComplexImageContainer');
 
     const preset = service.selectedComponentPreset();
@@ -361,6 +366,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Text');
 
     const preset1 = service.selectedComponentPreset()!;
@@ -445,6 +451,7 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
       service.selectComponent('EmptyArrComp');
 
       const usage = service.selectedComponentUsage();
@@ -468,6 +475,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Text');
 
     const usage = service.selectedComponentUsage();
@@ -496,6 +504,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Row');
 
     const usage = service.selectedComponentUsage();
@@ -548,6 +557,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('MaterialText');
 
     const preset = service.selectedComponentPreset();
@@ -586,6 +596,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('CustomContainer');
 
     const preset = service.selectedComponentPreset();
@@ -621,6 +632,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('CustomContainer');
 
     const preset = service.selectedComponentPreset();
@@ -646,6 +658,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('MaterialRow');
 
     const preset = service.selectedComponentPreset();
@@ -694,6 +707,7 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
       service.selectComponent('MaterialList');
 
       const preset = service.selectedComponentPreset();
@@ -728,6 +742,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Text');
 
     const preset = service.selectedComponentPreset();
@@ -775,6 +790,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Card');
 
     const preset = service.selectedComponentPreset();
@@ -798,6 +814,7 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('Tabs');
 
     const preset = service.selectedComponentPreset();
@@ -831,8 +848,14 @@ describe('GalleryCatalog', () => {
         },
       });
 
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('MaterialTestBadComponent');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toBeTruthy();
@@ -862,8 +885,14 @@ describe('GalleryCatalog', () => {
         },
       });
 
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('TestBadChildren');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       // child-1 should be pruned since it was a string child ID, target should be stripped of children
@@ -904,8 +933,14 @@ describe('GalleryCatalog', () => {
         },
       });
 
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('TestBadTabs');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       // child-1 should be pruned (referenced by tab 3 child string), target should be stripped of tabs
@@ -951,8 +986,14 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('TestChildToChildren');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toEqual({
@@ -1008,8 +1049,14 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('TestChildToLabel');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toEqual({
@@ -1069,8 +1116,14 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('MaterialTabs');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toEqual({
@@ -1119,8 +1172,14 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
+    TestBed.tick();
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.COMPONENT_USAGES,
+      payload: {},
+    });
     service.selectComponent('Tabs');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     const preset = service.selectedComponentPreset();
     expect(preset).toEqual({
@@ -1161,8 +1220,9 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
     service.selectComponent('UnionComponent');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     const props = service.selectedComponentProperties();
     expect(props).toEqual([
@@ -1198,8 +1258,14 @@ describe('GalleryCatalog', () => {
       },
     };
     catalogManagementMock.activeCatalog.set(mockCatalog);
+    service.setGalleryActive(true);
+    TestBed.tick();
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.COMPONENT_USAGES,
+      payload: {},
+    });
     service.selectComponent('ParentComponent');
-    TestBed.flushEffects();
+    TestBed.tick();
 
     const preset = service.selectedComponentPreset();
     expect(preset).toEqual({
@@ -1261,8 +1327,14 @@ describe('GalleryCatalog', () => {
         },
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.COMPONENT_USAGES,
+        payload: {},
+      });
       service.selectComponent('CustomTabs');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toEqual({
@@ -1295,7 +1367,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(hostCommunicationMock.sendMessage).toHaveBeenCalledWith({
         type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
@@ -1310,7 +1382,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(false);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(hostCommunicationMock.sendMessage).not.toHaveBeenCalled();
       expect(service.loadingUsages()).toBe(false);
@@ -1323,7 +1395,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.loadingUsages()).toBe(true);
 
@@ -1350,7 +1422,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.loadingUsages()).toBe(true);
 
@@ -1371,7 +1443,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.loadingUsages()).toBe(true);
 
@@ -1412,7 +1484,7 @@ describe('GalleryCatalog', () => {
       };
       catalogManagementMock.activeCatalog.set(mockCatalog);
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const mockUsages = {
         Button: {
@@ -1428,7 +1500,7 @@ describe('GalleryCatalog', () => {
       });
 
       service.selectComponent('Button');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const preset = service.selectedComponentPreset();
       expect(preset).toEqual({
@@ -1455,7 +1527,7 @@ describe('GalleryCatalog', () => {
       catalogManagementMock.activeCatalog.set(mockCatalog);
       service.setGalleryActive(true);
       service.selectComponent('Button');
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.loadingUsages()).toBe(true);
       expect(service.cachedUsages()).toBeNull();
@@ -1469,7 +1541,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const timeoutId = service['usageTimeoutId'];
       expect(timeoutId).toBeDefined();
@@ -1479,7 +1551,7 @@ describe('GalleryCatalog', () => {
         catalogId: 'https://a2ui.org/catalog2.json',
         components: {},
       });
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(spy).toHaveBeenCalledWith(timeoutId);
     });
@@ -1491,13 +1563,13 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       const timeoutId = service['usageTimeoutId'];
       expect(timeoutId).toBeDefined();
 
       service.setGalleryActive(false);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(spy).toHaveBeenCalledWith(timeoutId);
     });
@@ -1509,12 +1581,12 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
 
       // Receive usages to set loadingUsages to false
+      const mockUsages = {Button: {usage: []}};
       hostCommunicationMock.messageStream$.next({
         type: PreviewBridgeMessageType.COMPONENT_USAGES,
-        payload: {},
+        payload: mockUsages,
         origin: 'http://localhost',
         timestamp: Date.now(),
       });
@@ -1524,7 +1596,7 @@ describe('GalleryCatalog', () => {
       vi.runAllTimers();
 
       // The timeout callback ran, but it should not have set cachedUsages to {}
-      expect(service.cachedUsages()).toEqual({});
+      expect(service.cachedUsages()).toEqual(mockUsages);
 
       spyClear.mockRestore();
     });
@@ -1535,7 +1607,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       expect(service.loadingUsages()).toBe(true);
 
@@ -1556,7 +1628,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       // Clear the timeout manually to simulate undefined timeoutId
       service['usageTimeoutId'] = undefined;
@@ -1578,7 +1650,7 @@ describe('GalleryCatalog', () => {
         components: {},
       });
       service.setGalleryActive(true);
-      TestBed.flushEffects();
+      TestBed.tick();
 
       hostCommunicationMock.messageStream$.next({
         type: PreviewBridgeMessageType.COMPONENT_USAGES,
@@ -1589,6 +1661,183 @@ describe('GalleryCatalog', () => {
 
       expect(service.loadingUsages()).toBe(false);
       expect(service.cachedUsages()).toEqual({});
+    });
+
+    it('sends GET_COMPONENT_USAGES when requestComponentUsages is invoked while gallery is active', () => {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'https://a2ui.org/default_catalog.json',
+        components: {Text: {type: 'object'}},
+      });
+      service.setGalleryActive(true);
+      TestBed.tick();
+      hostCommunicationMock.sendMessage.mockClear();
+
+      service.requestComponentUsages();
+
+      expect(hostCommunicationMock.sendMessage).toHaveBeenCalledWith({
+        type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
+      });
+    });
+
+    it('auto-selects first available component when catalog loads if none selected', () => {
+      service.setGalleryActive(true);
+      expect(service.selectedComponentKey()).toBeNull();
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'https://a2ui.org/default_catalog.json',
+        components: {
+          Text: {type: 'object'},
+          Column: {type: 'object'},
+        },
+      });
+      TestBed.tick();
+
+      expect(service.selectedComponentKey()).toBe('Column');
+    });
+
+    it('re-requests component usages when RENDERER_READY is received and gallery is active', () => {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'https://a2ui.org/default_catalog.json',
+        components: {Text: {type: 'object'}},
+      });
+      service.setGalleryActive(true);
+      hostCommunicationMock.sendMessage.mockClear();
+
+      hostCommunicationMock.messageStream$.next({
+        type: PreviewBridgeMessageType.RENDERER_READY,
+        origin: 'http://localhost',
+        timestamp: Date.now(),
+      });
+
+      expect(hostCommunicationMock.sendMessage).toHaveBeenCalledWith({
+        type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
+      });
+    });
+
+    it('auto-selects first available component when active catalog switches to a catalog not containing current selection', () => {
+      service.setGalleryActive(true);
+      const catalog1: Catalog = {
+        components: {
+          Text: {type: 'object'},
+          Button: {type: 'object'},
+        },
+      };
+      catalogManagementMock.activeCatalog.set(catalog1);
+      TestBed.tick();
+
+      service.selectComponent('Text');
+      expect(service.selectedComponentKey()).toBe('Text');
+
+      const catalog2: Catalog = {
+        components: {
+          Alert: {type: 'object'},
+          Card: {type: 'object'},
+        },
+      };
+      catalogManagementMock.activeCatalog.set(catalog2);
+      TestBed.tick();
+
+      expect(service.selectedComponentKey()).toBe('Card');
+    });
+
+    it('retains selected component when active catalog switches to a catalog that contains current selection', () => {
+      service.setGalleryActive(true);
+      const catalog1: Catalog = {
+        components: {
+          Text: {type: 'object'},
+          Button: {type: 'object'},
+        },
+      };
+      catalogManagementMock.activeCatalog.set(catalog1);
+      TestBed.tick();
+
+      service.selectComponent('Button');
+      expect(service.selectedComponentKey()).toBe('Button');
+
+      const catalog2: Catalog = {
+        components: {
+          Alert: {type: 'object'},
+          Button: {type: 'object'},
+        },
+      };
+      catalogManagementMock.activeCatalog.set(catalog2);
+      TestBed.tick();
+
+      expect(service.selectedComponentKey()).toBe('Button');
+    });
+  });
+
+  describe('Auto-selection of Default Component', () => {
+    beforeEach(() => {
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'https://a2ui.org/default_catalog.json',
+        components: {
+          Text: {type: 'object'},
+          Column: {type: 'object'},
+          Button: {type: 'object'},
+        },
+      });
+      TestBed.tick();
+    });
+
+    it('auto-selects first component key when galleryActive is true and selectedComponentKey is null', () => {
+      service.setGalleryActive(true);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBe('Column');
+    });
+
+    it('auto-selects first component key when selectedComponentKey is invalid for current catalog', () => {
+      service.selectComponent('NonExistentComponent');
+      service.setGalleryActive(true);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBe('Column');
+    });
+
+    it('preserves valid selectedComponentKey when galleryActive becomes true', () => {
+      service.selectComponent('Button');
+      service.setGalleryActive(true);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBe('Button');
+    });
+
+    it('resets selectedComponentKey to null when galleryActive becomes false', () => {
+      service.setGalleryActive(true);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBe('Column');
+
+      service.setGalleryActive(false);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBeNull();
+    });
+
+    it('resets selectedComponentKey to null when galleryActive is true but componentsList is empty', () => {
+      service.setGalleryActive(true);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBe('Column');
+
+      catalogManagementMock.activeCatalog.set(null);
+      TestBed.tick();
+      expect(service.selectedComponentKey()).toBeNull();
+    });
+  });
+
+  it('retries GET_COMPONENT_USAGES request when RENDERER_READY is received while galleryActive is true and cachedUsages is null', () => {
+    catalogManagementMock.activeCatalog.set({
+      catalogId: 'https://a2ui.org/default_catalog.json',
+      components: {Text: {type: 'object'}},
+    });
+    service.setGalleryActive(true);
+    expect(service.cachedUsages()).toBeNull();
+    hostCommunicationMock.sendMessage.mockClear();
+
+    hostCommunicationMock.messageStream$.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://localhost',
+      timestamp: Date.now(),
+    });
+
+    expect(hostCommunicationMock.sendMessage).toHaveBeenCalledWith({
+      type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
     });
   });
 });

--- a/shell/src/app/gallery/services/gallery-catalog.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.ts
@@ -185,21 +185,22 @@ export class GalleryCatalog {
    */
   readonly componentsList = computed<CategorizedComponents[]>(() => {
     const catalog = this.catalogManagement.activeCatalog();
-    if (catalog == null || catalog['components'] == null) {
+    if (catalog == null || catalog.components == null) {
       return [];
     }
 
+    // prettier-ignore
     const grouped: Record<string, string[]> = {
-      Layout: [],
-      Content: [],
-      Input: [],
-      Feedback: [],
-      Other: [],
+      'Layout': [],
+      'Content': [],
+      'Input': [],
+      'Feedback': [],
+      'Other': [],
     };
 
-    for (const key of Object.keys(catalog['components'] || {})) {
+    for (const key of Object.keys(catalog.components || {})) {
       const cat = getCategoryForComponent(key);
-      (grouped[cat] || grouped['Other']).push(key);
+      grouped[cat].push(key);
     }
 
     return CATEGORIES_ORDER.map(category => ({
@@ -266,6 +267,7 @@ export class GalleryCatalog {
     this.destroyRef.onDestroy(() => {
       if (this.usageTimeoutId) {
         clearTimeout(this.usageTimeoutId);
+        this.usageTimeoutId = undefined;
       }
     });
 
@@ -274,29 +276,7 @@ export class GalleryCatalog {
       const isActive = this.galleryActive();
 
       if (isActive && activeCat) {
-        untracked(() => {
-          this._cachedUsages.set(null);
-          this._loadingUsages.set(true);
-        });
-
-        if (this.usageTimeoutId) {
-          clearTimeout(this.usageTimeoutId);
-        }
-
-        // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-        // prettier-ignore
-        this.hostCommunication.sendMessage({
-          'type': PreviewBridgeMessageType.GET_COMPONENT_USAGES,
-        });
-
-        this.usageTimeoutId = setTimeout(() => {
-          if (this.loadingUsages()) {
-            untracked(() => {
-              this._loadingUsages.set(false);
-              this._cachedUsages.set({});
-            });
-          }
-        }, 2000);
+        this.requestComponentUsages();
       } else {
         untracked(() => {
           this._cachedUsages.set(null);
@@ -304,7 +284,33 @@ export class GalleryCatalog {
         });
         if (this.usageTimeoutId) {
           clearTimeout(this.usageTimeoutId);
+          this.usageTimeoutId = undefined;
         }
+      }
+    });
+
+    effect(() => {
+      const active = this.galleryActive();
+      const list = this.componentsList();
+
+      if (active) {
+        if (list.length > 0) {
+          const currentKey = untracked(() => this.selectedComponentKey());
+          const allKeys = list.flatMap(group => group.components);
+          if (!currentKey || !allKeys.includes(currentKey)) {
+            untracked(() => {
+              this.selectComponent(allKeys[0]);
+            });
+          }
+        } else {
+          untracked(() => {
+            this._selectedComponentKey.set(null);
+          });
+        }
+      } else {
+        untracked(() => {
+          this._selectedComponentKey.set(null);
+        });
       }
     });
 
@@ -317,8 +323,37 @@ export class GalleryCatalog {
         const usages = envelope.payload as ComponentUsages | null;
         this._cachedUsages.set(usages || {});
         this._loadingUsages.set(false);
+      } else if (
+        envelope.type === PreviewBridgeMessageType.RENDERER_READY &&
+        this.galleryActive() &&
+        this.cachedUsages() === null
+      ) {
+        this.requestComponentUsages();
       }
     });
+  }
+
+  private requestComponentUsages(): void {
+    untracked(() => {
+      this._cachedUsages.set(null);
+      this._loadingUsages.set(true);
+    });
+
+    if (this.usageTimeoutId) {
+      clearTimeout(this.usageTimeoutId);
+      this.usageTimeoutId = undefined;
+    }
+
+    this.hostCommunication.sendMessage({
+      type: PreviewBridgeMessageType.GET_COMPONENT_USAGES,
+    });
+
+    this.usageTimeoutId = setTimeout(() => {
+      if (this.loadingUsages()) {
+        this._loadingUsages.set(false);
+        this._cachedUsages.set({});
+      }
+    }, 2000);
   }
 
   /**

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -22,6 +22,7 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {IS_EXTENSION_MODE} from '../../shell/environment-tokens/environment-tokens';
 import {signal, WritableSignal} from '@angular/core';
+import {Subject} from 'rxjs';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {Catalog} from '../../storage/models/catalog-storage.model';
@@ -31,6 +32,7 @@ import {
   AppConfigProvider,
   ThemePreference,
 } from '../../settings/app-config-provider/app-config-provider';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import type * as monaco from 'monaco-editor';
 import {MatSnackBar} from '@angular/material/snack-bar';
 
@@ -275,12 +277,14 @@ describe('RawFrame JSON Source Editor View', () => {
   let stateSyncMock: MockStateSync;
   let chatStateMock: MockChatState;
   let snackBarMock: {open: ReturnType<typeof vi.fn>; dismiss: ReturnType<typeof vi.fn>};
+  let messageStreamSubject: Subject<unknown>;
 
   beforeEach(() => {
     sendRenderA2UIMock = vi.fn();
     mockActiveCatalog = signal<Catalog | null>({title: 'Sample Catalog'});
     mockThemePreference = signal<ThemePreference>(ThemePreference.LIGHT);
     snackBarMock = {open: vi.fn(), dismiss: vi.fn()};
+    messageStreamSubject = new Subject<unknown>();
 
     undoStack.length = 0;
     redoStack.length = 0;
@@ -310,7 +314,13 @@ describe('RawFrame JSON Source Editor View', () => {
       providers: [
         provideNoopAnimations(),
         {provide: IS_EXTENSION_MODE, useValue: signal(isExtension)},
-        {provide: HostCommunication, useValue: {sendRenderA2UI: sendRenderA2UIMock}},
+        {
+          provide: HostCommunication,
+          useValue: {
+            sendRenderA2UI: sendRenderA2UIMock,
+            messageStream$: messageStreamSubject.asObservable(),
+          },
+        },
         {
           provide: CatalogManagement,
           useValue: {
@@ -662,5 +672,46 @@ describe('RawFrame JSON Source Editor View', () => {
     // Verify content updated successfully and editor restored back to readOnly: true
     expect(await harness.getJsonText()).toBe(streamDraft);
     expect(await harness.isReadOnly()).toBe(true);
+  });
+
+  it('re-dispatches layout payload when receiving RENDERER_READY event from messageStream$', async () => {
+    await setup(false);
+    sendRenderA2UIMock.mockClear();
+
+    messageStreamSubject.next({
+      type: PreviewBridgeMessageType.RENDERER_READY,
+      origin: 'http://test',
+      timestamp: Date.now(),
+    });
+
+    expect(sendRenderA2UIMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks isDestroyed state on component destruction', async () => {
+    const {fixture, component} = await setup(false);
+    expect(component['isDestroyed']).toBe(false);
+
+    fixture.destroy();
+    expect(component['isDestroyed']).toBe(true);
+  });
+
+  it('handles SyntaxError gracefully when parsing invalid layout JSON string', async () => {
+    const {component} = await setup(false);
+    expect(() => component['parseLayoutString']('{invalid json}')).toThrow(SyntaxError);
+  });
+
+  it('aborts microtask execution and signal update guard when component is destroyed before microtask runs', async () => {
+    const {fixture, component} = await setup(false);
+    const initialLayout = component.TEST_ONLY.layoutJson()();
+
+    stateSyncMock.activeDraftSignal.set(
+      '[{"version": "v0.9", "createSurface": {"surfaceId": "abort-test"}}]',
+    );
+
+    fixture.destroy();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(component.TEST_ONLY.layoutJson()()).toBe(initialLayout);
   });
 });

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -33,6 +33,7 @@ import {CatalogManagement} from '../../storage/catalog-management/catalog-manage
 import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState} from '../../chat/chat-state/chat-state';
 import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
 
 /**
  * Hosts the raw JSON view of active surface models, allowing direct source editing
@@ -61,11 +62,16 @@ export class RawFrame {
   private readonly destroyRef = inject(DestroyRef);
   private readonly snackBar = inject(MatSnackBar);
   private readonly layoutInput$ = new Subject<string>();
+  private isDestroyed = false;
 
   /** Public lock indicator preventing typing deadlocks during generative LLM stream turns. */
   protected readonly isLocked = this.chatState.isProgrammaticStreamActive;
 
   constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.isDestroyed = true;
+    });
+
     // Initialize backing editor layout state Signal dynamically from the volatile session cache
     this.layoutJson = signal(this.stateSync.hydrateActiveDraft());
     effect(() => {
@@ -83,12 +89,35 @@ export class RawFrame {
       }
     });
 
+    this.hostCommunication.messageStream$
+      .pipe(
+        filter(envelope => envelope?.type === PreviewBridgeMessageType.RENDERER_READY),
+        takeUntilDestroyed(),
+      )
+      .subscribe(() => {
+        try {
+          const payload = this.parseLayoutString(this.layoutJson());
+          if (payload !== null) {
+            this.hostCommunication.sendRenderA2UI(payload);
+          }
+        } catch (err) {
+          if (err instanceof SyntaxError) {
+            console.warn('Syntax error on RENDERER_READY:', err);
+          } else {
+            console.error('Unexpected error on RENDERER_READY:', err);
+          }
+        }
+      });
+
     // Sync back changes in StateSync activeDraft to editor layoutJson (e.g. from LLM stream completed updates)
     effect(() => {
       const activeDraftVal = this.stateSync.activeDraft();
       untracked(() => {
         if (this.layoutJson() !== activeDraftVal) {
           queueMicrotask(() => {
+            if (this.isDestroyed) {
+              return;
+            }
             this.layoutJson.set(activeDraftVal);
 
             // Run live render updating matching activeDraft commits
@@ -125,7 +154,7 @@ export class RawFrame {
           }
         }),
         filter((payload): payload is unknown[] => payload !== null),
-        takeUntilDestroyed(this.destroyRef),
+        takeUntilDestroyed(),
       )
       .subscribe((payload: unknown[]) => {
         this.hostCommunication.sendRenderA2UI(payload);

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -48,6 +48,8 @@ class MockSecureCredentialsStorage {
 describe('LocalStorageAppConfigProvider', () => {
   let mockStartupService: {
     getResolvedRendererUrl: ReturnType<typeof vi.fn>;
+    setResolvedRendererUrl: ReturnType<typeof vi.fn>;
+    resolveStartupConfiguration: ReturnType<typeof vi.fn>;
     isContextLocked: ReturnType<typeof vi.fn>;
     isThirdPartyEnvironment: ReturnType<typeof vi.fn>;
     isExtensionMode: ReturnType<typeof vi.fn>;
@@ -59,6 +61,8 @@ describe('LocalStorageAppConfigProvider', () => {
     mockSecureStorage = new MockSecureCredentialsStorage();
     mockStartupService = {
       getResolvedRendererUrl: vi.fn().mockReturnValue('https://default-renderer.com'),
+      setResolvedRendererUrl: vi.fn(),
+      resolveStartupConfiguration: vi.fn().mockResolvedValue('https://default-renderer.com'),
       isContextLocked: vi.fn().mockReturnValue(false),
       isThirdPartyEnvironment: vi.fn().mockReturnValue(false),
       isExtensionMode: vi.fn().mockReturnValue(false),
@@ -213,6 +217,18 @@ describe('LocalStorageAppConfigProvider', () => {
     provider.setRendererUrl('https://updated-renderer.com');
     expect(provider.rendererUrl()).toBe('https://updated-renderer.com');
     expect(localStorage.getItem(LocalStorageKey.RENDERER_URL)).toBe('https://updated-renderer.com');
+    expect(mockStartupService.setResolvedRendererUrl).toHaveBeenCalledWith(
+      'https://updated-renderer.com',
+    );
+  });
+
+  it('does not call startup.setResolvedRendererUrl when context is locked', () => {
+    mockStartupService.isContextLocked.mockReturnValue(true);
+    const provider = setupProvider();
+    provider.setRendererUrl('https://locked-renderer.com');
+    expect(provider.rendererUrl()).toBe('https://locked-renderer.com');
+    expect(localStorage.getItem(LocalStorageKey.RENDERER_URL)).toBe('https://locked-renderer.com');
+    expect(mockStartupService.setResolvedRendererUrl).not.toHaveBeenCalled();
   });
 
   it('persists updated API key to SecureCredentialsStorage and updates signal', async () => {
@@ -287,6 +303,7 @@ describe('LocalStorageAppConfigProvider', () => {
 
     await provider.flushConfig();
 
+    expect(mockStartupService.resolveStartupConfiguration).toHaveBeenCalled();
     expect(provider.rendererUrl()).toBe('https://base-url.com');
     expect(provider.geminiApiKey()).toBe('');
     expect(provider.authType()).toBe(AuthType.FIRST_PARTY); // Fallback 1P
@@ -414,5 +431,19 @@ describe('LocalStorageAppConfigProvider', () => {
       expect(() => provider.setThemePreference(ThemePreference.DARK)).not.toThrow();
       expect(() => provider.flushConfig()).not.toThrow();
     });
+  });
+
+  it('synchronizes renderer URL with StartupResolution when setRendererUrl is called', () => {
+    const provider = setupProvider();
+    provider.setRendererUrl('https://sync-renderer.com');
+    expect(mockStartupService.setResolvedRendererUrl).toHaveBeenCalledWith(
+      'https://sync-renderer.com',
+    );
+  });
+
+  it('invokes StartupResolution.resolveStartupConfiguration when flushConfig is called', async () => {
+    const provider = setupProvider();
+    await provider.flushConfig();
+    expect(mockStartupService.resolveStartupConfiguration).toHaveBeenCalled();
   });
 });

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -155,6 +155,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   override setRendererUrl(url: string): void {
     this._rendererUrl.set(url);
     this.localStorageInteractions.setItem(LocalStorageKey.RENDERER_URL, url);
+    if (!this.startup.isContextLocked()) {
+      this.startup.setResolvedRendererUrl(url);
+    }
   }
 
   /**
@@ -231,6 +234,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
 
     this._forcedAuthOverride.set(AuthType.DEFAULT);
     this._geminiApiKey.set('');
+    await this.startup.resolveStartupConfiguration();
+    // Asynchronously re-evaluate default configuration fallbacks
+    // (query params -> local storage -> config.json).
     this._rendererUrl.set(this.startup.getResolvedRendererUrl() || '');
     this._themePreference.set(ThemePreference.LIGHT);
     this._includeScreenshot.set(false);

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -537,7 +537,7 @@ describe('Settings', () => {
       const {fixture, component} = await setupComponent();
 
       mockGeminiApiKey.set('loaded-idb-key');
-      TestBed.flushEffects();
+      TestBed.tick();
       fixture.detectChanges();
 
       expect(component.settingsForm.controls.apiKey.value).toBe('loaded-idb-key');
@@ -546,7 +546,7 @@ describe('Settings', () => {
       component.settingsForm.controls.apiKey.markAsDirty();
 
       mockGeminiApiKey.set('background-sync-key');
-      TestBed.flushEffects();
+      TestBed.tick();
       fixture.detectChanges();
 
       expect(component.settingsForm.controls.apiKey.value).toBe('user-typed-key');

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -51,7 +51,7 @@ import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {DockviewComponent} from 'dockview';
 
 /** Internal interface mapping raw cross-frame workspace telemetry payloads */
-interface WorkspaceMessagePayload {
+export declare interface WorkspaceMessagePayload {
   action?: unknown;
   validationErrors?: unknown[] | Record<string, unknown> | string | boolean;
 }
@@ -124,7 +124,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
       const eventsPanel = this.dockviewApi?.getGroupPanel(ComposerPanelId.Events);
       const errorsPanel = this.dockviewApi?.getGroupPanel(ComposerPanelId.Errors);
 
-      if (envelope.type === PreviewBridgeMessageType.SEND_TO_SERVER && payload?.['action']) {
+      if (envelope.type === PreviewBridgeMessageType.SEND_TO_SERVER && payload?.action) {
         if (!eventsPanel?.api.isVisible) {
           this.unreadEventsCount.update(count => count + 1);
         }
@@ -134,9 +134,9 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
         }
       } else if (
         envelope.type === PreviewBridgeMessageType.DATA_MODEL_CHANGE &&
-        payload?.['validationErrors']
+        payload?.validationErrors
       ) {
-        const validationErrors = payload['validationErrors'];
+        const validationErrors = payload.validationErrors;
         const hasErrors = Array.isArray(validationErrors)
           ? validationErrors.length > 0
           : typeof validationErrors === 'object' && validationErrors !== null

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -38,10 +38,8 @@ export class CrossFrameValidator {
       return false;
     }
 
-    // NOTE: Bracket notation is used to access properties on the incoming message object
-    // to prevent compilers from renaming these property accesses during minification.
-    const msgType = message['type'];
-    const msgPayload = message['payload'];
+    const msgType = message.type;
+    const msgPayload = message.payload;
 
     if (typeof msgType !== 'string' || !msgType.trim()) {
       console.error('Malformed message: type must be a non-empty string.');
@@ -94,16 +92,13 @@ export class CrossFrameValidator {
         }
 
         const blockingState = msgPayload as SetBlockingStatePayload;
-        if (typeof blockingState['blocked'] !== 'boolean') {
+        if (typeof blockingState.blocked !== 'boolean') {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: must contain boolean property blocked.',
           );
           return false;
         }
-        if (
-          blockingState['message'] !== undefined &&
-          typeof blockingState['message'] !== 'string'
-        ) {
+        if (blockingState.message !== undefined && typeof blockingState.message !== 'string') {
           console.error(
             'Malformed payload for SET_BLOCKING_STATE: message property must be a string if present.',
           );
@@ -119,8 +114,8 @@ export class CrossFrameValidator {
         }
 
         const themePayload = msgPayload as SetThemePayload;
-        if (!Object.values(ThemePreference).includes(themePayload['theme'])) {
-          console.error(`Invalid theme preference mode: ${String(themePayload['theme'])}`);
+        if (!Object.values(ThemePreference).includes(themePayload.theme)) {
+          console.error(`Invalid theme preference mode: ${String(themePayload.theme)}`);
           return false;
         }
 
@@ -134,7 +129,7 @@ export class CrossFrameValidator {
         }
 
         const changePayload = msgPayload as DataModelChangePayload;
-        const updateObj = changePayload['updateDataModel'];
+        const updateObj = changePayload.updateDataModel;
         if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: must contain an updateDataModel object.',
@@ -143,13 +138,13 @@ export class CrossFrameValidator {
         }
 
         const updateData = updateObj as UpdateDataModelDetails;
-        if (typeof updateData['surfaceId'] !== 'string') {
+        if (typeof updateData.surfaceId !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel must contain a valid surfaceId string.',
           );
           return false;
         }
-        if (updateData['path'] !== undefined && typeof updateData['path'] !== 'string') {
+        if (updateData.path !== undefined && typeof updateData.path !== 'string') {
           console.error(
             'Malformed payload for DATA_MODEL_CHANGE: updateDataModel path must be a string if present.',
           );
@@ -171,16 +166,16 @@ export class CrossFrameValidator {
       return false;
     }
 
-    // NOTE: Bracket notation is used to access properties on cross-frame message objects
-    // to prevent compilers from renaming these properties during production minification.
     const itemObj = item as RenderA2uiItem;
-    if (itemObj['version'] !== 'v0.9') {
+    if (itemObj.version !== 'v0.9') {
       console.error('Malformed payload for RENDER_A2UI: array items must specify version "v0.9".');
       return false;
     }
 
     const updateKeys = ['createSurface', 'updateComponents', 'updateDataModel', 'deleteSurface'];
-    const presentKeys = updateKeys.filter(key => key in itemObj && itemObj[key] !== undefined);
+    const presentKeys = updateKeys.filter(
+      key => key in itemObj && (itemObj as Record<string, unknown>)[key] !== undefined,
+    );
 
     if (presentKeys.length === 0) {
       console.error(
@@ -197,7 +192,7 @@ export class CrossFrameValidator {
     }
 
     const updateType = presentKeys[0];
-    const updateObj = itemObj[updateType];
+    const updateObj = (itemObj as Record<string, unknown>)[updateType];
 
     if (!updateObj || typeof updateObj !== 'object' || Array.isArray(updateObj)) {
       console.error(`Malformed payload for RENDER_A2UI: ${updateType} property must be an object.`);
@@ -205,7 +200,7 @@ export class CrossFrameValidator {
     }
 
     const updateData = updateObj as BaseSurfaceDetails;
-    if (typeof updateData['surfaceId'] !== 'string') {
+    if (typeof updateData.surfaceId !== 'string') {
       console.error(
         `Malformed payload for RENDER_A2UI: ${updateType} must contain a valid surfaceId string.`,
       );
@@ -214,15 +209,15 @@ export class CrossFrameValidator {
 
     if (updateType === 'createSurface') {
       const createDetails = updateObj as CreateSurfaceDetails;
-      if (typeof createDetails['catalogId'] !== 'string') {
+      if (typeof createDetails.catalogId !== 'string') {
         console.error(
           'Malformed payload for RENDER_A2UI: createSurface must contain a valid catalogId string.',
         );
         return false;
       }
       if (
-        createDetails['sendDataModel'] !== undefined &&
-        typeof createDetails['sendDataModel'] !== 'boolean'
+        createDetails.sendDataModel !== undefined &&
+        typeof createDetails.sendDataModel !== 'boolean'
       ) {
         console.error(
           'Malformed payload for RENDER_A2UI: createSurface sendDataModel must be a boolean if present.',
@@ -231,13 +226,13 @@ export class CrossFrameValidator {
       }
     } else if (updateType === 'updateComponents') {
       const updateCompDetails = updateObj as UpdateComponentsDetails;
-      if (!Array.isArray(updateCompDetails['components'])) {
+      if (!Array.isArray(updateCompDetails.components)) {
         console.error(
           'Malformed payload for RENDER_A2UI: updateComponents must contain a components Array.',
         );
         return false;
       }
-      for (const comp of updateCompDetails['components']) {
+      for (const comp of updateCompDetails.components) {
         if (!comp || typeof comp !== 'object' || Array.isArray(comp)) {
           console.error(
             'Malformed payload for RENDER_A2UI: updateComponents components array items must be objects.',
@@ -247,10 +242,7 @@ export class CrossFrameValidator {
       }
     } else if (updateType === 'updateDataModel') {
       const updateModelDetails = updateObj as UpdateDataModelDetails;
-      if (
-        updateModelDetails['path'] !== undefined &&
-        typeof updateModelDetails['path'] !== 'string'
-      ) {
+      if (updateModelDetails.path !== undefined && typeof updateModelDetails.path !== 'string') {
         console.error(
           'Malformed payload for RENDER_A2UI: updateDataModel path must be a string if present.',
         );

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -634,4 +634,228 @@ describe('HostCommunication', () => {
       timestamp: expect.any(Number),
     });
   });
+
+  describe('captureScreenshot', () => {
+    let mockTrack: MediaStreamTrack;
+    let mockStream: MediaStream;
+    let originalMediaDevices: MediaDevices | undefined;
+    let originalRestrictionTarget: unknown;
+
+    beforeEach(() => {
+      originalMediaDevices = navigator.mediaDevices;
+      originalRestrictionTarget = (globalThis as Record<string, unknown>)['RestrictionTarget'];
+
+      mockTrack = {
+        stop: vi.fn(),
+        restrictTo: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MediaStreamTrack;
+
+      mockStream = {
+        getVideoTracks: vi.fn().mockReturnValue([mockTrack]),
+        getTracks: vi.fn().mockReturnValue([mockTrack]),
+      } as unknown as MediaStream;
+
+      Object.defineProperty(HTMLVideoElement.prototype, 'onloadedmetadata', {
+        set(fn: (() => void) | null) {
+          if (typeof fn === 'function') {
+            setTimeout(() => fn(), 0);
+          }
+        },
+        configurable: true,
+      });
+
+      vi.spyOn(HTMLVideoElement.prototype, 'play').mockResolvedValue(undefined);
+      vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+        'data:image/png;base64,mock',
+      );
+    });
+
+    afterEach(() => {
+      if (originalMediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', {
+          value: originalMediaDevices,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        // @ts-expect-error - cleanup navigator.mediaDevices
+        delete navigator.mediaDevices;
+      }
+
+      if (originalRestrictionTarget !== undefined) {
+        (globalThis as Record<string, unknown>)['RestrictionTarget'] = originalRestrictionTarget;
+      } else {
+        delete (globalThis as Record<string, unknown>)['RestrictionTarget'];
+      }
+
+      vi.restoreAllMocks();
+    });
+
+    it('throws error when no iframe element registered', async () => {
+      service.registerIframe(null);
+      await expect(service.captureScreenshot()).rejects.toThrow(
+        'No active iframe element found to capture screenshot.',
+      );
+
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+      await expect(service.captureScreenshot()).rejects.toThrow(
+        'No active iframe element found to capture screenshot.',
+      );
+    });
+
+    it('throws error when getDisplayMedia is unavailable', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {},
+        configurable: true,
+        writable: true,
+      });
+
+      await expect(service.captureScreenshot()).rejects.toThrow(
+        'Screen capture API (getDisplayMedia) is not supported in this environment.',
+      );
+    });
+
+    it('throws error when stream has no video tracks', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      const emptyStream = {
+        getVideoTracks: vi.fn().mockReturnValue([]),
+        getTracks: vi.fn().mockReturnValue([]),
+      } as unknown as MediaStream;
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getDisplayMedia: vi.fn().mockResolvedValue(emptyStream),
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      await expect(service.captureScreenshot()).rejects.toThrow(
+        'No video track found in media stream.',
+      );
+    });
+
+    it('captures screenshot using element restriction when RestrictionTarget is supported', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      const mockTarget = {type: 'restriction-target'};
+      const mockRestrictionTarget = {
+        fromElement: vi.fn().mockResolvedValue(mockTarget),
+      };
+      (globalThis as Record<string, unknown>)['RestrictionTarget'] = mockRestrictionTarget;
+
+      const getDisplayMediaSpy = vi.fn().mockResolvedValue(mockStream);
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {getDisplayMedia: getDisplayMediaSpy},
+        configurable: true,
+        writable: true,
+      });
+
+      const result = await service.captureScreenshot();
+
+      expect(getDisplayMediaSpy).toHaveBeenCalledWith({
+        video: {displaySurface: 'browser'},
+        preferCurrentTab: true,
+      });
+      expect(mockRestrictionTarget.fromElement).toHaveBeenCalledWith(mockIframeElement);
+      expect(mockTrack.restrictTo).toHaveBeenCalledWith(mockTarget);
+      expect(mockTrack.stop).toHaveBeenCalled();
+      expect(typeof result).toBe('string');
+    });
+
+    it('falls back gracefully to full tab capture when RestrictionTarget is undefined', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      delete (globalThis as Record<string, unknown>)['RestrictionTarget'];
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {getDisplayMedia: vi.fn().mockResolvedValue(mockStream)},
+        configurable: true,
+        writable: true,
+      });
+
+      const result = await service.captureScreenshot();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'RestrictionTarget API not supported, capturing full tab.',
+      );
+      expect(mockTrack.stop).toHaveBeenCalled();
+      expect(typeof result).toBe('string');
+    });
+
+    it('falls back gracefully when RestrictionTarget.fromElement throws or rejects', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      const restrictionError = new Error('Failed fromElement');
+      (globalThis as Record<string, unknown>)['RestrictionTarget'] = {
+        fromElement: vi.fn().mockRejectedValue(restrictionError),
+      };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {getDisplayMedia: vi.fn().mockResolvedValue(mockStream)},
+        configurable: true,
+        writable: true,
+      });
+
+      const result = await service.captureScreenshot();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to restrict video track to element, falling back to full tab capture:',
+        restrictionError,
+      );
+      expect(mockTrack.stop).toHaveBeenCalled();
+      expect(typeof result).toBe('string');
+    });
+
+    it('falls back gracefully when track.restrictTo throws or rejects', async () => {
+      const mockIframeElement = {
+        contentWindow: {postMessage: vi.fn()},
+      } as unknown as HTMLIFrameElement;
+      service.registerIframe(mockIframeElement);
+
+      const mockTarget = {type: 'restriction-target'};
+      (globalThis as Record<string, unknown>)['RestrictionTarget'] = {
+        fromElement: vi.fn().mockResolvedValue(mockTarget),
+      };
+      const restrictionError = new Error('Failed restrictTo');
+      mockTrack.restrictTo = vi.fn().mockRejectedValue(restrictionError);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {getDisplayMedia: vi.fn().mockResolvedValue(mockStream)},
+        configurable: true,
+        writable: true,
+      });
+
+      const result = await service.captureScreenshot();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to restrict video track to element, falling back to full tab capture:',
+        restrictionError,
+      );
+      expect(mockTrack.stop).toHaveBeenCalled();
+      expect(typeof result).toBe('string');
+    });
+  });
 });

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -29,7 +29,7 @@ import {PreviewBridgeMessageType} from 'a2ui-bridge';
  * Schema representing a structured postMessage payload used to communicate
  * event data and lifecycle checks between the host and preview frame.
  */
-export interface MessageEnvelope {
+export declare interface MessageEnvelope {
   /** Discriminator action type identifying the specific message intent */
   type: string;
   /** Optional payload attached to the message transaction */
@@ -43,6 +43,14 @@ export interface MessageEnvelope {
 declare global {
   interface Window {
     a2uiHostCommunication?: HostCommunication;
+  }
+
+  class RestrictionTarget {
+    static fromElement(element: Element): Promise<RestrictionTarget>;
+  }
+
+  interface MediaStreamTrack {
+    restrictTo(target: RestrictionTarget | null): Promise<void>;
   }
 }
 
@@ -133,13 +141,11 @@ export class HostCommunication implements OnDestroy {
   private readonly messageListener = (event: MessageEvent) => {
     const activeWindow = this.iframeElement ? this.iframeElement.contentWindow : this.iframeWindow;
     if (!activeWindow) {
-      // NOTE: Bracket notation is used to access properties on the incoming postMessage event
-      // to prevent compilers from renaming these property accesses during minification.
       const isBridgeMessage =
         event.data &&
         typeof event.data === 'object' &&
-        Object.values(PreviewBridgeMessageType).includes(event.data['type']);
-      if (!isBridgeMessage || event.data['type'] === PreviewBridgeMessageType.CONSOLE_LOG) {
+        Object.values(PreviewBridgeMessageType).includes(event.data.type);
+      if (!isBridgeMessage || event.data.type === PreviewBridgeMessageType.CONSOLE_LOG) {
         return;
       }
       this.earlyMessageBuffer.push(event);
@@ -167,13 +173,11 @@ export class HostCommunication implements OnDestroy {
     }
 
     const data = event.data;
-    // NOTE: Bracket notation is used to access properties on the incoming postMessage event
-    // to prevent compilers from renaming these property accesses during minification.
-    if (data && typeof data === 'object' && data['type']) {
-      const type = data['type'] as string;
+    if (data && typeof data === 'object' && data.type) {
+      const type = data.type as string;
       const envelope: MessageEnvelope = {
         type,
-        payload: data['payload'],
+        payload: data.payload,
         origin: event.origin,
         timestamp: Date.now(),
       };
@@ -277,12 +281,10 @@ export class HostCommunication implements OnDestroy {
    * @param theme Target theme option
    */
   sendTheme(theme: ThemePreference): void {
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
     this.sendMessage({
-      'type': PreviewBridgeMessageType.SET_THEME,
-      'payload': {
-        'theme': theme,
+      type: PreviewBridgeMessageType.SET_THEME,
+      payload: {
+        theme: theme,
       },
     });
   }
@@ -292,11 +294,9 @@ export class HostCommunication implements OnDestroy {
    * @param payload Array of layout nodes or configuration objects
    */
   sendRenderA2UI(payload: unknown[]): void {
-    // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-    // prettier-ignore
     this.sendMessage({
-      'type': PreviewBridgeMessageType.RENDER_A2UI,
-      'payload': payload,
+      type: PreviewBridgeMessageType.RENDER_A2UI,
+      payload: payload,
     });
   }
 
@@ -318,10 +318,11 @@ export class HostCommunication implements OnDestroy {
 
     let stream: MediaStream | null = null;
     try {
+      // prettier-ignore
       stream = await navigator.mediaDevices.getDisplayMedia({
         video: {displaySurface: 'browser'},
         // @ts-expect-error - preferCurrentTab is a recent/experimental API not yet in TS types
-        preferCurrentTab: true,
+        'preferCurrentTab': true,
       });
 
       const [track] = stream.getVideoTracks();
@@ -329,12 +330,23 @@ export class HostCommunication implements OnDestroy {
         throw new Error('No video track found in media stream.');
       }
 
-      // @ts-expect-error - RestrictionTarget is a recent API not yet in TS types
-      if (typeof RestrictionTarget !== 'undefined') {
-        // @ts-expect-error - RestrictionTarget is not in standard TypeScript definitions yet
-        const target = await RestrictionTarget.fromElement(this.iframeElement);
-        // @ts-expect-error - restrictTo is not in standard MediaStreamTrack types yet
-        await track.restrictTo(target);
+      const restrictionTargetClass = (globalThis as Record<string, unknown>)[
+        'RestrictionTarget'
+      ] as {fromElement?: (element: Element) => Promise<RestrictionTarget>} | undefined;
+
+      if (
+        typeof restrictionTargetClass?.fromElement === 'function' &&
+        typeof track?.restrictTo === 'function'
+      ) {
+        try {
+          const target = await restrictionTargetClass.fromElement(this.iframeElement);
+          await track.restrictTo(target);
+        } catch (restrictionError) {
+          console.warn(
+            'Failed to restrict video track to element, falling back to full tab capture:',
+            restrictionError,
+          );
+        }
       } else {
         console.warn('RestrictionTarget API not supported, capturing full tab.');
       }

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -271,4 +271,12 @@ describe('StartupResolution Task 2.6', () => {
 
     expect(customService.isThirdPartyEnvironment()).toBe(true);
   });
+
+  it('updates resolved renderer URL via setResolvedRendererUrl', () => {
+    service.setResolvedRendererUrl('http://custom-url:3000');
+    expect(service.getResolvedRendererUrl()).toBe('http://custom-url:3000');
+
+    service.setResolvedRendererUrl(null);
+    expect(service.getResolvedRendererUrl()).toBeNull();
+  });
 });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -47,6 +47,15 @@ export class StartupResolution {
   readonly resolvedUrl = this._resolvedUrl.asReadonly();
   readonly isLockedContext = this._isLockedContext.asReadonly();
 
+  /**
+   * Resolves the startup configuration for the application.
+   *
+   * Use for application initial bootstrapping or resetting settings to factory
+   * defaults (e.g. in `flushConfig()`). Asynchronously evaluates the fallback
+   * chain: query parameters -> local storage -> static `config.json` defaults.
+   *
+   * @return A Promise resolving to the resolved renderer URL, or null if unresolvable.
+   */
   async resolveStartupConfiguration(): Promise<string | null> {
     let staticConfig: AppConfig | null = null;
     const controller = new AbortController();
@@ -106,6 +115,20 @@ export class StartupResolution {
 
   getResolvedRendererUrl(): string | null {
     return this._resolvedUrl();
+  }
+
+  /**
+   * Updates the resolved renderer URL directly in state.
+   *
+   * Use for direct, synchronous runtime state updates (e.g. when a user
+   * explicitly changes the renderer URL in Settings via
+   * `AppConfigProvider.setRendererUrl`). Bypasses the asynchronous resolution
+   * pipeline to prevent query parameter overrides and network overhead.
+   *
+   * @param url The target renderer URL string or null.
+   */
+  setResolvedRendererUrl(url: string | null): void {
+    this._resolvedUrl.set(url);
   }
 
   isContextLocked(): boolean {

--- a/shell/src/app/storage/catalog-management/catalog-management.ts
+++ b/shell/src/app/storage/catalog-management/catalog-management.ts
@@ -136,10 +136,8 @@ export class CatalogManagement {
             this._isHandshakeInProgress.set(true);
             this._watchdogFired.set(false);
             this._catalogError.set(null);
-            // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-            // prettier-ignore
             this.hostCommunication.sendMessage({
-              'type': PreviewBridgeMessageType.GET_CATALOG,
+              type: PreviewBridgeMessageType.GET_CATALOG,
             });
 
             this.watchdogTimerId = setTimeout(() => {
@@ -172,16 +170,14 @@ export class CatalogManagement {
               return of(null);
             }
 
-            // NOTE: Bracket notation is used to access properties on cross-frame message payloads
-            // to prevent compilers from renaming these properties during production minification.
             const payload = rawPayload as {
               error?: {message?: string};
             } & Catalog;
-            const errorObj = payload['error'];
+            const errorObj = payload.error;
 
             if (errorObj) {
               const errorMsg =
-                errorObj['message'] || 'Unknown error occurred in preview bridge during handshake.';
+                errorObj.message || 'Unknown error occurred in preview bridge during handshake.';
               this._catalogError.set(errorMsg);
               console.error('Handshake failed with bridge error:', errorMsg);
               this._isHandshakeInProgress.set(false);
@@ -192,11 +188,11 @@ export class CatalogManagement {
             let catalogString: string;
             try {
               catalogObj = structuredClone(payload as Catalog);
-              if (typeof catalogObj['title'] === 'string') {
-                catalogObj['title'] = sanitizeHtml(catalogObj['title']).toString();
+              if (typeof catalogObj.title === 'string') {
+                catalogObj.title = sanitizeHtml(catalogObj.title).toString();
               }
-              if (typeof catalogObj['description'] === 'string') {
-                catalogObj['description'] = sanitizeHtml(catalogObj['description']).toString();
+              if (typeof catalogObj.description === 'string') {
+                catalogObj.description = sanitizeHtml(catalogObj.description).toString();
               }
               catalogString = stableStringify(catalogObj);
             } catch (err: unknown) {
@@ -207,7 +203,7 @@ export class CatalogManagement {
               return of(null);
             }
 
-            const catalogId = catalogObj['catalogId'] || catalogObj['$id'];
+            const catalogId = catalogObj.catalogId || catalogObj.$id;
             if (!catalogId) {
               const errorMsg = 'Catalog is missing a valid identifier (catalogId or $id).';
               this._catalogError.set(errorMsg);
@@ -258,8 +254,8 @@ export class CatalogManagement {
                   }
 
                   this._activeCatalog.set(catalogObj);
-                  this._activeCatalogTitle.set(catalogObj['title'] || '');
-                  this._activeCatalogDescription.set(catalogObj['description'] || '');
+                  this._activeCatalogTitle.set(catalogObj.title || '');
+                  this._activeCatalogDescription.set(catalogObj.description || '');
 
                   this._catalogError.set(null);
                   this._isHandshakeInProgress.set(false);

--- a/shell/src/app/storage/secure-credentials-storage/secure-credentials-storage.ts
+++ b/shell/src/app/storage/secure-credentials-storage/secure-credentials-storage.ts
@@ -19,7 +19,7 @@ import {Injectable} from '@angular/core';
 /**
  * Represents a key-value record stored within the highly secure IndexedDB instance.
  */
-export interface CredentialRecord {
+export declare interface CredentialRecord {
   /** The unique credential identifier key. */
   key: string;
   /** Binary Web Crypto AES-GCM encrypted ciphertext. */
@@ -29,7 +29,7 @@ export interface CredentialRecord {
 }
 
 /** Represents a persistent unextractable Web Crypto master key record. */
-export interface MasterKeyRecord {
+export declare interface MasterKeyRecord {
   /** The unique master key identifier. */
   key: string;
   /** The unextractable Web Crypto CryptoKey instance. */

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -1,4 +1,4 @@
 {
-  "defaultRendererUrl": "/samples/ng-basic-catalog/index.html",
+  "defaultRendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
   "allowOverrides": true
 }

--- a/shell/src/global_styles.scss
+++ b/shell/src/global_styles.scss
@@ -203,7 +203,8 @@ $dark-theme: mat.define-theme(
     --mdc-chip-with-trailing-icon-disabled-trailing-icon-color: #e5e2e2;
   }
 
-  // High-contrast overrides guaranteeing clean legibility for primary buttons and icon buttons in dark mode.
+  // High-contrast overrides guaranteeing clean legibility for primary buttons
+  // and icon buttons in dark mode.
   .mat-mdc-button.mat-primary,
   .mat-mdc-outlined-button.mat-primary,
   .mat-mdc-raised-button.mat-primary,
@@ -242,13 +243,13 @@ body .mat-mdc-slide-toggle .mdc-form-field,
 body .mat-mdc-slide-toggle .mat-internal-form-field {
   display: inline-flex !important;
   align-items: center !important;
-  gap: 16px !important; /* Clean spacer gap between switch and text label */
+  gap: 16px !important; // Clean spacer gap between switch and text label
 }
 
 body .mat-mdc-slide-toggle label,
 body .mat-mdc-slide-toggle .mdc-label {
-  padding-left: 16px !important; /* Safe spacing cushion blocking handle overlaps */
-  white-space: normal !important; /* Forces clean wrapping on narrow viewports */
+  padding-left: 16px !important; // Safe spacing cushion blocking handle overlaps
+  white-space: normal !important; // Forces clean wrapping on narrow viewports
   line-height: 1.4 !important;
   color: var(--mat-sys-on-surface) !important;
 }


### PR DESCRIPTION
# Description

Refactor cross-frame boundary interfaces to use 'declare interface'. This causes tsickle to generate compiler @externs definitions for Closure Compiler, preventing property renaming without requiring inline string key quoting, manual casting, or bracket access.

Replace verbose record casting with clean, type-safe, idiomatic  TypeScript dot-notation.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

