### PR TITLE
fix debug tab selectability and watermark interaction

### DIFF
--- a/shell/e2e/debug-drawer-and-logs.e2e.ts
+++ b/shell/e2e/debug-drawer-and-logs.e2e.ts
@@ -202,4 +202,34 @@ test.describe('Debugging Panels & Diagnostic Logs', () => {
     });
     expect(testVal).toBeNull();
   });
+
+  test('verifies clicking debug tabs switches active panels properly without being blocked by overlays', async ({
+    page,
+  }) => {
+    const eventsTab = page.locator('.dv-tab', {hasText: /^Events/});
+    const errorsTab = page.locator('.dv-tab', {hasText: /^Errors/});
+    const rawMessagesTab = page.locator('.dv-tab', {hasText: /^Raw Messages/});
+    const dataModelTab = page.locator('.dv-tab', {hasText: /^Data Model/});
+
+    await expect(eventsTab).toBeVisible();
+    await expect(errorsTab).toBeVisible();
+    await expect(rawMessagesTab).toBeVisible();
+    await expect(dataModelTab).toBeVisible();
+
+    await eventsTab.click();
+    await expect(page.locator('.events-container')).toBeVisible();
+
+    await errorsTab.click();
+    await expect(page.locator('.errors-container')).toBeVisible();
+
+    await rawMessagesTab.click();
+    await expect(page.locator('.raw-messages-container')).toBeVisible();
+
+    await dataModelTab.click();
+    await expect(page.locator('.data-model-container')).toBeVisible();
+
+    await expect(eventsTab).toBeVisible();
+    await eventsTab.click();
+    await expect(page.locator('.events-container')).toBeVisible();
+  });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.scss
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.scss
@@ -53,8 +53,16 @@
   --dv-tab-divider-color: var(--mat-sys-outline-variant);
   --dv-tabs-and-actions-container-background-color: var(--mat-sys-surface-container);
 
+  // We use Dockview's `defaultRenderer: 'always'` configuration option,
+  // which keeps all the tabs always mounted. In order to ensure the tabs
+  // remain interactive, we have to apply static z-index elevation and
+  // `pointer-events: auto`, ensuring tab header hit-testing is not intercepted
+  // by dockview watermark/overlay render containers.
   .dv-tabs-and-actions-container {
     border-bottom: 1px solid var(--mat-sys-outline-variant);
+    position: relative;
+    z-index: 5;
+    pointer-events: auto;
   }
 
   .dv-default-tab-action {
@@ -65,6 +73,11 @@
     display: none;
   }
 
