### PR TITLE
Use DI for the config.json URL.

### DIFF
--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -134,13 +134,10 @@ test.describe('Settings and Client Configuration', () => {
         });
       });
 
-      await page.goto('/settings');
-      await page.evaluate(() => {
-        try {
-          localStorage.setItem('a2ui_composer_force_3p', 'true');
-        } catch (e) {}
+      await page.addInitScript(() => {
+        localStorage.setItem('a2ui_composer_force_3p', 'true');
       });
-      await page.reload();
+      await page.goto('/settings');
 
       // Context is unlocked because allowOverrides is true
       await expect(page.getByLabel('Target Renderer URL')).toBeEnabled();
@@ -184,13 +181,11 @@ test.describe('Settings and Client Configuration', () => {
     test('verifies 1P vs 3P environment detection and disables chat panel on missing API keys', async ({
       page,
     }) => {
-      await page.goto('/?renderer=http://localhost:3000');
-      await page.evaluate(() => {
+      await page.addInitScript(() => {
         localStorage.setItem('a2ui_composer_force_3p', 'true');
         localStorage.removeItem('a2ui_composer_force_1p');
       });
-      await page.reload();
-      await page.waitForURL(url => url.pathname === '/');
+      await page.goto('/?renderer=http://localhost:3000');
       await expect(page.locator('.disabled-chat-panel')).toBeVisible();
       await expect(page.locator('.disabled-notice-text')).toContainText(
         'This feature is only available with a valid Gemini API key.',

--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -25,14 +25,11 @@ test.beforeEach(async ({page}) => {
 test.describe('Settings and Client Configuration', () => {
   test.describe('Custom Config Modification & Persistence', () => {
     test.beforeEach(async ({page}) => {
-      await page.goto('/settings');
-      await page.evaluate(() => {
-        try {
-          localStorage.clear();
-          localStorage.setItem('a2ui_composer_force_3p', 'true');
-        } catch (e) {}
+      await page.addInitScript(() => {
+        localStorage.clear();
+        localStorage.setItem('a2ui_composer_force_3p', 'true');
       });
-      await page.reload();
+      await page.goto('/settings');
     });
 
     test('persists configuration successfully, triggers explicit window reload, and unlocks guarded routes', async ({
@@ -57,7 +54,6 @@ test.describe('Settings and Client Configuration', () => {
       );
       expect(sentinel).toBeUndefined();
 
-      await page.goto('/');
       await expect(page.locator('.workspace-container')).toBeVisible();
     });
 
@@ -98,6 +94,26 @@ test.describe('Settings and Client Configuration', () => {
       await expect(page.getByLabel('Target Renderer URL')).toBeDisabled();
       const rendererVal = await page.getByLabel('Target Renderer URL').inputValue();
       expect(rendererVal).toBe('http://locked-renderer.com');
+    });
+
+    test('fetches configuration when config.json request is intercepted by route handler', async ({
+      page,
+    }) => {
+      await page.route('**/config.json', async route => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            defaultRendererUrl: 'http://intercepted-custom-config:3000',
+            allowOverrides: true,
+          }),
+        });
+      });
+
+      await page.goto('/settings');
+      const rendererInput = page.getByLabel('Target Renderer URL');
+      await expect(rendererInput).not.toBeDisabled();
+      const rendererVal = await rendererInput.inputValue();
+      expect(rendererVal).toBe('http://intercepted-custom-config:3000');
     });
 
     test('verifies server apiKey in config.json decouples context locking, disables API key unmasking, and does not persist key on save', async ({
@@ -170,10 +186,8 @@ test.describe('Settings and Client Configuration', () => {
     }) => {
       await page.goto('/?renderer=http://localhost:3000');
       await page.evaluate(() => {
-        try {
-          localStorage.setItem('a2ui_composer_force_3p', 'true');
-          localStorage.removeItem('a2ui_composer_force_1p');
-        } catch (e) {}
+        localStorage.setItem('a2ui_composer_force_3p', 'true');
+        localStorage.removeItem('a2ui_composer_force_1p');
       });
       await page.reload();
       await page.waitForURL(url => url.pathname === '/');
@@ -186,11 +200,8 @@ test.describe('Settings and Client Configuration', () => {
     test('verifies auth section is hidden when IS_1P_AUTH_ENABLED is false and API key provisioning panel visibility', async ({
       page,
     }) => {
-      await page.goto('/');
-      await page.evaluate(() => {
-        try {
-          localStorage.clear();
-        } catch (e) {}
+      await page.addInitScript(() => {
+        localStorage.clear();
       });
       await page.goto('/settings');
 

--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -103,8 +103,12 @@ test.describe('Settings and Client Configuration', () => {
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify({
-            defaultRendererUrl: 'http://intercepted-custom-config:3000',
-            allowOverrides: true,
+            profiles: {
+              default: {
+                rendererUrl: 'http://intercepted-custom-config:3000',
+                allowOverrides: true,
+              },
+            },
           }),
         });
       });

--- a/shell/src/app/shell/environment-tokens/environment-tokens.spec.ts
+++ b/shell/src/app/shell/environment-tokens/environment-tokens.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {CONFIG_URL, IS_1P_AUTH_ENABLED, IS_EXTENSION_MODE} from './environment-tokens';
+
+describe('environment-tokens', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+  });
+
+  it("provides default value 'config.json' for CONFIG_URL", () => {
+    const configUrl = TestBed.inject(CONFIG_URL);
+    expect(configUrl).toBe('config.json');
+  });
+
+  it('provides default signal(false) for IS_EXTENSION_MODE', () => {
+    const isExtensionMode = TestBed.inject(IS_EXTENSION_MODE);
+    expect(isExtensionMode()).toBe(false);
+  });
+
+  it('provides default false for IS_1P_AUTH_ENABLED', () => {
+    const is1PAuthEnabled = TestBed.inject(IS_1P_AUTH_ENABLED);
+    expect(is1PAuthEnabled).toBe(false);
+  });
+});

--- a/shell/src/app/shell/environment-tokens/environment-tokens.ts
+++ b/shell/src/app/shell/environment-tokens/environment-tokens.ts
@@ -33,3 +33,11 @@ export const IS_1P_AUTH_ENABLED = new InjectionToken<boolean>('IS_1P_AUTH_ENABLE
   providedIn: 'root',
   factory: () => false,
 });
+
+/**
+ * Injection token specifying the URL from which static config.json is fetched.
+ */
+export const CONFIG_URL = new InjectionToken<string>('CONFIG_URL', {
+  providedIn: 'root',
+  factory: () => 'config.json',
+});

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -784,8 +784,12 @@ describe('StartupResolution Task 2.6', () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         new Response(
           JSON.stringify({
-            defaultRendererUrl: 'http://custom-url:3000',
-            allowOverrides: true,
+            profiles: {
+              default: {
+                rendererUrl: 'http://custom-url:3000',
+                allowOverrides: true,
+              },
+            },
           }),
         ),
       );
@@ -823,8 +827,12 @@ describe('StartupResolution Task 2.6', () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         new Response(
           JSON.stringify({
-            defaultRendererUrl: 'http://custom-locked-renderer:3000',
-            allowOverrides: false,
+            profiles: {
+              default: {
+                rendererUrl: 'http://custom-locked-renderer:3000',
+                allowOverrides: false,
+              },
+            },
           }),
         ),
       );

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -780,6 +780,7 @@ describe('StartupResolution Task 2.6', () => {
     });
 
     it('fetches runtime configuration from custom CONFIG_URL when overridden in injector', async () => {
+      const logSpy = vi.spyOn(console, 'log');
       const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -791,6 +792,7 @@ describe('StartupResolution Task 2.6', () => {
 
       const url = await customService.resolveStartupConfiguration();
 
+      expect(logSpy).toHaveBeenCalledWith('Fetching /custom/config.json configuration...');
       expect(fetchSpy).toHaveBeenCalledWith(
         '/custom/config.json',
         expect.objectContaining({signal: expect.any(AbortSignal)}),
@@ -811,7 +813,7 @@ describe('StartupResolution Task 2.6', () => {
         expect.objectContaining({signal: expect.any(AbortSignal)}),
       );
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Watchdog timeout or failure fetching config.json'),
+        expect.stringContaining('Watchdog timeout or failure fetching /custom/config.json'),
         expect.any(Error),
       );
       expect(url).toBe('http://fallback-storage:3000');

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -20,7 +20,7 @@ import {StartupResolution} from './startup-resolution';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
-import {IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
+import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 
 class MockAppConfigProvider {
@@ -151,6 +151,20 @@ describe('StartupResolution Task 2.6', () => {
     expect(url).toBe('http://fallback-storage:3000');
   });
 
+  it('handles malformed JSON response gracefully and falls back to local storage', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('invalid json payload'));
+    const warnSpy = vi.spyOn(console, 'warn');
+
+    localStorage.setItem(LocalStorageKey.RENDERER_URL, 'http://fallback-storage:3000');
+
+    const url = await service.resolveStartupConfiguration();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Watchdog timeout or failure fetching config.json'),
+      expect.any(SyntaxError),
+    );
+    expect(url).toBe('http://fallback-storage:3000');
+  });
+
   it('identifies 3P environment based on hostname or local overrides when 1P auth is enabled', () => {
     const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
     const hostnameSpy = vi.spyOn(service, 'getWindowHostname');
@@ -196,6 +210,10 @@ describe('StartupResolution Task 2.6', () => {
     // Scenario 2: URL resolved, and 3P has API key -> valid
     mockConfigProvider.geminiApiKey.set('AIzaSyValidKey');
     expect(await service.isEnvironmentValid()).toBe(true);
+
+    // Scenario 3: URL resolved is null -> invalid
+    service.setResolvedRendererUrl(null);
+    expect(await service.isEnvironmentValid()).toBe(false);
   });
 
   it('purges Gemini API key via AppConfigProvider when operating in 1P environments', async () => {
@@ -317,7 +335,7 @@ describe('StartupResolution Task 2.6', () => {
         StartupResolution,
         LocalStorageInteractions,
         {provide: AppConfigProvider, useValue: mockConfigProvider},
-        {provide: IS_1P_AUTH_ENABLED, useValue: true},
+        {provide: IS_1P_AUTH_ENABLED, useValue: false},
       ],
     });
     const customService = TestBed.inject(StartupResolution);
@@ -741,6 +759,78 @@ describe('StartupResolution Task 2.6', () => {
       await service.resolveStartupConfiguration();
       expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with custom CONFIG_URL provider', () => {
+    let customService: StartupResolution;
+
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          StartupResolution,
+          LocalStorageInteractions,
+          {provide: AppConfigProvider, useValue: mockConfigProvider},
+          {provide: IS_1P_AUTH_ENABLED, useValue: true},
+          {provide: CONFIG_URL, useValue: '/custom/config.json'},
+        ],
+      });
+      customService = TestBed.inject(StartupResolution);
+    });
+
+    it('fetches runtime configuration from custom CONFIG_URL when overridden in injector', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            defaultRendererUrl: 'http://custom-url:3000',
+            allowOverrides: true,
+          }),
+        ),
+      );
+
+      const url = await customService.resolveStartupConfiguration();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/custom/config.json',
+        expect.objectContaining({signal: expect.any(AbortSignal)}),
+      );
+      expect(url).toBe('http://custom-url:3000');
+    });
+
+    it('handles fetch failure gracefully when using custom CONFIG_URL', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      localStorage.setItem(LocalStorageKey.RENDERER_URL, 'http://fallback-storage:3000');
+
+      const url = await customService.resolveStartupConfiguration();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/custom/config.json',
+        expect.objectContaining({signal: expect.any(AbortSignal)}),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Watchdog timeout or failure fetching config.json'),
+        expect.any(Error),
+      );
+      expect(url).toBe('http://fallback-storage:3000');
+    });
+
+    it('locks context when custom CONFIG_URL response has allowOverrides set to false', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            defaultRendererUrl: 'http://custom-locked-renderer:3000',
+            allowOverrides: false,
+          }),
+        ),
+      );
+
+      const url = await customService.resolveStartupConfiguration();
+
+      expect(url).toBe('http://custom-locked-renderer:3000');
+      expect(customService.isContextLocked()).toBe(true);
     });
   });
 });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -85,7 +85,7 @@ export class StartupResolution {
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
     try {
-      console.log('Fetching config.json configuration...');
+      console.log(`Fetching ${this.configUrl} configuration...`);
       const response = await fetch(this.configUrl, {signal: controller.signal});
       if (response.ok) {
         // Although we *expect* JSON, it's possible that the response includes
@@ -99,10 +99,7 @@ export class StartupResolution {
         staticConfig = JSON.parse(cleanText);
       }
     } catch (err) {
-      console.warn(
-        'Watchdog timeout or failure fetching config.json. Allowing overrides fallbacks.',
-        err,
-      );
+      console.warn(`Watchdog timeout or failure fetching ${this.configUrl}`, err);
     } finally {
       clearTimeout(timeoutId);
     }

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -19,7 +19,7 @@ import {QueryParser} from '../query-parser/query-parser';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
-import {IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
+import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
 
 /**
  * Represents the configuration options for an application profile,
@@ -47,6 +47,7 @@ export class StartupResolution {
   private readonly localStorageInteractions = inject(LocalStorageInteractions);
   private readonly injector = inject(Injector);
   private readonly is1PAuthEnabled = inject(IS_1P_AUTH_ENABLED);
+  private readonly configUrl = inject(CONFIG_URL);
 
   readonly resolvedUrl = this._resolvedUrl.asReadonly();
   readonly isLockedContext = this._isLockedContext.asReadonly();
@@ -85,7 +86,7 @@ export class StartupResolution {
 
     try {
       console.log('Fetching config.json configuration...');
-      const response = await fetch('config.json', {signal: controller.signal});
+      const response = await fetch(this.configUrl, {signal: controller.signal});
       if (response.ok) {
         // Although we *expect* JSON, it's possible that the response includes
         // a JSON Vulnerability Protection prefixes (often referred to as an


### PR DESCRIPTION
# Description

By default, it just injects the `config.json` as before.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

