### PR TITLE
feat(shell): handle server api key in config.json in-memory only

### DIFF
--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -96,6 +96,67 @@ test.describe('Settings and Client Configuration', () => {
       expect(rendererVal).toBe('http://locked-renderer.com');
     });
 
+    test('verifies server apiKey in config.json decouples context locking, disables API key unmasking, and does not persist key on save', async ({
+      page,
+    }) => {
+      await page.route('**/config.json', async route => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            defaultRendererUrl: 'http://unlocked-renderer.com',
+            allowOverrides: true,
+            apiKey: 'server-provided-api-key',
+          }),
+        });
+      });
+
+      await page.goto('/settings');
+      await page.evaluate(() => {
+        try {
+          localStorage.setItem('a2ui_composer_force_3p', 'true');
+        } catch (e) {}
+      });
+      await page.reload();
+
+      // Context is unlocked because allowOverrides is true
+      await expect(page.getByLabel('Target Renderer URL')).toBeEnabled();
+
+      // Toggle button is disabled because API key was provided by config
+      await expect(page.locator('.api-key-toggle-btn')).toBeDisabled();
+
+      // Click 'Save Settings' and wait for navigation
+      const saveBtn = page.getByRole('button', {name: 'Save Settings'});
+      await Promise.all([page.waitForURL(url => url.pathname === '/'), saveBtn.click()]);
+      await page.waitForLoadState('load');
+
+      // Verify localStorage and IndexedDB have no stored credential
+      const storedKey = await page.evaluate(async () => {
+        const localVal = localStorage.getItem('a2ui_gemini_api_key');
+        if (localVal) return localVal;
+
+        return new Promise<string | null>(resolve => {
+          if (typeof indexedDB === 'undefined') {
+            resolve(null);
+            return;
+          }
+          const req = indexedDB.open('a2ui_secure_credentials_db', 2);
+          req.onsuccess = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains('credentials')) {
+              resolve(null);
+              return;
+            }
+            const tx = db.transaction('credentials', 'readonly');
+            const getReq = tx.objectStore('credentials').get('a2ui_gemini_api_key');
+            getReq.onsuccess = () => resolve(getReq.result ? 'found' : null);
+            getReq.onerror = () => resolve(null);
+          };
+          req.onerror = () => resolve(null);
+        });
+      });
+      expect(storedKey).toBeNull();
+    });
+
     test('verifies 1P vs 3P environment detection and disables chat panel on missing API keys', async ({
       page,
     }) => {

--- a/shell/src/app/settings/app-config-provider/app-config-provider.ts
+++ b/shell/src/app/settings/app-config-provider/app-config-provider.ts
@@ -67,6 +67,9 @@ export abstract class AppConfigProvider {
   /** Ephemeral api key token for Gemini LLM handshakes. */
   abstract readonly geminiApiKey: Signal<string>;
 
+  /** Exposes whether the active Gemini API key was supplied via config.json. */
+  abstract readonly isApiKeyProvidedByConfig: Signal<boolean>;
+
   /** Exposes the active theme preference selection, light vs dark. */
   abstract readonly themePreference: Signal<ThemePreference>;
 
@@ -96,6 +99,13 @@ export abstract class AppConfigProvider {
    * @param key The fresh Gemini developer api key credential.
    */
   abstract setGeminiApiKey(key: string): Promise<void> | void;
+
+  /**
+   * Sets in-memory Gemini API key loaded from config.json without persisting it to storage.
+   *
+   * @param key The server-configured API key token.
+   */
+  abstract setApiKeyFromConfig(key: string): void;
 
   /**
    * Erases the Gemini developer API key credential from secure persistence

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -408,6 +408,71 @@ describe('LocalStorageAppConfigProvider', () => {
     expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBeNull();
   });
 
+  describe('server-provided api key from config', () => {
+    it('defaults isApiKeyProvidedByConfig to false', () => {
+      const provider = setupProvider();
+      expect(provider.isApiKeyProvidedByConfig()).toBe(false);
+    });
+
+    it('sets in-memory geminiApiKey signal and isApiKeyProvidedByConfig flag without persisting to storage', async () => {
+      const setCredentialSpy = vi.spyOn(mockSecureStorage, 'setCredential');
+      const provider = setupProvider();
+
+      provider.setApiKeyFromConfig('  server-config-key  ');
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(true);
+      expect(provider.geminiApiKey()).toBe('server-config-key');
+      expect(setCredentialSpy).not.toHaveBeenCalled();
+      expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBeNull();
+    });
+
+    it('returns early and does not write to storage or reset isApiKeyProvidedByConfig flag when setGeminiApiKey is called while config-provided', async () => {
+      const setCredentialSpy = vi.spyOn(mockSecureStorage, 'setCredential');
+      const provider = setupProvider();
+
+      provider.setApiKeyFromConfig('server-config-key');
+      expect(provider.isApiKeyProvidedByConfig()).toBe(true);
+
+      await provider.setGeminiApiKey('user-attempted-key');
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(true);
+      expect(provider.geminiApiKey()).toBe('server-config-key');
+      expect(setCredentialSpy).not.toHaveBeenCalled();
+      expect(await mockSecureStorage.getCredential(SecureCredentialsKey.GEMINI_API_KEY)).toBeNull();
+    });
+
+    it('preserves config-provided API key during initializeCredentials bootstrap', async () => {
+      await mockSecureStorage.setCredential(SecureCredentialsKey.GEMINI_API_KEY, 'stored-key');
+      const provider = setupProvider();
+
+      provider.setApiKeyFromConfig('server-config-key');
+      await provider.initialize();
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(true);
+      expect(provider.geminiApiKey()).toBe('server-config-key');
+    });
+
+    it('resets isApiKeyProvidedByConfig flag to false when purgeGeminiApiKey is invoked', async () => {
+      const provider = setupProvider();
+      provider.setApiKeyFromConfig('server-config-key');
+
+      await provider.purgeGeminiApiKey();
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(false);
+      expect(provider.geminiApiKey()).toBe('');
+    });
+
+    it('resets isApiKeyProvidedByConfig flag to false when flushConfig is invoked', async () => {
+      const provider = setupProvider();
+      provider.setApiKeyFromConfig('server-config-key');
+
+      await provider.flushConfig();
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(false);
+      expect(provider.geminiApiKey()).toBe('');
+    });
+  });
+
   describe('under potential Server-Side Rendering (SSR) environments', () => {
     afterEach(() => {
       vi.unstubAllGlobals();

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -56,6 +56,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   /** Coordinates dynamic API key state tracking. */
   private readonly _geminiApiKey = signal<string>('');
 
+  /** Tracks whether the active API key was supplied via config.json. */
+  private readonly _isApiKeyProvidedByConfig = signal<boolean>(false);
+
   /** Coordinates dynamic renderer preview frame URL endpoint. */
   private readonly _rendererUrl = signal<string>(
     this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL) ||
@@ -84,6 +87,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
 
   /** Asynchronously resolves the sensitive Gemini API key from SecureCredentialsStorage. */
   private async initializeCredentials(): Promise<void> {
+    if (this._isApiKeyProvidedByConfig()) {
+      return;
+    }
     try {
       const key = await this.secureCredentialsStorage.getCredential(
         SecureCredentialsKey.GEMINI_API_KEY,
@@ -132,6 +138,10 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   /** Exposes the user-provided Gemini developer API key wrapper signal. */
   override readonly geminiApiKey: Signal<string> = this._geminiApiKey.asReadonly();
 
+  /** Exposes whether the active Gemini API key was supplied via config.json. */
+  override readonly isApiKeyProvidedByConfig: Signal<boolean> =
+    this._isApiKeyProvidedByConfig.asReadonly();
+
   /** Exposes active light/dark UI style theme preference signal wrapper. */
   override readonly themePreference: Signal<ThemePreference> = this._themePreference.asReadonly();
 
@@ -166,7 +176,11 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
    * @param key The fresh Gemini developer API key credential.
    */
   override async setGeminiApiKey(key: string): Promise<void> {
+    if (this._isApiKeyProvidedByConfig()) {
+      return;
+    }
     const trimmedKey = key.trim();
+    this._isApiKeyProvidedByConfig.set(false);
     this._geminiApiKey.set(trimmedKey);
     try {
       await this.secureCredentialsStorage.setCredential(
@@ -179,10 +193,24 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
+   * Sets in-memory Gemini API key loaded from config.json without persisting it to storage.
+   *
+   * @param key The server-configured API key token.
+   */
+  override setApiKeyFromConfig(key: string): void {
+    const trimmed = key.trim();
+    if (trimmed) {
+      this._isApiKeyProvidedByConfig.set(true);
+      this._geminiApiKey.set(trimmed);
+    }
+  }
+
+  /**
    * Securely erases the Gemini developer API key token from SecureCredentialsStorage
    * and resets our in-memory reactive Signal to an empty string.
    */
   override async purgeGeminiApiKey(): Promise<void> {
+    this._isApiKeyProvidedByConfig.set(false);
     this._geminiApiKey.set('');
     await this.secureCredentialsStorage
       .removeCredential(SecureCredentialsKey.GEMINI_API_KEY)
@@ -233,6 +261,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     this.localStorageInteractions.removeItem(LocalStorageKey.THEME_PREFERENCE);
 
     this._forcedAuthOverride.set(AuthType.DEFAULT);
+    this._isApiKeyProvidedByConfig.set(false);
     this._geminiApiKey.set('');
     await this.startup.resolveStartupConfiguration();
     // Asynchronously re-evaluate default configuration fallbacks

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -66,7 +66,8 @@
                 matSuffix
                 class="api-key-toggle-btn"
                 type="button"
-                (click)="hideApiKey.set(!hideApiKey())"
+                (click)="toggleHideApiKey()"
+                [disabled]="isApiKeyUnmaskDisabled()"
                 [attr.aria-label]="hideApiKey() ? 'Show API key' : 'Hide API key'"
               >
                 <mat-icon aria-hidden="true">{{

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -63,13 +63,16 @@ describe('Settings', () => {
   let mockAuthOverride: WritableSignal<AuthType>;
   let mockRendererUrl: WritableSignal<string>;
   let mockGeminiApiKey: WritableSignal<string>;
+  let mockIsApiKeyProvidedByConfig: WritableSignal<boolean>;
   let mockConfigProvider: {
     initialize: Mock<() => Promise<void>>;
     authType: Signal<AuthType>;
     rendererUrl: Signal<string>;
     geminiApiKey: Signal<string>;
+    isApiKeyProvidedByConfig: Signal<boolean>;
     setRendererUrl: Mock<(url: string) => void>;
     setGeminiApiKey: Mock<(key: string) => void>;
+    setApiKeyFromConfig: Mock<(key: string) => void>;
     setForcedAuthMode: Mock<(mode: AuthType) => void>;
     flushConfig: Mock<() => void>;
     purgeGeminiApiKey: Mock<() => void>;
@@ -95,6 +98,7 @@ describe('Settings', () => {
     mockAuthOverride = signal<AuthType>(AuthType.DEFAULT);
     mockRendererUrl = signal<string>('http://resolved-url.com');
     mockGeminiApiKey = signal<string>('');
+    mockIsApiKeyProvidedByConfig = signal<boolean>(false);
 
     const mockAuthType = computed(() => {
       const override = mockAuthOverride();
@@ -111,10 +115,15 @@ describe('Settings', () => {
       authType: mockAuthType,
       rendererUrl: mockRendererUrl.asReadonly(),
       geminiApiKey: mockGeminiApiKey.asReadonly(),
+      isApiKeyProvidedByConfig: mockIsApiKeyProvidedByConfig.asReadonly(),
       setRendererUrl: vi.fn().mockImplementation((url: string) => {
         mockRendererUrl.set(url);
       }),
       setGeminiApiKey: vi.fn().mockImplementation((key: string) => {
+        mockGeminiApiKey.set(key);
+      }),
+      setApiKeyFromConfig: vi.fn().mockImplementation((key: string) => {
+        mockIsApiKeyProvidedByConfig.set(true);
         mockGeminiApiKey.set(key);
       }),
       setForcedAuthMode: vi.fn().mockImplementation((mode: AuthType) => {
@@ -336,6 +345,7 @@ describe('Settings', () => {
     });
     override envMode = signal(EnvMode.STANDALONE);
     override geminiApiKey = signal('');
+    override isApiKeyProvidedByConfig = signal(false);
     override includeScreenshot = signal(false);
     override rendererUrl = signal('');
     override themePreference = signal<ThemePreference>(ThemePreference.LIGHT);
@@ -344,6 +354,7 @@ describe('Settings', () => {
     override purgeGeminiApiKey = vi.fn();
     override setForcedAuthMode = vi.fn();
     override setGeminiApiKey = vi.fn();
+    override setApiKeyFromConfig = vi.fn();
     override setIncludeScreenshot = vi.fn();
     override setRendererUrl = vi.fn();
     override setThemePreference = vi.fn();
@@ -583,6 +594,73 @@ describe('Settings', () => {
       expect(component.saveErrorMessage()).toBe('Simulated Storage Rejection');
       expect(await harness.hasSaveErrorBanner()).toBe(true);
       expect(await harness.getSaveErrorBannerText()).toContain('Simulated Storage Rejection');
+    });
+  });
+
+  describe('API Key View Prohibition', () => {
+    it('disables API key toggle button and prohibits unmasking when isApiKeyProvidedByConfig is true', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockIsApiKeyProvidedByConfig.set(true);
+
+      const {component, harness} = await setupComponent();
+
+      expect(component.isApiKeyUnmaskDisabled()).toBe(true);
+      expect(await harness.isApiKeyToggleBtnDisabled()).toBe(true);
+
+      component.toggleHideApiKey();
+      expect(component.hideApiKey()).toBe(true);
+      expect(await harness.getApiKeyInputType()).toBe('password');
+    });
+
+    it('disables apiKey form control when isApiKeyProvidedByConfig is true', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockIsApiKeyProvidedByConfig.set(true);
+
+      const {component} = await setupComponent();
+
+      expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
+    });
+
+    it('does not invoke setGeminiApiKey when saving settings with config-provided API key', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockIsApiKeyProvidedByConfig.set(true);
+      mockGeminiApiKey.set('server-key');
+
+      const {component} = await setupComponent();
+      const reloadSpy = vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      await component.saveSettings();
+
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
+      expect(reloadSpy).toHaveBeenCalled();
+    });
+
+    it('disables API key toggle button and prohibits unmasking when context is locked', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockStartupResolution.isContextLocked.mockReturnValue(true);
+
+      const {component, harness} = await setupComponent();
+
+      expect(component.isApiKeyUnmaskDisabled()).toBe(true);
+      expect(await harness.isApiKeyToggleBtnDisabled()).toBe(true);
+
+      component.toggleHideApiKey();
+      expect(component.hideApiKey()).toBe(true);
+    });
+
+    it('enables API key toggle button and permits unmasking when key is user-provided and context is unlocked', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockIsApiKeyProvidedByConfig.set(false);
+      mockStartupResolution.isContextLocked.mockReturnValue(false);
+
+      const {component, harness} = await setupComponent();
+
+      expect(component.isApiKeyUnmaskDisabled()).toBe(false);
+      expect(await harness.isApiKeyToggleBtnDisabled()).toBe(false);
+
+      await harness.clickApiKeyToggleBtn();
+      expect(component.hideApiKey()).toBe(false);
+      expect(await harness.getApiKeyInputType()).toBe('text');
     });
   });
 });

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -73,6 +73,9 @@ export class Settings implements OnInit {
 
   readonly isLocked: WritableSignal<boolean> = signal(false);
   readonly isThirdParty: WritableSignal<boolean> = signal(false);
+  readonly isApiKeyProvidedByConfig: Signal<boolean> = computed(() =>
+    this.configProvider.isApiKeyProvidedByConfig(),
+  );
   readonly hideApiKey: WritableSignal<boolean> = signal(true);
   readonly forceThirdPartyAuth: WritableSignal<boolean> = signal(false);
   readonly saveErrorMessage: WritableSignal<string | null> = signal(null);
@@ -134,7 +137,7 @@ export class Settings implements OnInit {
 
   private configureApiKeyControl(is3P: boolean): void {
     const apiKeyControl = this.settingsForm.controls.apiKey;
-    if (is3P) {
+    if (is3P && !this.isApiKeyUnmaskDisabled()) {
       apiKeyControl.setValidators([Validators.pattern(/\S/)]);
       if (apiKeyControl.disabled) {
         apiKeyControl.enable({emitEvent: false});
@@ -165,7 +168,9 @@ export class Settings implements OnInit {
         if (!this.isLocked()) {
           this.configProvider.setRendererUrl(values.rendererUrl.trim());
         }
-        await this.configProvider.setGeminiApiKey(values.apiKey.trim());
+        if (!this.isApiKeyProvidedByConfig()) {
+          await this.configProvider.setGeminiApiKey(values.apiKey.trim());
+        }
       } else {
         await this.configProvider.purgeGeminiApiKey();
         if (!this.isLocked()) {
@@ -193,6 +198,17 @@ export class Settings implements OnInit {
       const basePath = this.platformLocation.getBaseHrefFromDOM() || '/';
       locationAssign(this.document.defaultView.location, basePath);
     }
+  }
+
+  isApiKeyUnmaskDisabled(): boolean {
+    return this.isApiKeyProvidedByConfig() || this.isLocked();
+  }
+
+  toggleHideApiKey(): void {
+    if (this.isApiKeyUnmaskDisabled()) {
+      return;
+    }
+    this.hideApiKey.set(!this.hideApiKey());
   }
 
   toggleForceThirdPartyAuth(): void {

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -76,6 +76,9 @@ export class Settings implements OnInit {
   readonly isApiKeyProvidedByConfig: Signal<boolean> = computed(() =>
     this.configProvider.isApiKeyProvidedByConfig(),
   );
+  readonly isApiKeyUnmaskDisabled: Signal<boolean> = computed(
+    () => this.isApiKeyProvidedByConfig() || this.isLocked(),
+  );
   readonly hideApiKey: WritableSignal<boolean> = signal(true);
   readonly forceThirdPartyAuth: WritableSignal<boolean> = signal(false);
   readonly saveErrorMessage: WritableSignal<string | null> = signal(null);
@@ -198,10 +201,6 @@ export class Settings implements OnInit {
       const basePath = this.platformLocation.getBaseHrefFromDOM() || '/';
       locationAssign(this.document.defaultView.location, basePath);
     }
-  }
-
-  isApiKeyUnmaskDisabled(): boolean {
-    return this.isApiKeyProvidedByConfig() || this.isLocked();
   }
 
   toggleHideApiKey(): void {

--- a/shell/src/app/settings/settings-view/test/settings.harness.ts
+++ b/shell/src/app/settings/settings-view/test/settings.harness.ts
@@ -16,6 +16,7 @@
  */
 
 import {ComponentHarness} from '@angular/cdk/testing';
+import {MatButtonHarness} from '@angular/material/button/testing';
 import {MatInputHarness} from '@angular/material/input/testing';
 import {MatSlideToggleHarness} from '@angular/material/slide-toggle/testing';
 
@@ -35,7 +36,9 @@ export class SettingsHarness extends ComponentHarness {
   protected getErrors = this.locatorForAll('mat-error');
   protected getFormSections = this.locatorForAll('.form-section');
   protected getLogsConsole = this.locatorFor('.logs-console');
-  protected getApiKeyToggleBtn = this.locatorForOptional('button[matSuffix]');
+  protected getApiKeyToggleBtn = this.locatorForOptional(
+    MatButtonHarness.with({selector: 'button[matSuffix]'}),
+  );
 
   protected getBridgeBadge = this.locatorFor('.bridge-badge');
   protected getCatalogBadge = this.locatorFor('.catalog-badge');
@@ -103,6 +106,12 @@ export class SettingsHarness extends ComponentHarness {
     const btn = await this.getApiKeyToggleBtn();
     if (!btn) throw new Error('API Key toggle visibility button not found');
     await btn.click();
+  }
+
+  async isApiKeyToggleBtnDisabled(): Promise<boolean> {
+    const btn = await this.getApiKeyToggleBtn();
+    if (!btn) throw new Error('API Key toggle visibility button not found');
+    return btn.isDisabled();
   }
 
   async getApiKeyInputType(): Promise<string | null> {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -316,6 +316,30 @@ describe('StartupResolution Task 2.6', () => {
       expect(service.isContextLocked()).toBe(true);
       expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyCamelKey');
     });
+
+    it('trims whitespace immediately when config.json provides apiKey with surrounding spaces', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: '   AIzaSyTrimmedKey   ',
+      });
+
+      await service.resolveStartupConfiguration();
+
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyTrimmedKey');
+    });
+
+    it('supports api-key kebab-case property with immediate trimming', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        'api-key': '   AIzaSyKebabKey   ',
+      });
+
+      await service.resolveStartupConfiguration();
+
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyKebabKey');
+    });
   });
 
   it('updates resolved renderer URL via setResolvedRendererUrl', () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -328,18 +328,6 @@ describe('StartupResolution Task 2.6', () => {
 
       expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyTrimmedKey');
     });
-
-    it('supports api-key kebab-case property with immediate trimming', async () => {
-      mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        'api-key': '   AIzaSyKebabKey   ',
-      });
-
-      await service.resolveStartupConfiguration();
-
-      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyKebabKey');
-    });
   });
 
   it('updates resolved renderer URL via setResolvedRendererUrl', () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -25,7 +25,12 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 
 class MockAppConfigProvider {
   geminiApiKey = signal<string>('');
+  isApiKeyProvidedByConfig = signal<boolean>(false);
   purgeGeminiApiKey = vi.fn().mockResolvedValue(undefined);
+  setApiKeyFromConfig = vi.fn().mockImplementation((key: string) => {
+    this.isApiKeyProvidedByConfig.set(true);
+    this.geminiApiKey.set(key);
+  });
 }
 
 describe('StartupResolution Task 2.6', () => {
@@ -270,6 +275,47 @@ describe('StartupResolution Task 2.6', () => {
     getItemSpy.mockImplementation(key => (key === LocalStorageKey.FORCE_3P ? 'true' : null));
 
     expect(customService.isThirdPartyEnvironment()).toBe(true);
+  });
+
+  describe('server api key in config.json', () => {
+    it('sets in-memory API key in AppConfigProvider when config.json provides apiKey property', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: 'AIzaSyCamelKey',
+      });
+
+      const url = await service.resolveStartupConfiguration();
+
+      expect(url).toBe('http://base:3000');
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyCamelKey');
+      expect(service.isContextLocked()).toBe(false);
+    });
+
+    it('ignores empty or whitespace apiKey property in config.json', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: '   ',
+      });
+
+      await service.resolveStartupConfiguration();
+
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+    });
+
+    it('locks context strictly when allowOverrides is false regardless of apiKey presence', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: false,
+        apiKey: 'AIzaSyCamelKey',
+      });
+
+      await service.resolveStartupConfiguration();
+
+      expect(service.isContextLocked()).toBe(true);
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('AIzaSyCamelKey');
+    });
   });
 
   it('updates resolved renderer URL via setResolvedRendererUrl', () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -29,6 +29,7 @@ export interface AppConfig {
   defaultRendererUrl: string;
   allowOverrides: boolean;
   apiKey?: string;
+  'api-key'?: string;
 }
 
 @Injectable({
@@ -88,8 +89,9 @@ export class StartupResolution {
     if (staticConfig) {
       console.log('Using static config.');
       this._resolvedUrl.set(staticConfig.defaultRendererUrl);
-      const configApiKey = staticConfig.apiKey;
-      if (typeof configApiKey === 'string' && configApiKey.trim().length > 0) {
+      const rawApiKey = staticConfig.apiKey ?? staticConfig['api-key'];
+      const configApiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';
+      if (configApiKey) {
         try {
           const configProvider = this.injector.get(AppConfigProvider);
           configProvider.setApiKeyFromConfig(configApiKey);
@@ -108,11 +110,11 @@ export class StartupResolution {
     }
 
     if (!this._isLockedContext()) {
-      console.log('Checking for renderer query param...')
+      console.log('Checking for renderer query param...');
       const queryCandidate = QueryParser.parseRendererUrl(this.getWindowSearch());
       if (queryCandidate) {
         this._resolvedUrl.set(queryCandidate);
-        console.log('Using renderer query param.')
+        console.log('Using renderer query param.');
         await this.evaluateEnvironmentPurge();
         return this._resolvedUrl();
       }
@@ -120,7 +122,7 @@ export class StartupResolution {
 
     const localPrefs = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
     if (localPrefs && !this._isLockedContext()) {
-      console.log('Using renderer from local storage.')
+      console.log('Using renderer from local storage.');
       this._resolvedUrl.set(localPrefs);
     }
 

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -28,6 +28,7 @@ import {IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
 export interface AppConfig {
   defaultRendererUrl: string;
   allowOverrides: boolean;
+  apiKey?: string;
 }
 
 @Injectable({
@@ -62,6 +63,7 @@ export class StartupResolution {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
+      console.log('Fetching config.json configuration...');
       const response = await fetch('config.json', {signal: controller.signal});
       if (response.ok) {
         // Although we *expect* JSON, it's possible that the response includes
@@ -84,7 +86,18 @@ export class StartupResolution {
     }
 
     if (staticConfig) {
+      console.log('Using static config.');
       this._resolvedUrl.set(staticConfig.defaultRendererUrl);
+      const configApiKey = staticConfig.apiKey;
+      if (typeof configApiKey === 'string' && configApiKey.trim().length > 0) {
+        try {
+          const configProvider = this.injector.get(AppConfigProvider);
+          configProvider.setApiKeyFromConfig(configApiKey);
+        } catch (err) {
+          console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
+        }
+      }
+
       if (!staticConfig.allowOverrides) {
         console.log('Static configuration loaded with allowOverrides: false. Locking context.');
         this._isLockedContext.set(true);
@@ -95,9 +108,11 @@ export class StartupResolution {
     }
 
     if (!this._isLockedContext()) {
+      console.log('Checking for renderer query param...')
       const queryCandidate = QueryParser.parseRendererUrl(this.getWindowSearch());
       if (queryCandidate) {
         this._resolvedUrl.set(queryCandidate);
+        console.log('Using renderer query param.')
         await this.evaluateEnvironmentPurge();
         return this._resolvedUrl();
       }
@@ -105,6 +120,7 @@ export class StartupResolution {
 
     const localPrefs = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
     if (localPrefs && !this._isLockedContext()) {
+      console.log('Using renderer from local storage.')
       this._resolvedUrl.set(localPrefs);
     }
 

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -29,7 +29,6 @@ export interface AppConfig {
   defaultRendererUrl: string;
   allowOverrides: boolean;
   apiKey?: string;
-  'api-key'?: string;
 }
 
 @Injectable({
@@ -89,7 +88,7 @@ export class StartupResolution {
     if (staticConfig) {
       console.log('Using static config.');
       this._resolvedUrl.set(staticConfig.defaultRendererUrl);
-      const rawApiKey = staticConfig.apiKey ?? staticConfig['api-key'];
+      const rawApiKey = staticConfig.apiKey;
       const configApiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';
       if (configApiKey) {
         try {


### PR DESCRIPTION
# Description

Support parsing 'apiKey' from config.json during startup.
Populate Gemini API key in-memory without persisting to browser storage.
Disable API key input and unmasking when key is config-provided or
context is locked.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

