### PR TITLE
Support profile-based configuration via query parameters

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,4 @@ coverage
 **/coverage/**
 **/.angular/
 **/test-results/
+**/playwright-report/**

--- a/shell/e2e/cross-frame-security.e2e.ts
+++ b/shell/e2e/cross-frame-security.e2e.ts
@@ -19,6 +19,18 @@ import {PreviewBridgeMessageType} from 'a2ui-bridge';
 
 test.describe('Cross-Frame Security & Sandboxing', () => {
   test.beforeEach(async ({page}) => {
+    await page.route('**/config.json', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          profiles: {
+            default: {
+              allowOverrides: true,
+            },
+          },
+        }),
+      });
+    });
     await page.addInitScript(() => {
       try {
         localStorage.setItem('a2ui_composer_force_1p', 'true');
@@ -81,9 +93,9 @@ test.describe('Cross-Frame Security & Sandboxing', () => {
     await expect(page.locator('.workspace-container')).toBeVisible();
 
     await page.getByRole('tab', {name: 'Raw Messages'}).click();
-    await expect(page.getByTestId('raw-message-envelope')).toBeVisible();
-    const envText = await page.getByTestId('raw-message-envelope').textContent();
-    expect(envText).toContain(PreviewBridgeMessageType.RENDERER_READY);
-    expect(envText).toContain('http://custom-renderer.com');
+    const envelope = page.getByTestId('raw-message-envelope');
+    await expect(envelope).toBeVisible();
+    await expect(envelope).toContainText(PreviewBridgeMessageType.RENDERER_READY);
+    await expect(envelope).toContainText('http://custom-renderer.com');
   });
 });

--- a/shell/e2e/debug-drawer-and-logs.e2e.ts
+++ b/shell/e2e/debug-drawer-and-logs.e2e.ts
@@ -22,6 +22,19 @@ test.beforeEach(async ({page}) => {
     console.error(`Unhandled page error: ${err.message}`);
   });
 
+  await page.route('**/config.json', async route => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        profiles: {
+          default: {
+            allowOverrides: true,
+          },
+        },
+      }),
+    });
+  });
+
   // Mock custom renderer response
   await page.route('http://custom-renderer.com/*', async route => {
     await route.fulfill({
@@ -30,8 +43,7 @@ test.beforeEach(async ({page}) => {
     });
   });
 
-  await page.goto('/?renderer=http://custom-renderer.com/index.html');
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     try {
       localStorage.clear();
       localStorage.setItem('a2ui_composer_force_1p', 'true');
@@ -119,10 +131,9 @@ test.describe('Debugging Panels & Diagnostic Logs', () => {
     await page.locator('.dv-tab', {hasText: /^Errors/}).click();
     const errorRow = page.locator('.errors-container table tr.element-row').first();
     await expect(errorRow).toBeVisible();
-    const rowText = await errorRow.textContent();
-    expect(rowText).toContain('warn');
-    expect(rowText).toContain('console');
-    expect(rowText).toContain('Telemetry active warn');
+    await expect(errorRow).toContainText('warn');
+    await expect(errorRow).toContainText('console');
+    await expect(errorRow).toContainText('Telemetry active warn');
   });
 
   test('verifies unread tab badging animations and resets', async ({page}) => {

--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -35,7 +35,11 @@ const CONFIGS: IntegrationConfig[] = [
     pickupLocationLocator: iframe =>
       iframe.locator('.a2ui-text-field-container:has-text("Pick-up Location") input'),
     fillDate: async (locator, value) => {
-      await locator.fill(value);
+      await locator.evaluate((el: HTMLInputElement, val) => {
+        el.value = val;
+        el.dispatchEvent(new Event('input', {bubbles: true}));
+        el.dispatchEvent(new Event('change', {bubbles: true}));
+      }, value);
     },
   },
   {

--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -73,6 +73,19 @@ test.beforeEach(async ({page}) => {
     console.error(`Unhandled page error: ${err.message}`);
   });
 
+  await page.route('**/config.json', async route => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        profiles: {
+          default: {
+            allowOverrides: true,
+          },
+        },
+      }),
+    });
+  });
+
   await page.addInitScript(() => {
     try {
       localStorage.setItem('a2ui_composer_force_1p', 'true');
@@ -295,8 +308,8 @@ test.describe('Bridge Telemetry Layout Constraints', () => {
       window.parent.postMessage(msg, '*');
     }, unblockMsg);
 
-    await expect(page.getByTestId('raw-message-envelope').first()).toBeVisible();
-    const envText = await page.getByTestId('raw-message-envelope').first().textContent();
-    expect(envText).toContain(PreviewBridgeMessageType.FORCE_UNBLOCK);
+    const envelope = page.getByTestId('raw-message-envelope').first();
+    await expect(envelope).toBeVisible();
+    await expect(envelope).toContainText(PreviewBridgeMessageType.FORCE_UNBLOCK);
   });
 });

--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -84,8 +84,12 @@ test.describe('Settings and Client Configuration', () => {
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify({
-            defaultRendererUrl: 'http://locked-renderer.com',
-            allowOverrides: false,
+            profiles: {
+              default: {
+                rendererUrl: 'http://locked-renderer.com',
+                allowOverrides: false,
+              },
+            },
           }),
         });
       });
@@ -103,9 +107,13 @@ test.describe('Settings and Client Configuration', () => {
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify({
-            defaultRendererUrl: 'http://unlocked-renderer.com',
-            allowOverrides: true,
-            apiKey: 'server-provided-api-key',
+            profiles: {
+              default: {
+                rendererUrl: 'http://unlocked-renderer.com',
+                allowOverrides: true,
+                apiKey: 'server-provided-api-key',
+              },
+            },
           }),
         });
       });

--- a/shell/e2e/workspace-routing-bootstrapping.e2e.ts
+++ b/shell/e2e/workspace-routing-bootstrapping.e2e.ts
@@ -99,6 +99,19 @@ test.describe('Workspace Navigation & Layout Modes', () => {
   test('loads components gallery view successfully via direct URL navigation', async ({
     page,
   }, testInfo) => {
+    await page.route('**/config.json', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          profiles: {
+            default: {
+              rendererUrl: 'http://custom-renderer.com',
+              allowOverrides: true,
+            },
+          },
+        }),
+      });
+    });
     await page.goto('/gallery');
 
     const galleryContainer = page.locator('.gallery-container');

--- a/shell/e2e/workspace-routing-bootstrapping.e2e.ts
+++ b/shell/e2e/workspace-routing-bootstrapping.e2e.ts
@@ -30,8 +30,12 @@ test.describe('Startup Resolution & Redirection', () => {
       await route.fulfill({
         contentType: 'application/json',
         body: JSON.stringify({
-          allowOverrides: true,
-          // no defaultRendererUrl
+          profiles: {
+            default: {
+              allowOverrides: true,
+              // no rendererUrl
+            },
+          },
         }),
       });
     });
@@ -48,6 +52,31 @@ test.describe('Startup Resolution & Redirection', () => {
     await page.waitForURL(url => url.pathname === '/');
     await expect(page.locator('.workspace-container')).toBeVisible();
     await expect(page.locator('.disabled-chat-panel')).toBeVisible();
+  });
+
+  test('bootstraps workspace successfully using ?profile=<name> query parameter', async ({
+    page,
+  }) => {
+    await page.route('**/config.json', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          profiles: {
+            default: {
+              allowOverrides: true,
+            },
+            custom: {
+              rendererUrl: 'http://custom-profile-renderer.com',
+              allowOverrides: true,
+            },
+          },
+        }),
+      });
+    });
+    await page.goto('/?profile=custom');
+    await page.waitForURL(url => url.pathname === '/');
+    await expect(page).toHaveTitle(/A2UI Composer/);
+    await expect(page.locator('.workspace-container')).toBeVisible();
   });
 });
 

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -139,16 +139,18 @@ describe('LocalStorageAppConfigProvider', () => {
     expect(provider.geminiApiKey()).toBe('');
   });
 
