### PR TITLE
fix: resolve sidenav layout whitespace gap race condition

### DIFF
--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -39,6 +39,19 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  display: flex;
+
+  ::ng-deep .mat-drawer {
+    position: relative !important;
+    transform: none !important;
+  }
+
+  ::ng-deep .mat-drawer-content {
+    flex: 1;
+    min-width: 0;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
 }
 
 .composer-sidenav {

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -179,6 +179,13 @@ describe('ComposerShell Layout', () => {
     },
   );
 
+  it('ensures mat-sidenav-content margin-left is 0px to eliminate whitespace gap', async () => {
+    const sidenavContent = fixture.nativeElement.querySelector('mat-sidenav-content');
+    expect(sidenavContent).toBeTruthy();
+    const computedStyle = window.getComputedStyle(sidenavContent);
+    expect(['0', '0px']).toContain(computedStyle.marginLeft);
+  });
+
   it('reads the persisted theme preference from storage on initialization', async () => {
     configProviderMock.themePreference.set(ThemePreference.DARK);
     const newFixture = TestBed.createComponent(ComposerShell);


### PR DESCRIPTION
# Description

Use Flexbox layout on mat-sidenav-container to override Angular Material's JS-calculated inline margins on mat-sidenav-content. This prevents empty whitespace gaps when the sidenav collapses.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