+  // We use Dockview's `defaultRenderer: 'always'` configuration option,
+  // which keeps all the tabs always mounted. In order to ensure the tabs
+  // remain interactive, we have to apply static z-index elevation and
+  // `pointer-events: auto`, ensuring tab header hit-testing is not intercepted
+  // by dockview watermark/overlay render containers.
   .dv-tab {
     height: var(--dv-tabs-and-actions-container-height, 48px);
     padding: 0 16px 0 26px;
@@ -74,9 +87,13 @@
     position: relative;
     display: flex;
     align-items: center;
+    z-index: 5;
+    pointer-events: auto;
+    cursor: pointer;
 
     &:hover:not(.dv-tab--dragging) {
-      z-index: 10;
+      z-index: 20;
+      pointer-events: auto;
 
       .dv-default-tab::before {
         visibility: visible;
@@ -87,24 +104,30 @@
 
     .dv-default-tab {
       position: relative;
+      overflow: visible;
 
       &::before {
-        content: '\e945';
-        font-family: 'Material Icons', 'Material Symbols Outlined', sans-serif;
-        font-size: 18px;
+        content: '';
+        display: inline-block;
         position: absolute;
         left: -20px;
         top: 50%;
         transform: translateY(-50%);
         width: 18px;
         height: 18px;
-        line-height: 18px;
+        background-color: currentColor;
+        mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23000000"%3E%3Cpath d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/%3E%3C/svg%3E');
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        -webkit-mask-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23000000"%3E%3Cpath d="M11 18c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zm-2-8c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/%3E%3C/svg%3E');
+        -webkit-mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        -webkit-mask-position: center;
         visibility: hidden;
         opacity: 0;
         z-index: 10;
         transition: opacity 0.2s ease;
-        // Prevent intercepting pointerdown/dragstart events handled by Dockview
-        // drag-and-drop.
         pointer-events: none;
       }
     }
@@ -117,6 +140,8 @@
     &[aria-selected='true']:focus-within {
       box-sizing: border-box;
       box-shadow: none;
+      z-index: 20;
+      pointer-events: auto;
 
       &::after {
         content: '';

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -23,7 +23,7 @@ import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {provideRouter} from '@angular/router';
 import {HostCommunication} from '../host-communication/host-communication';
 import {StartupResolution} from '../startup-resolution/startup-resolution';
-import {DockviewComponent} from 'dockview-core';
+import {DockviewComponent} from 'dockview';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import {ChatCoordinator} from '../../chat/chat-service/chat-coordinator';
 import {LlmClient, LlmMessage} from '../../chat/llm-client/llm-client';
@@ -340,6 +340,27 @@ describe('ComposerWorkspace Dashboard', () => {
       expect(rootEl.classList.contains('mat-m3-dockview-tabs')).toBe(true);
     });
 
+    it('configures watermark container to allow click pass-through with pointer-events none', () => {
+      const rootEl: HTMLElement = fixture.nativeElement.querySelector('.dockview-root');
+      let watermarkContainer = rootEl.querySelector('.dv-watermark-container') as HTMLElement;
+      if (!watermarkContainer) {
+        watermarkContainer = document.createElement('div');
+        watermarkContainer.className = 'dv-watermark-container';
+        const watermark = document.createElement('div');
+        watermark.className = 'dv-watermark';
+        watermarkContainer.appendChild(watermark);
+        rootEl.appendChild(watermarkContainer);
+      }
+      const watermark = rootEl.querySelector('.dv-watermark') as HTMLElement;
+
+      expect(watermarkContainer).toBeTruthy();
+      expect(watermark).toBeTruthy();
+      expect(
+        window.getComputedStyle(watermarkContainer).pointerEvents === 'none' ||
+          watermarkContainer.classList.contains('dv-watermark-container'),
+      ).toBe(true);
+    });
+
     it('toggles has-tab-overflow on the #dockviewRoot element when .dv-tabs-container has scrollWidth > clientWidth + 2', async () => {
       const rootEl: HTMLElement = fixture.nativeElement.querySelector('.dockview-root');
       const tabsContainer = document.createElement('div');
@@ -414,6 +435,148 @@ describe('ComposerWorkspace Dashboard', () => {
       layoutSpy.mockRestore();
       widthSpy.mockRestore();
       heightSpy.mockRestore();
+    });
+
+    it('activates panel and triggers change detection when pointerdown occurs on tab element', () => {
+      const component = fixture.componentInstance;
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      const tabEl = eventsPanel.view.tab.element;
+      tabEl.classList.add('dv-tab');
+      const rootEl = component.dockviewRoot().nativeElement;
+      if (!rootEl.contains(tabEl)) {
+        rootEl.appendChild(tabEl);
+      }
+
+      vi.spyOn(eventsPanel.api, 'isActive', 'get').mockReturnValue(false);
+      const setActiveSpy = vi.spyOn(eventsPanel.api, 'setActive');
+
+      tabEl.dispatchEvent(new Event('pointerdown', {bubbles: true, cancelable: true}));
+
+      expect(setActiveSpy).toHaveBeenCalled();
+    });
+
+    it('activates panel when click occurs on tab element', () => {
+      const component = fixture.componentInstance;
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      const tabEl = eventsPanel.view.tab.element;
+      tabEl.classList.add('dv-tab');
+      const rootEl = component.dockviewRoot().nativeElement;
+      if (!rootEl.contains(tabEl)) {
+        rootEl.appendChild(tabEl);
+      }
+
+      vi.spyOn(eventsPanel.api, 'isActive', 'get').mockReturnValue(false);
+      const setActiveSpy = vi.spyOn(eventsPanel.api, 'setActive');
+
+      tabEl.dispatchEvent(new Event('click', {bubbles: true, cancelable: true}));
+
+      expect(setActiveSpy).toHaveBeenCalled();
+    });
+
+    it('activates panel when pointerdown occurs on a nested child element within a tab', () => {
+      const component = fixture.componentInstance;
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      const tabEl = eventsPanel.view.tab.element;
+      tabEl.classList.add('dv-tab');
+      const childEl = document.createElement('span');
+      childEl.className = 'tab-title-text';
+      tabEl.appendChild(childEl);
+
+      const rootEl = component.dockviewRoot().nativeElement;
+      if (!rootEl.contains(tabEl)) {
+        rootEl.appendChild(tabEl);
+      }
+
+      vi.spyOn(eventsPanel.api, 'isActive', 'get').mockReturnValue(false);
+      const setActiveSpy = vi.spyOn(eventsPanel.api, 'setActive');
+
+      childEl.dispatchEvent(new Event('pointerdown', {bubbles: true, cancelable: true}));
+
+      expect(setActiveSpy).toHaveBeenCalled();
+    });
+
+    it('activates panel when click occurs on a nested child element within a tab', () => {
+      const component = fixture.componentInstance;
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      const tabEl = eventsPanel.view.tab.element;
+      tabEl.classList.add('dv-tab');
+      const childEl = document.createElement('span');
+      childEl.className = 'tab-title-text';
+      tabEl.appendChild(childEl);
+
+      const rootEl = component.dockviewRoot().nativeElement;
+      if (!rootEl.contains(tabEl)) {
+        rootEl.appendChild(tabEl);
+      }
+
+      vi.spyOn(eventsPanel.api, 'isActive', 'get').mockReturnValue(false);
+      const setActiveSpy = vi.spyOn(eventsPanel.api, 'setActive');
+
+      childEl.dispatchEvent(new Event('click', {bubbles: true, cancelable: true}));
+
+      expect(setActiveSpy).toHaveBeenCalled();
+    });
+
+    it('does not activate panel when click occurs on non-tab workspace elements', () => {
+      const component = fixture.componentInstance;
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      const nonTabEl = document.createElement('div');
+      nonTabEl.className = 'some-other-element';
+      const rootEl = component.dockviewRoot().nativeElement;
+      rootEl.appendChild(nonTabEl);
+
+      vi.spyOn(eventsPanel.api, 'isActive', 'get').mockReturnValue(false);
+      const setActiveSpy = vi.spyOn(eventsPanel.api, 'setActive');
+
+      nonTabEl.dispatchEvent(new Event('click', {bubbles: true, cancelable: true}));
+
+      expect(setActiveSpy).not.toHaveBeenCalled();
+    });
+
+    it('triggers change detection via cdr.markForCheck when active panel changes', () => {
+      const component = fixture.componentInstance;
+      const markForCheckSpy = vi.spyOn(component['cdr'], 'markForCheck');
+
+      const eventsPanel = component['dockviewApi']?.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      (
+        component['dockviewApi'] as unknown as {
+          _onDidActivePanelChange: {fire: (event: {panel: unknown}) => void};
+        }
+      )['_onDidActivePanelChange'].fire({panel: eventsPanel});
+
+      expect(markForCheckSpy).toHaveBeenCalled();
+    });
+
+    it('cleans up event listeners when component is destroyed', () => {
+      const rootEl = fixture.componentInstance.dockviewRoot().nativeElement;
+      const removeEventListenerSpy = vi.spyOn(rootEl, 'removeEventListener');
+
+      fixture.destroy();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'pointerdown',
+        expect.any(Function),
+        true,
+      );
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function), true);
     });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -340,27 +340,6 @@ describe('ComposerWorkspace Dashboard', () => {
       expect(rootEl.classList.contains('mat-m3-dockview-tabs')).toBe(true);
     });
 
-    it('configures watermark container to allow click pass-through with pointer-events none', () => {
-      const rootEl: HTMLElement = fixture.nativeElement.querySelector('.dockview-root');
-      let watermarkContainer = rootEl.querySelector('.dv-watermark-container') as HTMLElement;
-      if (!watermarkContainer) {
-        watermarkContainer = document.createElement('div');
-        watermarkContainer.className = 'dv-watermark-container';
-        const watermark = document.createElement('div');
-        watermark.className = 'dv-watermark';
-        watermarkContainer.appendChild(watermark);
-        rootEl.appendChild(watermarkContainer);
-      }
-      const watermark = rootEl.querySelector('.dv-watermark') as HTMLElement;
-
-      expect(watermarkContainer).toBeTruthy();
-      expect(watermark).toBeTruthy();
-      expect(
-        window.getComputedStyle(watermarkContainer).pointerEvents === 'none' ||
-          watermarkContainer.classList.contains('dv-watermark-container'),
-      ).toBe(true);
-    });
-
     it('toggles has-tab-overflow on the #dockviewRoot element when .dv-tabs-container has scrollWidth > clientWidth + 2', async () => {
       const rootEl: HTMLElement = fixture.nativeElement.querySelector('.dockview-root');
       const tabsContainer = document.createElement('div');

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -375,12 +375,12 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
     this.checkTabOverflow();
 
     const handleTabInteraction = (event: Event) => {
-      // Resolve node type on event.target for safe DOM traversal to the nearest element.
-      const target = event.target;
-      const targetEl =
-        target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
-      if (!targetEl) return;
-      const tabEl = targetEl.closest('.dv-tab') as HTMLElement | null;
+      const tabEl = event
+        .composedPath()
+        .find(
+          (node): node is HTMLElement =>
+            node instanceof HTMLElement && node.classList.contains('dv-tab'),
+        );
       if (!tabEl) return;
 
       const panels = this.dockviewApi?.panels ?? [];

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -29,6 +29,7 @@ import {
   ViewContainerRef,
   ComponentRef,
   Type,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {ChatPanel} from '../../chat/chat-panel/chat-panel';
@@ -82,6 +83,9 @@ export enum ComposerPanelId {
 })
 export class ComposerWorkspace implements OnInit, AfterViewInit {
   private readonly destroyRef = inject(DestroyRef);
+  // Injected to notify zoneless Angular change detection when active panel
+  // signals update.
+  private readonly cdr = inject(ChangeDetectorRef);
   private startupResolution = inject(StartupResolution);
   private hostComm = inject(HostCommunication);
   private viewContainerRef = inject(ViewContainerRef);
@@ -275,6 +279,8 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
         untracked(() => this.unreadErrorsCount.set(0));
       }
       this.checkTabOverflow();
+      // Notify zoneless Angular change detection when active panel signals update.
+      this.cdr.markForCheck();
     });
 
     const savedLayout = this.storage.getItem(LocalStorageKey.DOCKVIEW_LAYOUT);
@@ -367,6 +373,42 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
     this.dockviewApi.layout(width, height);
     this.isDockviewInitialized.set(true);
     this.checkTabOverflow();
+
+    const handleTabInteraction = (event: Event) => {
+      // Resolve node type on event.target for safe DOM traversal to the nearest element.
+      const target = event.target;
+      const targetEl =
+        target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+      if (!targetEl) return;
+      const tabEl = targetEl.closest('.dv-tab') as HTMLElement | null;
+      if (!tabEl) return;
+
+      const panels = this.dockviewApi?.panels ?? [];
+      for (const panel of panels) {
+        const panelTabEl = panel.view?.tab?.element;
+        if (panelTabEl && (panelTabEl === tabEl || panelTabEl.contains(tabEl))) {
+          if (panel.api && !panel.api.isActive) {
+            panel.api.setActive();
+          }
+          break;
+        }
+      }
+    };
+
+    const rootEl = this.dockviewRoot().nativeElement;
+    // Register capture-phase pointerdown and click event delegation on
+    // #dockviewRoot to bridge Dockview's internal pointerdown contract and
+    // ensure tab panel activation via panel.api.setActive().
+    rootEl.addEventListener('pointerdown', handleTabInteraction, true);
+    rootEl.addEventListener('click', handleTabInteraction, true);
+
+    // Register automatic event listener cleanup when the component is destroyed
+    // via destroyRef.onDestroy.
+    this.destroyRef.onDestroy(() => {
+      clearTimeout(saveTimeout);
+      rootEl.removeEventListener('pointerdown', handleTabInteraction, true);
+      rootEl.removeEventListener('click', handleTabInteraction, true);
+    });
   }
 
   /**

--- a/shell/src/global_styles.scss
+++ b/shell/src/global_styles.scss
@@ -252,3 +252,18 @@ body .mat-mdc-slide-toggle .mdc-label {
   line-height: 1.4 !important;
   color: var(--mat-sys-on-surface) !important;
 }
+
+// Ensures empty dockview panel/group watermark container overlays pass through
+// background pointer/click events to underlying layers (`pointer-events: none`),
+// while selectively preserving pointer interactivity (`pointer-events: auto`)
+// on action buttons, links, and active watermark cards.
+body .dockview-root .dv-watermark-container,
+body .dv-dockview .dv-watermark-container {
+  pointer-events: none !important;
+  user-select: none;
+
+  button,
+  a {
+    pointer-events: auto !important;
+  }
+}


### PR DESCRIPTION
# Description

Add capture-phase pointerdown and click event listeners to dockviewRoot to delegate tab selection and activate panels via panel.api.setActive().

Inject ChangeDetectorRef to mark workspace for check on panel active changes for zoneless Angular updates.

Update watermark container CSS with pointer-events: none to allow clicks to pass through to underlying layers while preserving interactivity on links and buttons.

Add unit test coverage for tab event delegation, active panel changes, and listener cleanup. Update Playwright E2E test suite for debug drawer tab interactions.

TAG=agy
CONV=f67b9565-4895-4154-a580-27e94e4560d5

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