-  it('initializes rendererUrl with stored renderer URL if present', () => {
+  it('prioritizes resolved renderer URL from startup over stored renderer URL', () => {
+    mockStartupService.getResolvedRendererUrl.mockReturnValue('https://resolved-profile.com');
+    localStorage.setItem(LocalStorageKey.RENDERER_URL, 'https://stored-renderer.com');
+    const provider = setupProvider();
+    expect(provider.rendererUrl()).toBe('https://resolved-profile.com');
+  });
+
+  it('falls back to stored renderer URL if no resolved renderer URL exists', () => {
+    mockStartupService.getResolvedRendererUrl.mockReturnValue('');
     localStorage.setItem(LocalStorageKey.RENDERER_URL, 'https://stored-renderer.com');
     const provider = setupProvider();
     expect(provider.rendererUrl()).toBe('https://stored-renderer.com');
-  });
-
-  it('initializes rendererUrl with fallback resolved URL if no stored URL exists', () => {
-    mockStartupService.getResolvedRendererUrl.mockReturnValue('https://resolved-fallback.com');
-    const provider = setupProvider();
-    expect(provider.rendererUrl()).toBe('https://resolved-fallback.com');
   });
 
   it('synchronizes rendererUrl with resolved fallback when initialize is invoked', async () => {
@@ -332,14 +334,14 @@ describe('LocalStorageAppConfigProvider', () => {
     expect(provider.geminiApiKey()).toBe('');
   });
 
-  it('attaches catch handler and logs warning when setGeminiApiKey write fails, but updates signal and resolves without throwing', async () => {
+  it('attaches catch handler, logs warning, and re-throws when setGeminiApiKey write fails, after updating signal', async () => {
     const warnSpy = vi.spyOn(console, 'warn');
     vi.spyOn(mockSecureStorage, 'setCredential').mockRejectedValue(
       new Error('Simulated Write Failure'),
     );
 
     const provider = setupProvider();
-    await expect(provider.setGeminiApiKey('failed-key')).resolves.not.toThrow();
+    await expect(provider.setGeminiApiKey('failed-key')).rejects.toThrow('Simulated Write Failure');
     expect(provider.geminiApiKey()).toBe('failed-key');
 
     expect(warnSpy).toHaveBeenCalledWith(
@@ -348,7 +350,7 @@ describe('LocalStorageAppConfigProvider', () => {
     );
   });
 
-  it('updates geminiApiKey signal even when setCredential persistence fails so runtime session works', async () => {
+  it('updates geminiApiKey signal even when setCredential persistence fails and re-throws', async () => {
     await mockSecureStorage.setCredential(SecureCredentialsKey.GEMINI_API_KEY, 'initial-key');
     const provider = setupProvider();
     await provider.initialize();
@@ -358,19 +360,23 @@ describe('LocalStorageAppConfigProvider', () => {
       new Error('Simulated Write Failure'),
     );
 
-    await expect(provider.setGeminiApiKey('new-failed-key')).resolves.not.toThrow();
+    await expect(provider.setGeminiApiKey('new-failed-key')).rejects.toThrow(
+      'Simulated Write Failure',
+    );
 
     expect(provider.geminiApiKey()).toBe('new-failed-key');
   });
 
-  it('wraps setGeminiApiKey in robust error handling so it does not throw when storage rejects with SecurityError or QuotaExceededError', async () => {
+  it('logs warning and re-throws error when setGeminiApiKey encounters SecurityError or QuotaExceededError', async () => {
     const warnSpy = vi.spyOn(console, 'warn');
     vi.spyOn(mockSecureStorage, 'setCredential').mockRejectedValue(
       new DOMException('SecurityError in sandboxed iframe', 'SecurityError'),
     );
 
     const provider = setupProvider();
-    await expect(provider.setGeminiApiKey('sandboxed-key')).resolves.not.toThrow();
+    await expect(provider.setGeminiApiKey('sandboxed-key')).rejects.toThrow(
+      'SecurityError in sandboxed iframe',
+    );
     expect(provider.geminiApiKey()).toBe('sandboxed-key');
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Failed to persist Gemini API key'),

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -61,8 +61,8 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
 
   /** Coordinates dynamic renderer preview frame URL endpoint. */
   private readonly _rendererUrl = signal<string>(
-    this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL) ||
-      this.startup.getResolvedRendererUrl() ||
+    this.startup.getResolvedRendererUrl() ||
+      this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL) ||
       '',
   );
 
@@ -106,11 +106,13 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
 
   /** Initializes the renderer URL from configuration or persistent storage. */
   private initializeRendererUrl(): void {
-    const localUrl = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
-    if (!localUrl) {
-      const resolved = this.startup.getResolvedRendererUrl();
-      if (resolved) {
-        this._rendererUrl.set(resolved);
+    const resolved = this.startup.getResolvedRendererUrl();
+    if (resolved) {
+      this._rendererUrl.set(resolved);
+    } else {
+      const localUrl = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
+      if (localUrl) {
+        this._rendererUrl.set(localUrl);
       }
     }
   }
@@ -186,6 +188,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
       );
     } catch (err) {
       console.warn('Failed to persist Gemini API key to SecureCredentialsStorage:', err);
+      throw err;
     }
   }
 

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -85,7 +85,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     await this.initializeCredentials();
   }
 
-  /** Asynchronously resolves the sensitive Gemini API key from SecureCredentialsStorage. */
+  /** Loads stored API credentials into state. */
   private async initializeCredentials(): Promise<void> {
     if (this._isApiKeyProvidedByConfig()) {
       return;
@@ -104,7 +104,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     }
   }
 
-  /** Synchronizes the active renderer URL with the resolved StartupResolution fallback. */
+  /** Initializes the renderer URL from configuration or persistent storage. */
   private initializeRendererUrl(): void {
     const localUrl = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
     if (!localUrl) {
@@ -115,15 +115,12 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     }
   }
 
-  /**
-   * Exposes whether the host environment operates in standalone or integrated
-   * extension mode.
-   */
+  /** Environment operating mode. */
   override readonly envMode: Signal<EnvMode> = computed(() => {
     return this.startup.isExtensionMode() ? EnvMode.EXTENSION : EnvMode.STANDALONE;
   });
 
-  /** Exposes the active authentication protocol context. */
+  /** Active authentication mode. */
   override readonly authType: Signal<AuthType> = computed(() => {
     const override = this._forcedAuthOverride();
     if (override !== AuthType.DEFAULT) {
@@ -132,35 +129,35 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     return this.startup.isThirdPartyEnvironment() ? AuthType.THIRD_PARTY : AuthType.FIRST_PARTY;
   });
 
-  /** Exposes the active preview frame target URL wrapper signal. */
+  /** Active renderer endpoint URL. */
   override readonly rendererUrl: Signal<string> = this._rendererUrl.asReadonly();
 
-  /** Exposes the user-provided Gemini developer API key wrapper signal. */
+  /** Active API key for external service calls. */
   override readonly geminiApiKey: Signal<string> = this._geminiApiKey.asReadonly();
 
-  /** Exposes whether the active Gemini API key was supplied via config.json. */
+  /** Indicates whether the active API key is managed by static configuration. */
   override readonly isApiKeyProvidedByConfig: Signal<boolean> =
     this._isApiKeyProvidedByConfig.asReadonly();
 
-  /** Exposes active light/dark UI style theme preference signal wrapper. */
+  /** Visual theme preference. */
   override readonly themePreference: Signal<ThemePreference> = this._themePreference.asReadonly();
 
-  /** Exposes whether screenshots should be automatically attached to LLM prompts. */
+  /** Preference for including screenshots in user interactions. */
   override readonly includeScreenshot: Signal<boolean> = this._includeScreenshot.asReadonly();
 
   /**
-   * Mutates and persists the preferred setting for including screenshots.
+   * Updates the screenshot attachment preference.
    *
-   * @param include Boolean toggle value.
+   * @param include Whether screenshots should be included.
    */
   override setIncludeScreenshot(include: boolean): void {
     this._includeScreenshot.set(include);
   }
 
   /**
-   * Mutates and saves the active renderer URL endpoint.
+   * Updates and persists the active renderer URL endpoint.
    *
-   * @param url The target destination URL endpoint.
+   * @param url The target renderer URL.
    */
   override setRendererUrl(url: string): void {
     this._rendererUrl.set(url);
@@ -171,9 +168,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
-   * Mutates and saves the personal third-party API key.
+   * Updates and persists the API key for external service calls.
    *
-   * @param key The fresh Gemini developer API key credential.
+   * @param key The API key credential.
    */
   override async setGeminiApiKey(key: string): Promise<void> {
     if (this._isApiKeyProvidedByConfig()) {
@@ -193,9 +190,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
-   * Sets in-memory Gemini API key loaded from config.json without persisting it to storage.
+   * Sets the API key provided by static configuration.
    *
-   * @param key The server-configured API key token.
+   * @param key The configuration-provided API key.
    */
   override setApiKeyFromConfig(key: string): void {
     const trimmed = key.trim();
@@ -206,8 +203,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
-   * Securely erases the Gemini developer API key token from SecureCredentialsStorage
-   * and resets our in-memory reactive Signal to an empty string.
+   * Purges stored API key credentials and resets API key state.
    */
   override async purgeGeminiApiKey(): Promise<void> {
     this._isApiKeyProvidedByConfig.set(false);
@@ -220,9 +216,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
-   * Mutates and saves active light/dark style theme preferences context.
+   * Updates and persists the visual theme preference.
    *
-   * @param theme Preferred visual style theme mode selector.
+   * @param theme The theme preference.
    */
   override setThemePreference(theme: ThemePreference): void {
     this._themePreference.set(theme);
@@ -230,9 +226,9 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   }
 
   /**
-   * Overrides target authentication environments.
+   * Sets an explicit override for the authentication mode.
    *
-   * @param mode The forced authentication protocol mode.
+   * @param mode The authentication mode override.
    */
   override setForcedAuthMode(mode: AuthType): void {
     this._forcedAuthOverride.set(mode);
@@ -244,14 +240,14 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
       this.localStorageInteractions.setItem(LocalStorageKey.FORCE_3P, 'true');
       this.localStorageInteractions.removeItem(LocalStorageKey.FORCE_1P);
     } else {
-      // AuthType.DEFAULT -> Clear all override flags in browser storage
+      // Revert to environment auto-detection when no explicit override is active.
       this.localStorageInteractions.removeItem(LocalStorageKey.FORCE_1P);
       this.localStorageInteractions.removeItem(LocalStorageKey.FORCE_3P);
     }
   }
 
   /**
-   * Purges runtime overrides and dynamic key markers from persistent layers.
+   * Resets all persisted configuration, credentials, and runtime overrides to default state.
    */
   override async flushConfig(): Promise<void> {
     this.localStorageInteractions.removeItem(LocalStorageKey.RENDERER_URL);
@@ -264,18 +260,15 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     this._isApiKeyProvidedByConfig.set(false);
     this._geminiApiKey.set('');
     await this.startup.resolveStartupConfiguration();
-    // Asynchronously re-evaluate default configuration fallbacks
-    // (query params -> local storage -> config.json).
     this._rendererUrl.set(this.startup.getResolvedRendererUrl() || '');
     this._themePreference.set(ThemePreference.LIGHT);
     this._includeScreenshot.set(false);
   }
 
   /**
-   * Evaluates baseline local storage and retrieves starting authentication
-   * modes.
+   * Resolves the initial authentication mode override from storage.
    *
-   * @returns Active AuthType mapping.
+   * @returns The initial authentication mode.
    */
   private getInitialForcedAuth(): AuthType {
     if (!this.is1PAuthEnabled) {

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -26,10 +26,7 @@
           @if (isLocked()) {
             <div class="locked-notice">
               <mat-icon color="warn" aria-hidden="true">lock</mat-icon>
-              <span
-                >Active URL configuration is locked by enterprise policy (allowOverrides:
-                false).</span
-              >
+              <span>Active URL configuration is locked.</span>
             </div>
           }
           <mat-form-field appearance="outline" class="full-width">
@@ -94,7 +91,7 @@
           @if (isLocked()) {
             <div class="locked-notice auth-locked-notice">
               <mat-icon color="warn" aria-hidden="true">lock</mat-icon>
-              <span>Authentication mode overrides are locked by enterprise policy.</span>
+              <span>Authentication mode overrides are locked.</span>
             </div>
           }
           <div class="toggle-container" style="margin-top: 12px">

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -241,7 +241,7 @@ describe('Settings', () => {
     expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
 
     expect(await harness.hasLockedNotice()).toBe(true);
-    expect(await harness.getLockedNoticeText()).toContain('locked by enterprise policy');
+    expect(await harness.getLockedNoticeText()).toContain('Active URL configuration is locked.');
   });
 
   it('displays default connection status badges and overlay logs console when disconnected', async () => {
@@ -435,7 +435,7 @@ describe('Settings', () => {
 
     expect(await harness.hasAuthLockedNotice()).toBe(true);
     expect(await harness.getAuthLockedNoticeText()).toContain(
-      'Authentication mode overrides are locked by enterprise policy',
+      'Authentication mode overrides are locked',
     );
 
     expect(await harness.isSlideToggleDisabled()).toBe(true);
@@ -562,6 +562,25 @@ describe('Settings', () => {
 
       expect(component.settingsForm.controls.apiKey.value).toBe('user-typed-key');
     });
+
+    it('synchronizes rendererUrl signal from config provider into rendererUrl form control without clobbering dirty user input', async () => {
+      const {fixture, component} = await setupComponent();
+
+      mockRendererUrl.set('https://profile-renderer-url.com');
+      fixture.detectChanges();
+
+      expect(component.settingsForm.controls.rendererUrl.value).toBe(
+        'https://profile-renderer-url.com',
+      );
+
+      component.settingsForm.controls.rendererUrl.setValue('https://user-typed-url.com');
+      component.settingsForm.controls.rendererUrl.markAsDirty();
+
+      mockRendererUrl.set('https://background-sync-renderer.com');
+      fixture.detectChanges();
+
+      expect(component.settingsForm.controls.rendererUrl.value).toBe('https://user-typed-url.com');
+    });
   });
 
   describe('Anti-Silent Failure UI Alert & Error Reporting (saveSettings)', () => {
@@ -635,17 +654,16 @@ describe('Settings', () => {
       expect(reloadSpy).toHaveBeenCalled();
     });
 
-    it('disables API key toggle button and prohibits unmasking when context is locked', async () => {
+    it('keeps API key control enabled and permits unmasking when context is locked but isApiKeyProvidedByConfig is false', async () => {
       mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
       mockStartupResolution.isContextLocked.mockReturnValue(true);
+      mockIsApiKeyProvidedByConfig.set(false);
 
       const {component, harness} = await setupComponent();
 
-      expect(component.isApiKeyUnmaskDisabled()).toBe(true);
-      expect(await harness.isApiKeyToggleBtnDisabled()).toBe(true);
-
-      component.toggleHideApiKey();
-      expect(component.hideApiKey()).toBe(true);
+      expect(component.isApiKeyUnmaskDisabled()).toBe(false);
+      expect(component.settingsForm.controls.apiKey.enabled).toBe(true);
+      expect(await harness.isApiKeyToggleBtnDisabled()).toBe(false);
     });
 
     it('enables API key toggle button and permits unmasking when key is user-provided and context is unlocked', async () => {

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -76,8 +76,8 @@ export class Settings implements OnInit {
   readonly isApiKeyProvidedByConfig: Signal<boolean> = computed(() =>
     this.configProvider.isApiKeyProvidedByConfig(),
   );
-  readonly isApiKeyUnmaskDisabled: Signal<boolean> = computed(
-    () => this.isApiKeyProvidedByConfig() || this.isLocked(),
+  readonly isApiKeyUnmaskDisabled: Signal<boolean> = computed(() =>
+    this.isApiKeyProvidedByConfig(),
   );
   readonly hideApiKey: WritableSignal<boolean> = signal(true);
   readonly forceThirdPartyAuth: WritableSignal<boolean> = signal(false);
@@ -115,6 +115,18 @@ export class Settings implements OnInit {
         apiKeyControl.setValue(currentKey, {emitEvent: false});
       }
     });
+
+    effect(() => {
+      const url = this.configProvider.rendererUrl();
+      const rendererControl = this.settingsForm.controls.rendererUrl;
+      if (!rendererControl.dirty && url !== rendererControl.value) {
+        rendererControl.setValue(url, {emitEvent: false});
+      }
+    });
+
+    effect(() => {
+      this.configureApiKeyControl(this.isThirdParty());
+    });
   }
 
   ngOnInit(): void {
@@ -123,15 +135,8 @@ export class Settings implements OnInit {
 
     const is3P = this.startupResolution.isThirdPartyEnvironment();
     this.isThirdParty.set(is3P);
-    this.configureApiKeyControl(is3P);
 
     this.forceThirdPartyAuth.set(this.configProvider.authType() === AuthType.THIRD_PARTY);
-
-    const initialUrl = this.configProvider.rendererUrl();
-
-    this.settingsForm.patchValue({
-      rendererUrl: initialUrl,
-    });
 
     if (locked) {
       this.settingsForm.controls.rendererUrl.disable();
@@ -140,7 +145,7 @@ export class Settings implements OnInit {
 
   private configureApiKeyControl(is3P: boolean): void {
     const apiKeyControl = this.settingsForm.controls.apiKey;
-    if (is3P && !this.isApiKeyUnmaskDisabled()) {
+    if (is3P && !this.isApiKeyProvidedByConfig()) {
       apiKeyControl.setValidators([Validators.pattern(/\S/)]);
       if (apiKeyControl.disabled) {
         apiKeyControl.enable({emitEvent: false});

--- a/shell/src/app/shell/query-parser/query-parser.spec.ts
+++ b/shell/src/app/shell/query-parser/query-parser.spec.ts
@@ -117,4 +117,52 @@ describe('QueryParser', () => {
       );
     });
   });
+
+  describe('isProhibitedKey', () => {
+    it('detects prohibited credential keys including uppercase, ALL-CAPS, standard, and trailing digit keys', () => {
+      const prohibitedKeys = [
+        'APIKEY',
+        'API_KEY',
+        'AUTH_TOKEN',
+        'APPSECRET',
+        'KEY',
+        'SECRET',
+        'key1',
+        'token2',
+        'apiKey',
+        'api_key',
+        'apikey',
+      ];
+      for (const key of prohibitedKeys) {
+        expect(QueryParser['isProhibitedKey'](key)).toBe(true);
+      }
+    });
+
+    it('allows benign keys ending with false-positive suffixes', () => {
+      const benignKeys = [
+        'hockey',
+        'turkey',
+        'monkey',
+        'donkey',
+        'whiskey',
+        'lackey',
+        'jockey',
+        'hockey1',
+        'turkey2',
+        'HOCKEY',
+      ];
+      for (const key of benignKeys) {
+        expect(QueryParser['isProhibitedKey'](key)).toBe(false);
+      }
+    });
+
+    it('detects prohibited keys like hockeyKey', () => {
+      expect(QueryParser['isProhibitedKey']('hockeyKey')).toBe(true);
+    });
+
+    it('allows URL parsing when benign query parameters are present', () => {
+      const url = QueryParser.parseRendererUrl('?renderer=http://localhost:3000&hockey=puck');
+      expect(url).toBe('http://localhost:3000/');
+    });
+  });
 });

--- a/shell/src/app/shell/query-parser/query-parser.spec.ts
+++ b/shell/src/app/shell/query-parser/query-parser.spec.ts
@@ -80,4 +80,41 @@ describe('QueryParser', () => {
       expect.stringContaining('Malformed renderer parameter string encountered'),
     );
   });
+
+  describe('parseProfileName', () => {
+    it('parses profile name from ?profile query parameter', () => {
+      expect(QueryParser.parseProfileName('?profile=ge')).toBe('ge');
+    });
+
+    it('parses profile name from ?config query parameter as fallback', () => {
+      expect(QueryParser.parseProfileName('?config=dev')).toBe('dev');
+    });
+
+    it('prefers ?profile parameter over ?config parameter when both exist', () => {
+      expect(QueryParser.parseProfileName('?profile=ge&config=dev')).toBe('ge');
+    });
+
+    it('rejects profile names with invalid characters', () => {
+      expect(QueryParser.parseProfileName('?profile=testing/invalid')).toBeNull();
+      expect(QueryParser.parseProfileName('?profile=testing<script>')).toBeNull();
+    });
+
+    it('rejects profile name parsing when prohibited credential keys are present in query string', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
+      expect(QueryParser.parseProfileName('?profile=testing&apiKey=secret')).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Security Violation: Prohibited credentials'),
+      );
+    });
+
+    it('rejects unseparated prohibited credential keys like apikey or authtoken', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
+      expect(QueryParser.parseProfileName('?profile=testing&apikey=secret')).toBeNull();
+      expect(QueryParser.parseRendererUrl('?renderer=http://host:3000&authtoken=123')).toBeNull();
+      expect(QueryParser.parseRendererUrl('?renderer=http://host:3000&appsecret=abc')).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Security Violation: Prohibited credentials'),
+      );
+    });
+  });
 });

--- a/shell/src/app/shell/query-parser/query-parser.ts
+++ b/shell/src/app/shell/query-parser/query-parser.ts
@@ -21,8 +21,21 @@
 export class QueryParser {
   /** @nocollapse */
   private static isProhibitedKey(key: string): boolean {
-    const lowerKey = key.toLowerCase();
-    return lowerKey.includes('key') || lowerKey.includes('token') || lowerKey.includes('secret');
+    const words = key
+      .split(/(?<=[a-z0-9])(?=[A-Z])|[^a-zA-Z0-9]+/)
+      .map(w => w.toLowerCase())
+      .filter(Boolean);
+    const exclusions = ['monkey', 'donkey', 'hockey', 'turkey', 'whiskey', 'lackey', 'jockey'];
+
+    return words.some(word => {
+      const isProhibited =
+        /key\d*$/.test(word) || /token\d*$/.test(word) || /secret\d*$/.test(word);
+      if (isProhibited) {
+        const wordBase = word.replace(/\d+$/, '');
+        return !exclusions.some(exc => wordBase.endsWith(exc));
+      }
+      return false;
+    });
   }
 
   /** @nocollapse */

--- a/shell/src/app/shell/query-parser/query-parser.ts
+++ b/shell/src/app/shell/query-parser/query-parser.ts
@@ -21,8 +21,8 @@
 export class QueryParser {
   /** @nocollapse */
   private static isProhibitedKey(key: string): boolean {
-    const words = key.split(/(?=[A-Z])|[_.-]/).map(w => w.toLowerCase());
-    return words.some(w => w === 'key' || w === 'token' || w === 'secret');
+    const lowerKey = key.toLowerCase();
+    return lowerKey.includes('key') || lowerKey.includes('token') || lowerKey.includes('secret');
   }
 
   /** @nocollapse */
@@ -67,6 +67,31 @@ export class QueryParser {
           `Malformed renderer parameter string encountered: '${uriCandidate}'. Stripping invalid URI.`,
         );
       }
+    }
+
+    return null;
+  }
+
+  /** @nocollapse */
+  static parseProfileName(searchString: string): string | null {
+    const params = new URLSearchParams(searchString);
+
+    for (const key of params.keys()) {
+      if (QueryParser.isProhibitedKey(key)) {
+        console.warn(
+          'Security Violation: Prohibited credentials detected in root query string. Stripping parameters.',
+        );
+        return null;
+      }
+    }
+
+    const profileCandidate = params.get('profile') || params.get('config');
+    if (!profileCandidate) {
+      return null;
+    }
+
+    if (/^[a-zA-Z0-9_-]+$/.test(profileCandidate)) {
+      return profileCandidate;
     }
 
     return null;

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -337,4 +337,126 @@ describe('StartupResolution Task 2.6', () => {
     service.setResolvedRendererUrl(null);
     expect(service.getResolvedRendererUrl()).toBeNull();
   });
+
+  describe('profile resolution', () => {
+    it('merges profile overrides when valid profile param is supplied', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        profiles: {
+          ge: {
+            rendererUrl: 'http://testing-renderer:3000',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=ge');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://testing-renderer:3000');
+    });
+
+    it('logs warning and uses root defaults when requested profile does not exist', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        profiles: {
+          ge: {
+            rendererUrl: 'http://testing-renderer:3000',
+          },
+        },
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn');
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=unknown');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://base:3000');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Requested profile 'unknown' not found"),
+      );
+    });
+
+    it('locks context immediately when merged profile sets allowOverrides to false', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        profiles: {
+          locked: {
+            allowOverrides: false,
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?profile=locked&renderer=http://override:3000',
+      );
+      localStorage.setItem(LocalStorageKey.RENDERER_URL, 'http://storage:3000');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://base:3000');
+      expect(service.isContextLocked()).toBe(true);
+    });
+
+    it('allows renderer query override over profile defaults when merged allowOverrides is true', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        profiles: {
+          ge: {
+            rendererUrl: 'http://testing-renderer:3000',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?profile=ge&renderer=http://custom-renderer:3000',
+      );
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://custom-renderer:3000/');
+    });
+
+    it('handles prototype property names in profile parameter safely', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        profiles: {
+          ge: {
+            rendererUrl: 'http://testing-renderer:3000',
+          },
+        },
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn');
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=constructor');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://base:3000');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Requested profile 'constructor' not found"),
+      );
+    });
+
+    it('prevents profile from enabling allowOverrides when root configuration is locked', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: false,
+        profiles: {
+          unlockAttempt: {
+            allowOverrides: true,
+            rendererUrl: 'http://unlock-renderer:3000',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?profile=unlockAttempt&renderer=http://malicious-override:3000',
+      );
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://unlock-renderer:3000');
+      expect(service.isContextLocked()).toBe(true);
+    });
+  });
 });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -67,8 +67,12 @@ describe('StartupResolution Task 2.6', () => {
 
   it('fetches static config and locks when overrides are prohibited', async () => {
     mockFetchConfig({
-      defaultRendererUrl: 'http://enterprise:3000',
-      allowOverrides: false,
+      profiles: {
+        default: {
+          rendererUrl: 'http://enterprise:3000',
+          allowOverrides: false,
+        },
+      },
     });
 
     const logSpy = vi.spyOn(console, 'log');
@@ -86,8 +90,12 @@ describe('StartupResolution Task 2.6', () => {
       new Response(
         ")]}'\n" +
           JSON.stringify({
-            defaultRendererUrl: 'http://lf:3000',
-            allowOverrides: true,
+            profiles: {
+              default: {
+                rendererUrl: 'http://lf:3000',
+                allowOverrides: true,
+              },
+            },
           }),
       ),
     );
@@ -100,8 +108,12 @@ describe('StartupResolution Task 2.6', () => {
       new Response(
         ")]}'\r\n" +
           JSON.stringify({
-            defaultRendererUrl: 'http://crlf:3000',
-            allowOverrides: true,
+            profiles: {
+              default: {
+                rendererUrl: 'http://crlf:3000',
+                allowOverrides: true,
+              },
+            },
           }),
       ),
     );
@@ -111,8 +123,12 @@ describe('StartupResolution Task 2.6', () => {
 
   it('evaluates query params prior to storage when overrides exist', async () => {
     mockFetchConfig({
-      defaultRendererUrl: 'http://base:3000',
-      allowOverrides: true,
+      profiles: {
+        default: {
+          rendererUrl: 'http://base:3000',
+          allowOverrides: true,
+        },
+      },
     });
 
     vi.spyOn(service, 'getWindowSearch').mockReturnValue('?renderer=http://query:3000');
@@ -163,8 +179,12 @@ describe('StartupResolution Task 2.6', () => {
 
   it('evaluates environment validity correctly via isEnvironmentValid', async () => {
     mockFetchConfig({
-      defaultRendererUrl: 'http://base:3000',
-      allowOverrides: true,
+      profiles: {
+        default: {
+          rendererUrl: 'http://base:3000',
+          allowOverrides: true,
+        },
+      },
     });
 
     vi.spyOn(service, 'getWindowHostname').mockReturnValue('localhost');
@@ -180,8 +200,12 @@ describe('StartupResolution Task 2.6', () => {
 
   it('purges Gemini API key via AppConfigProvider when operating in 1P environments', async () => {
     mockFetchConfig({
-      defaultRendererUrl: 'http://base:3000',
-      allowOverrides: true,
+      profiles: {
+        default: {
+          rendererUrl: 'http://base:3000',
+          allowOverrides: true,
+        },
+      },
     });
 
     vi.spyOn(service, 'getWindowHostname').mockReturnValue('google.com');
@@ -189,6 +213,29 @@ describe('StartupResolution Task 2.6', () => {
     await service.resolveStartupConfiguration();
 
     expect(mockConfigProvider.purgeGeminiApiKey).toHaveBeenCalled();
+  });
+
+  it('logs warning when evaluateEnvironmentPurge fails to purge Gemini API key', async () => {
+    mockFetchConfig({
+      profiles: {
+        default: {
+          rendererUrl: 'http://base:3000',
+          allowOverrides: true,
+        },
+      },
+    });
+
+    vi.spyOn(service, 'getWindowHostname').mockReturnValue('google.com');
+    const warnSpy = vi.spyOn(console, 'warn');
+    const purgeErr = new Error('Purge failed');
+    mockConfigProvider.purgeGeminiApiKey.mockRejectedValueOnce(purgeErr);
+
+    await service.resolveStartupConfiguration();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to purge Gemini API key in 1P environment:',
+      purgeErr,
+    );
   });
 
   it('correctly evaluates isExtensionMode based on query param and storage', () => {
@@ -218,21 +265,26 @@ describe('StartupResolution Task 2.6', () => {
     expect(url).toBe('http://query:3000/');
   });
 
-  it('skips query and storage evaluations when context is already locked from prior run', async () => {
+  it('resets state signals on consecutive resolveStartupConfiguration calls', async () => {
     mockFetchConfig({
-      defaultRendererUrl: 'http://enterprise:3000',
-      allowOverrides: false,
+      profiles: {
+        default: {
+          rendererUrl: 'http://enterprise:3000',
+          allowOverrides: false,
+        },
+      },
     });
     await service.resolveStartupConfiguration(); // locks context
+    expect(service.isContextLocked()).toBe(true);
 
-    // Second run, config fetch fails, but context is locked
+    // Second run, config fetch fails, signals were reset so context is unlocked and falls back to query/storage
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
     vi.spyOn(service, 'getWindowSearch').mockReturnValue('?renderer=http://query:3000');
     localStorage.setItem(LocalStorageKey.RENDERER_URL, 'http://storage:3000');
     const url = await service.resolveStartupConfiguration();
 
-    // Stays with enterprise URL
-    expect(url).toBe('http://enterprise:3000');
+    expect(service.isContextLocked()).toBe(false);
+    expect(url).toBe('http://query:3000/');
   });
 
   it('returns window search and hostname safely', () => {
@@ -281,9 +333,13 @@ describe('StartupResolution Task 2.6', () => {
   describe('server api key in config.json', () => {
     it('sets in-memory API key in AppConfigProvider when config.json provides apiKey property', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: 'AIzaSyCamelKey',
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: 'AIzaSyCamelKey',
+          },
+        },
       });
 
       const url = await service.resolveStartupConfiguration();
@@ -295,9 +351,13 @@ describe('StartupResolution Task 2.6', () => {
 
     it('ignores empty or whitespace apiKey property in config.json', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: '   ',
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: '   ',
+          },
+        },
       });
 
       await service.resolveStartupConfiguration();
@@ -307,9 +367,13 @@ describe('StartupResolution Task 2.6', () => {
 
     it('locks context strictly when allowOverrides is false regardless of apiKey presence', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: false,
-        apiKey: 'AIzaSyCamelKey',
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: false,
+            apiKey: 'AIzaSyCamelKey',
+          },
+        },
       });
 
       await service.resolveStartupConfiguration();
@@ -320,9 +384,13 @@ describe('StartupResolution Task 2.6', () => {
 
     it('trims whitespace immediately when config.json provides apiKey with surrounding spaces', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: '   AIzaSyTrimmedKey   ',
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: '   AIzaSyTrimmedKey   ',
+          },
+        },
       });
 
       await service.resolveStartupConfiguration();
@@ -340,11 +408,27 @@ describe('StartupResolution Task 2.6', () => {
   });
 
   describe('profile resolution', () => {
-    it('merges profile overrides when valid profile param is supplied', async () => {
+    it('loads default profile when no profile query parameter is provided', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
         profiles: {
+          default: {
+            rendererUrl: 'http://default-renderer:3000',
+            allowOverrides: true,
+          },
+        },
+      });
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://default-renderer:3000');
+    });
+
+    it('loads named profile directly when valid profile param is supplied', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+          },
           ge: {
             rendererUrl: 'http://testing-renderer:3000',
           },
@@ -357,11 +441,35 @@ describe('StartupResolution Task 2.6', () => {
       expect(url).toBe('http://testing-renderer:3000');
     });
 
-    it('logs warning and uses root defaults when requested profile does not exist', async () => {
+    it('uses named profile directly without merging default profile properties', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
         profiles: {
+          default: {
+            rendererUrl: 'http://default-renderer:3000',
+            apiKey: 'default-key',
+            allowOverrides: false,
+          },
+          dev: {
+            rendererUrl: 'http://dev-renderer:3000',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://dev-renderer:3000');
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(service.isContextLocked()).toBe(false);
+    });
+
+    it('logs warning and falls back to default profile when invalid profile parameter is provided', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://default-renderer:3000',
+            allowOverrides: true,
+          },
           ge: {
             rendererUrl: 'http://testing-renderer:3000',
           },
@@ -369,21 +477,34 @@ describe('StartupResolution Task 2.6', () => {
       });
 
       const warnSpy = vi.spyOn(console, 'warn');
-      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=unknown');
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=invalid');
 
       const url = await service.resolveStartupConfiguration();
-      expect(url).toBe('http://base:3000');
+      expect(url).toBe('http://default-renderer:3000');
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Requested profile 'unknown' not found"),
+        expect.stringContaining("Requested profile 'invalid' not found in static configuration."),
       );
     });
 
-    it('locks context immediately when merged profile sets allowOverrides to false', async () => {
+    it('handles missing profiles key or missing default profile gracefully', async () => {
+      mockFetchConfig({});
+      let url = await service.resolveStartupConfiguration();
+      expect(url).toBeNull();
+
+      mockFetchConfig({profiles: {}});
+      url = await service.resolveStartupConfiguration();
+      expect(url).toBeNull();
+    });
+
+    it('locks context immediately when active profile sets allowOverrides to false', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
         profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+          },
           locked: {
+            rendererUrl: 'http://locked-renderer:3000',
             allowOverrides: false,
           },
         },
@@ -395,15 +516,17 @@ describe('StartupResolution Task 2.6', () => {
       localStorage.setItem(LocalStorageKey.RENDERER_URL, 'http://storage:3000');
 
       const url = await service.resolveStartupConfiguration();
-      expect(url).toBe('http://base:3000');
+      expect(url).toBe('http://locked-renderer:3000');
       expect(service.isContextLocked()).toBe(true);
     });
 
-    it('allows renderer query override over profile defaults when merged allowOverrides is true', async () => {
+    it('allows renderer query override over profile defaults when allowOverrides is true', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
         profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+          },
           ge: {
             rendererUrl: 'http://testing-renderer:3000',
           },
@@ -420,9 +543,11 @@ describe('StartupResolution Task 2.6', () => {
 
     it('handles prototype property names in profile parameter safely', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
         profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+          },
           ge: {
             rendererUrl: 'http://testing-renderer:3000',
           },
@@ -435,50 +560,72 @@ describe('StartupResolution Task 2.6', () => {
       const url = await service.resolveStartupConfiguration();
       expect(url).toBe('http://base:3000');
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Requested profile 'constructor' not found"),
+        expect.stringContaining(
+          "Requested profile 'constructor' not found in static configuration.",
+        ),
       );
     });
 
-    it('prevents profile from enabling allowOverrides when root configuration is locked', async () => {
+    it('handles null profile entries in config.json gracefully', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: false,
         profiles: {
-          unlockAttempt: {
-            allowOverrides: true,
-            rendererUrl: 'http://unlock-renderer:3000',
+          default: null as unknown as object,
+          dev: null as unknown as object,
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
+
+      const url = await service.resolveStartupConfiguration();
+      expect(url).toBeNull();
+      expect(service.isContextLocked()).toBe(false);
+    });
+
+    it('bypasses lock and logs warning when static profile sets allowOverrides: false but specifies no rendererUrl', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            allowOverrides: false,
           },
         },
       });
 
-      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
-        '?profile=unlockAttempt&renderer=http://malicious-override:3000',
-      );
-
+      const warnSpy = vi.spyOn(console, 'warn');
       const url = await service.resolveStartupConfiguration();
-      expect(url).toBe('http://unlock-renderer:3000');
-      expect(service.isContextLocked()).toBe(true);
+
+      expect(url).toBeNull();
+      expect(service.isContextLocked()).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Static profile sets allowOverrides: false but specifies no rendererUrl. Bypassing lock.',
+      );
     });
   });
 
   describe('apiKey resolution', () => {
     it('extracts and sets trimmed API key from static config', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: '  test-api-key  ',
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: '  test-api-key  ',
+          },
+        },
       });
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('test-api-key');
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('test-api-key');
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
-    it('overrides root API key with profile API key when profile is active', async () => {
+    it('uses named profile API key when profile is active', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: 'root-key',
         profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: 'root-key',
+          },
           dev: {
             apiKey: 'profile-key',
           },
@@ -488,15 +635,18 @@ describe('StartupResolution Task 2.6', () => {
       vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('profile-key');
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('profile-key');
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
-    it('uses root API key when requested profile does not specify an API key', async () => {
+    it('does not use default profile API key when requested profile does not specify an API key', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: 'root-key',
         profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: 'root-key',
+          },
           dev: {
             rendererUrl: 'http://dev:3000',
           },
@@ -506,27 +656,54 @@ describe('StartupResolution Task 2.6', () => {
       vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('root-key');
-    });
-
-    it('does not call setGeminiApiKey when API key is empty or whitespace-only', async () => {
-      mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
-        apiKey: '   ',
-      });
-
-      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
-    it('does not call setGeminiApiKey when API key is missing from config', async () => {
+    it('does not call setApiKeyFromConfig or setGeminiApiKey when API key is empty or whitespace-only', async () => {
       mockFetchConfig({
-        defaultRendererUrl: 'http://base:3000',
-        allowOverrides: true,
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: '   ',
+          },
+        },
       });
 
       await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
+    });
+
+    it('does not call setApiKeyFromConfig or setGeminiApiKey when API key is missing from config', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+          },
+        },
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
+    });
+
+    it('handles non-string apiKey values safely without setting API key', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            allowOverrides: true,
+            apiKey: 12345 as unknown as string,
+          },
+        },
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
   });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -27,6 +27,7 @@ class MockAppConfigProvider {
   geminiApiKey = signal<string>('');
   isApiKeyProvidedByConfig = signal<boolean>(false);
   purgeGeminiApiKey = vi.fn().mockResolvedValue(undefined);
+  setGeminiApiKey = vi.fn().mockResolvedValue(undefined);
   setApiKeyFromConfig = vi.fn().mockImplementation((key: string) => {
     this.isApiKeyProvidedByConfig.set(true);
     this.geminiApiKey.set(key);
@@ -457,6 +458,76 @@ describe('StartupResolution Task 2.6', () => {
       const url = await service.resolveStartupConfiguration();
       expect(url).toBe('http://unlock-renderer:3000');
       expect(service.isContextLocked()).toBe(true);
+    });
+  });
+
+  describe('apiKey resolution', () => {
+    it('extracts and sets trimmed API key from static config', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: '  test-api-key  ',
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('test-api-key');
+    });
+
+    it('overrides root API key with profile API key when profile is active', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: 'root-key',
+        profiles: {
+          dev: {
+            apiKey: 'profile-key',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('profile-key');
+    });
+
+    it('uses root API key when requested profile does not specify an API key', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: 'root-key',
+        profiles: {
+          dev: {
+            rendererUrl: 'http://dev:3000',
+          },
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('root-key');
+    });
+
+    it('does not call setGeminiApiKey when API key is empty or whitespace-only', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+        apiKey: '   ',
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
+    });
+
+    it('does not call setGeminiApiKey when API key is missing from config', async () => {
+      mockFetchConfig({
+        defaultRendererUrl: 'http://base:3000',
+        allowOverrides: true,
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
   });
 });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -599,6 +599,42 @@ describe('StartupResolution Task 2.6', () => {
         'Static profile sets allowOverrides: false but specifies no rendererUrl. Bypassing lock.',
       );
     });
+
+    it('handles array payloads for profiles or individual profile entries safely', async () => {
+      // 1. Array payload for profiles
+      mockFetchConfig({
+        profiles: [{rendererUrl: 'http://array-profile:3000'}] as unknown as object,
+      });
+
+      let url = await service.resolveStartupConfiguration();
+      expect(url).toBeNull();
+
+      // 2. Array payload for default profile entry
+      mockFetchConfig({
+        profiles: {
+          default: [{rendererUrl: 'http://array-default:3000'}] as unknown as object,
+        },
+      });
+
+      url = await service.resolveStartupConfiguration();
+      expect(url).toBeNull();
+
+      // 3. Array payload for requested named profile entry
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://default-renderer:3000',
+            allowOverrides: true,
+          },
+          dev: [{rendererUrl: 'http://array-dev:3000'}] as unknown as object,
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
+
+      url = await service.resolveStartupConfiguration();
+      expect(url).toBe('http://default-renderer:3000');
+    });
   });
 
   describe('apiKey resolution', () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -22,8 +22,8 @@ import {AppConfigProvider} from '../../settings/app-config-provider/app-config-p
 import {IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
 
 /**
- * Represents the resolved runtime configuration for the application,
- * including target endpoints, mode flags, and active catalog IDs.
+ * Represents the configuration options for an application profile,
+ * including target renderer endpoints, API keys, and override permissions.
  */
 export declare interface ProfileConfig {
   rendererUrl?: string;
@@ -39,8 +39,7 @@ export declare interface AppConfig {
   providedIn: 'root',
 })
 /**
- * Orchestrates the initial application startup pipeline, resolving query
- * parameters, validating environments, and initializing core state.
+ * Orchestrates application startup configuration and environment resolution.
  */
 export class StartupResolution {
   private readonly _resolvedUrl = signal<string | null>(null);

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -31,10 +31,7 @@ export declare interface ProfileConfig {
   allowOverrides?: boolean;
 }
 
-export declare interface AppConfig extends ProfileConfig {
-  defaultRendererUrl: string;
-  apiKey?: string;
-  allowOverrides: boolean;
+export declare interface AppConfig {
   profiles?: Record<string, ProfileConfig>;
 }
 
@@ -65,6 +62,24 @@ export class StartupResolution {
    * @return A Promise resolving to the resolved renderer URL, or null if unresolvable.
    */
   async resolveStartupConfiguration(): Promise<string | null> {
+    this._isLockedContext.set(false);
+    this._resolvedUrl.set(null);
+
+    const staticConfig = await this.fetchStaticConfig();
+    if (staticConfig) {
+      const isLocked = await this.processStaticConfig(staticConfig);
+      if (isLocked) {
+        return this._resolvedUrl();
+      }
+    }
+
+    this.applyOverrides();
+    await this.evaluateEnvironmentPurge();
+
+    return this._resolvedUrl();
+  }
+
+  private async fetchStaticConfig(): Promise<AppConfig | null> {
     let staticConfig: AppConfig | null = null;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
@@ -92,78 +107,107 @@ export class StartupResolution {
       clearTimeout(timeoutId);
     }
 
-    if (staticConfig) {
-      console.log('Using static config.');
-      const requestedProfile = QueryParser.parseProfileName(this.getWindowSearch());
-      if (requestedProfile) {
-        const hasProfile =
-          staticConfig.profiles &&
-          Object.prototype.hasOwnProperty.call(staticConfig.profiles, requestedProfile);
-        if (hasProfile) {
-          const profileConfig = staticConfig.profiles![requestedProfile];
-          const allowOverrides =
-            staticConfig.allowOverrides && (profileConfig.allowOverrides ?? true);
-          const defaultRendererUrl = profileConfig.rendererUrl ?? staticConfig.defaultRendererUrl;
-          staticConfig = {
-            ...staticConfig,
-            ...profileConfig,
-            defaultRendererUrl,
-            allowOverrides,
-          };
-        } else {
-          console.warn(
-            `Requested profile '${requestedProfile}' not found in static configuration.`,
-          );
+    return staticConfig;
+  }
+
+  private selectActiveProfile(staticConfig: AppConfig): ProfileConfig {
+    const profiles = staticConfig.profiles;
+    let defaultProfile: ProfileConfig = {};
+    if (
+      profiles &&
+      typeof profiles === 'object' &&
+      Object.prototype.hasOwnProperty.call(profiles, 'default')
+    ) {
+      const dp = profiles['default'];
+      if (dp && typeof dp === 'object') {
+        defaultProfile = dp;
+      }
+    }
+
+    const requestedProfile = QueryParser.parseProfileName(this.getWindowSearch());
+    let activeProfile: ProfileConfig = defaultProfile;
+
+    if (requestedProfile) {
+      let foundProfile: ProfileConfig | null = null;
+      if (
+        profiles &&
+        typeof profiles === 'object' &&
+        Object.prototype.hasOwnProperty.call(profiles, requestedProfile)
+      ) {
+        const profileConfig = profiles[requestedProfile];
+        if (profileConfig && typeof profileConfig === 'object') {
+          foundProfile = profileConfig;
         }
       }
 
-      const apiKey = staticConfig.apiKey?.trim();
-      if (apiKey) {
+      if (foundProfile) {
+        activeProfile = foundProfile;
+      } else {
+        console.warn(`Requested profile '${requestedProfile}' not found in static configuration.`);
+      }
+    }
+
+    return activeProfile;
+  }
+
+  private applyApiKeyFromProfile(profile: ProfileConfig): void {
+    const rawApiKey = profile.apiKey;
+    const apiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';
+    if (apiKey) {
+      try {
         const configProvider = this.injector.get(AppConfigProvider);
-        await configProvider.setGeminiApiKey(apiKey);
+        configProvider.setApiKeyFromConfig(apiKey);
+      } catch (err) {
+        console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
       }
+    }
+  }
 
-      this._resolvedUrl.set(staticConfig.defaultRendererUrl);
-      const rawApiKey = staticConfig.apiKey;
-      const configApiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';
-      if (configApiKey) {
-        try {
-          const configProvider = this.injector.get(AppConfigProvider);
-          configProvider.setApiKeyFromConfig(configApiKey);
-        } catch (err) {
-          console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
-        }
-      }
+  private async processStaticConfig(staticConfig: AppConfig): Promise<boolean> {
+    console.log('Using static config.');
+    const activeProfile = this.selectActiveProfile(staticConfig);
+    this.applyApiKeyFromProfile(activeProfile);
 
-      if (!staticConfig.allowOverrides) {
+    if (activeProfile.rendererUrl) {
+      this._resolvedUrl.set(activeProfile.rendererUrl);
+    }
+
+    const allowOverrides = activeProfile.allowOverrides ?? true;
+    if (!allowOverrides) {
+      if (!activeProfile.rendererUrl) {
+        console.warn(
+          'Static profile sets allowOverrides: false but specifies no rendererUrl. Bypassing lock.',
+        );
+      } else {
         console.log('Static configuration loaded with allowOverrides: false. Locking context.');
         this._isLockedContext.set(true);
 
         await this.evaluateEnvironmentPurge();
-        return this._resolvedUrl();
+        return true;
       }
     }
 
-    if (!this._isLockedContext()) {
-      console.log('Checking for renderer query param...');
-      const queryCandidate = QueryParser.parseRendererUrl(this.getWindowSearch());
-      if (queryCandidate) {
-        this._resolvedUrl.set(queryCandidate);
-        console.log('Using renderer query param.');
-        await this.evaluateEnvironmentPurge();
-        return this._resolvedUrl();
-      }
+    return false;
+  }
+
+  private applyOverrides(): void {
+    if (this._isLockedContext()) {
+      return;
+    }
+
+    console.log('Checking for renderer query param...');
+    const queryCandidate = QueryParser.parseRendererUrl(this.getWindowSearch());
+    if (queryCandidate) {
+      this._resolvedUrl.set(queryCandidate);
+      console.log('Using renderer query param.');
+      return;
     }
 
     const localPrefs = this.localStorageInteractions.getItem(LocalStorageKey.RENDERER_URL);
-    if (localPrefs && !this._isLockedContext()) {
+    if (localPrefs) {
       console.log('Using renderer from local storage.');
       this._resolvedUrl.set(localPrefs);
     }
-
-    await this.evaluateEnvironmentPurge();
-
-    return this._resolvedUrl();
   }
 
   getResolvedRendererUrl(): string | null {
@@ -239,7 +283,9 @@ export class StartupResolution {
       try {
         const configProvider = this.injector.get(AppConfigProvider);
         await configProvider.purgeGeminiApiKey();
-      } catch (e) {}
+      } catch (err) {
+        console.warn('Failed to purge Gemini API key in 1P environment:', err);
+      }
     }
   }
 }

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -25,10 +25,17 @@ import {IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
  * Represents the resolved runtime configuration for the application,
  * including target endpoints, mode flags, and active catalog IDs.
  */
-export interface AppConfig {
-  defaultRendererUrl: string;
-  allowOverrides: boolean;
+export declare interface ProfileConfig {
+  rendererUrl?: string;
   apiKey?: string;
+  allowOverrides?: boolean;
+}
+
+export declare interface AppConfig extends ProfileConfig {
+  defaultRendererUrl: string;
+  apiKey?: string;
+  allowOverrides: boolean;
+  profiles?: Record<string, ProfileConfig>;
 }
 
 @Injectable({
@@ -87,6 +94,29 @@ export class StartupResolution {
 
     if (staticConfig) {
       console.log('Using static config.');
+      const requestedProfile = QueryParser.parseProfileName(this.getWindowSearch());
+      if (requestedProfile) {
+        const hasProfile =
+          staticConfig.profiles &&
+          Object.prototype.hasOwnProperty.call(staticConfig.profiles, requestedProfile);
+        if (hasProfile) {
+          const profileConfig = staticConfig.profiles![requestedProfile];
+          const allowOverrides =
+            staticConfig.allowOverrides && (profileConfig.allowOverrides ?? true);
+          const defaultRendererUrl = profileConfig.rendererUrl ?? staticConfig.defaultRendererUrl;
+          staticConfig = {
+            ...staticConfig,
+            ...profileConfig,
+            defaultRendererUrl,
+            allowOverrides,
+          };
+        } else {
+          console.warn(
+            `Requested profile '${requestedProfile}' not found in static configuration.`,
+          );
+        }
+      }
+
       this._resolvedUrl.set(staticConfig.defaultRendererUrl);
       const rawApiKey = staticConfig.apiKey;
       const configApiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -109,16 +109,19 @@ export class StartupResolution {
     return staticConfig;
   }
 
+  /**
+   * Selects the active profile configuration based on static config and query parameters.
+   */
   private selectActiveProfile(staticConfig: AppConfig): ProfileConfig {
     const profiles = staticConfig.profiles;
+    if (!profiles || typeof profiles !== 'object' || Array.isArray(profiles)) {
+      return {};
+    }
+
     let defaultProfile: ProfileConfig = {};
-    if (
-      profiles &&
-      typeof profiles === 'object' &&
-      Object.prototype.hasOwnProperty.call(profiles, 'default')
-    ) {
+    if (Object.prototype.hasOwnProperty.call(profiles, 'default')) {
       const dp = profiles['default'];
-      if (dp && typeof dp === 'object') {
+      if (dp && typeof dp === 'object' && !Array.isArray(dp)) {
         defaultProfile = dp;
       }
     }
@@ -128,13 +131,9 @@ export class StartupResolution {
 
     if (requestedProfile) {
       let foundProfile: ProfileConfig | null = null;
-      if (
-        profiles &&
-        typeof profiles === 'object' &&
-        Object.prototype.hasOwnProperty.call(profiles, requestedProfile)
-      ) {
+      if (Object.prototype.hasOwnProperty.call(profiles, requestedProfile)) {
         const profileConfig = profiles[requestedProfile];
-        if (profileConfig && typeof profileConfig === 'object') {
+        if (profileConfig && typeof profileConfig === 'object' && !Array.isArray(profileConfig)) {
           foundProfile = profileConfig;
         }
       }

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -117,6 +117,12 @@ export class StartupResolution {
         }
       }
 
+      const apiKey = staticConfig.apiKey?.trim();
+      if (apiKey) {
+        const configProvider = this.injector.get(AppConfigProvider);
+        await configProvider.setGeminiApiKey(apiKey);
+      }
+
       this._resolvedUrl.set(staticConfig.defaultRendererUrl);
       const rawApiKey = staticConfig.apiKey;
       const configApiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -1,4 +1,10 @@
 {
   "defaultRendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
-  "allowOverrides": true
+  "allowOverrides": true,
+  "profiles": {
+    "dev": {
+      "rendererUrl": "locahost:4200/samples/ng-basic-catalog",
+      "allowOverrides": true
+    }
+  }
 }

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -1,10 +1,16 @@
 {
-  "defaultRendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
-  "allowOverrides": true,
   "profiles": {
+    "default": {
+      "rendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
+      "allowOverrides": true
+    },
     "dev": {
       "rendererUrl": "http://localhost:4200/samples/ng-basic-catalog/",
-      "allowOverrides": true
+      "allowOverrides": false
+    },
+    "react": {
+      "rendererUrl": "http://localhost:4200/samples/react-basic-catalog/",
+      "allowOverrides": false
     }
   }
 }

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -3,7 +3,7 @@
   "allowOverrides": true,
   "profiles": {
     "dev": {
-      "rendererUrl": "locahost:4200/samples/ng-basic-catalog",
+      "rendererUrl": "http://localhost:4200/samples/ng-basic-catalog/",
       "allowOverrides": true
     }
   }

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -9,7 +9,7 @@
       "allowOverrides": false
     },
     "react": {
-      "rendererUrl": "http://localhost:4200/samples/react-basic-catalog/",
+      "rendererUrl": "http://localhost:3459",
       "allowOverrides": false
     }
   }


### PR DESCRIPTION
# Description

Add support for loading runtime configuration profiles via URL query parameters (`?profile=dev` or `?config=react`).

`config.json` now looks like:
```
{
  "defaultRendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
  "allowOverrides": true,
  "profiles": {
    "dev": {
      "rendererUrl": "http://localhost:4200/samples/ng-basic-catalog/",
      "allowOverrides": true
    },
    "react": {
      "defaultRendererUrl": "https://a2ui-project.github.io/composer/samples/react-basic-catalog/",
      "allowOverrides": true,
    }
  }
}
```


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

