### PR TITLE
Profile selector

### DIFF
--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -26,8 +26,11 @@ test.describe('Settings and Client Configuration', () => {
   test.describe('Custom Config Modification & Persistence', () => {
     test.beforeEach(async ({page}) => {
       await page.addInitScript(() => {
-        localStorage.clear();
-        localStorage.setItem('a2ui_composer_force_3p', 'true');
+        if (!sessionStorage.getItem('init_cleared')) {
+          sessionStorage.setItem('init_cleared', 'true');
+          localStorage.clear();
+          localStorage.setItem('a2ui_composer_force_3p', 'true');
+        }
       });
       await page.goto('/settings');
     });
@@ -36,7 +39,8 @@ test.describe('Settings and Client Configuration', () => {
       page,
     }) => {
       const rendererInput = page.getByLabel('Target Renderer URL');
-      await rendererInput.fill('http://localhost:3000');
+      await expect(rendererInput).toBeEnabled();
+      await rendererInput.fill('http://localhost:9090');
 
       const apiKeyInput = page.getByLabel('Gemini API Key');
       await apiKeyInput.fill('test-api-key');
@@ -46,6 +50,7 @@ test.describe('Settings and Client Configuration', () => {
       });
 
       const saveBtn = page.getByRole('button', {name: 'Save Settings'});
+      await expect(saveBtn).toBeEnabled();
       await Promise.all([page.waitForURL(url => url.pathname === '/'), saveBtn.click()]);
       await page.waitForLoadState('load');
 
@@ -55,6 +60,11 @@ test.describe('Settings and Client Configuration', () => {
       expect(sentinel).toBeUndefined();
 
       await expect(page.locator('.workspace-container')).toBeVisible();
+
+      const storedRendererUrl = await page.evaluate(() =>
+        localStorage.getItem('a2ui_composer_renderer_url'),
+      );
+      expect(storedRendererUrl).toBe('http://localhost:9090');
     });
 
     test('persists configuration successfully with default relative renderer URL and loads workspace with pre-populated draft', async ({
@@ -144,13 +154,18 @@ test.describe('Settings and Client Configuration', () => {
       await page.goto('/settings');
 
       // Context is unlocked because allowOverrides is true
-      await expect(page.getByLabel('Target Renderer URL')).toBeEnabled();
+      const rendererInput = page.getByLabel('Target Renderer URL');
+      await expect(rendererInput).toBeEnabled();
 
       // Toggle button is disabled because API key was provided by config
       await expect(page.locator('.api-key-toggle-btn')).toBeDisabled();
 
+      // Modify a field to trigger unsaved changes
+      await rendererInput.fill('http://unlocked-renderer.com/modified');
+
       // Click 'Save Settings' and wait for navigation
       const saveBtn = page.getByRole('button', {name: 'Save Settings'});
+      await expect(saveBtn).toBeEnabled();
       await Promise.all([page.waitForURL(url => url.pathname === '/'), saveBtn.click()]);
       await page.waitForLoadState('load');
 

--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -71,9 +71,10 @@ test.describe('Settings and Client Configuration', () => {
       page,
     }) => {
       const apiKeyInput = page.getByLabel('Gemini API Key');
-      await apiKeyInput.fill('test-api-key');
+      await apiKeyInput.fill('new-unique-api-key');
 
       const saveBtn = page.getByRole('button', {name: 'Save Settings'});
+      await expect(saveBtn).toBeEnabled();
       await Promise.all([page.waitForURL(url => url.pathname === '/'), saveBtn.click()]);
       await page.waitForLoadState('load');
 

--- a/shell/src/app/app.routes.spec.ts
+++ b/shell/src/app/app.routes.spec.ts
@@ -21,7 +21,7 @@ import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {signal} from '@angular/core';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {routes} from './app.routes';
-import {StartupResolution} from './shell/startup-resolution/startup-resolution';
+import {StartupResolution, ProfileConfig} from './shell/startup-resolution/startup-resolution';
 import {ChatState} from './chat/chat-state/chat-state';
 import {ChatCoordinator} from './chat/chat-service/chat-coordinator';
 import {StateSync} from './chat/state-sync/state-sync';
@@ -40,6 +40,12 @@ import {PipelineStatus} from './chat/pipeline-status/pipeline-status';
 class MockStartupResolution {
   readonly resolvedUrl = signal('http://localhost:4200');
   readonly isLockedContext = signal(false);
+  readonly profiles = signal<Record<string, ProfileConfig>>({});
+  readonly selectedProfileId = signal<string | null>(null);
+  readonly activeProfile = signal<ProfileConfig | null>(null);
+  readonly isLoading = signal(false);
+  readonly error = signal<string | null>(null);
+  setSelectedProfileId = vi.fn();
   isEnvironmentValid = vi.fn().mockReturnValue(true);
   isExtensionMode = vi.fn().mockReturnValue(false);
   isContextLocked = vi.fn().mockReturnValue(false);
@@ -72,10 +78,12 @@ class MockAppConfigProvider {
   readonly authType = signal(AuthType.FIRST_PARTY);
   readonly rendererUrl = signal('http://localhost:4200/renderer');
   readonly geminiApiKey = signal('');
+  readonly isApiKeyProvidedByConfig = signal(false);
   readonly themePreference = signal<ThemePreference>(ThemePreference.LIGHT);
   readonly includeScreenshot = signal<boolean>(true);
   setThemePreference = vi.fn();
   setGeminiApiKey = vi.fn();
+  setApiKeyFromConfig = vi.fn();
   setRendererUrl = vi.fn();
   setIncludeScreenshot = vi.fn((include: boolean) => {
     this.includeScreenshot.set(include);

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -477,6 +477,18 @@ describe('LocalStorageAppConfigProvider', () => {
       expect(provider.isApiKeyProvidedByConfig()).toBe(false);
       expect(provider.geminiApiKey()).toBe('');
     });
+
+    it('resets geminiApiKey to empty string when setApiKeyFromConfig receives empty or whitespace string', () => {
+      const provider = setupProvider();
+      provider.setApiKeyFromConfig('server-config-key');
+      expect(provider.geminiApiKey()).toBe('server-config-key');
+      expect(provider.isApiKeyProvidedByConfig()).toBe(true);
+
+      provider.setApiKeyFromConfig('   ');
+
+      expect(provider.isApiKeyProvidedByConfig()).toBe(false);
+      expect(provider.geminiApiKey()).toBe('');
+    });
   });
 
   describe('under potential Server-Side Rendering (SSR) environments', () => {

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -204,6 +204,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
       this._geminiApiKey.set(trimmed);
     } else {
       this._isApiKeyProvidedByConfig.set(false);
+      this._geminiApiKey.set('');
     }
   }
 

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -198,10 +198,12 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
    * @param key The configuration-provided API key.
    */
   override setApiKeyFromConfig(key: string): void {
-    const trimmed = key.trim();
+    const trimmed = (key || '').trim();
     if (trimmed) {
       this._isApiKeyProvidedByConfig.set(true);
       this._geminiApiKey.set(trimmed);
+    } else {
+      this._isApiKeyProvidedByConfig.set(false);
     }
   }
 

--- a/shell/src/app/settings/profile-selector/profile-selector.ng.html
+++ b/shell/src/app/settings/profile-selector/profile-selector.ng.html
@@ -1,0 +1,38 @@
+<!--
+  Copyright 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<div
+  class="profile-selector-container"
+  [matTooltip]="tooltipMessage()"
+  [matTooltipDisabled]="!isDisabled()"
+  [attr.tabindex]="isDisabled() ? 0 : null"
+  [attr.aria-label]="isDisabled() ? tooltipMessage() : null"
+>
+  <mat-form-field appearance="outline" class="profile-selector-form-field">
+    <mat-label>Profile</mat-label>
+    <mat-select
+      id="profile-select"
+      [value]="selectedProfileId()"
+      [disabled]="isDisabled()"
+      (selectionChange)="onSelectionChange($event.value)"
+    >
+      <mat-option [value]="null">Custom</mat-option>
+      @for (option of profileOptions(); track option.id) {
+        <mat-option [value]="option.id">{{ option.displayName }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+</div>

--- a/shell/src/app/settings/profile-selector/profile-selector.scss
+++ b/shell/src/app/settings/profile-selector/profile-selector.scss
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.profile-selector-container {
+  display: inline-block;
+  width: 100%;
+}
+
+.profile-selector-form-field {
+  width: 100%;
+}

--- a/shell/src/app/settings/profile-selector/profile-selector.spec.ts
+++ b/shell/src/app/settings/profile-selector/profile-selector.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
+import {ProfileSelector} from './profile-selector';
+import {ProfileSelectorHarness} from './test/profile-selector.harness';
+import {ProfileConfig} from '../../shell/startup-resolution/startup-resolution';
+import {describe, beforeEach, it, expect, vi} from 'vitest';
+
+describe('ProfileSelector', () => {
+  let fixture: ComponentFixture<ProfileSelector>;
+  let component: ProfileSelector;
+  let harness: ProfileSelectorHarness;
+
+  const mockProfiles: Record<string, ProfileConfig> = {
+    dev: {
+      displayName: 'Development Environment',
+      rendererUrl: 'http://localhost:3000',
+    },
+    prod: {
+      rendererUrl: 'https://prod.example.com',
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileSelector],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileSelector);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ProfileSelectorHarness);
+  });
+
+  it('renders options with displayName fallback when displayName is missing', async () => {
+    fixture.componentRef.setInput('profiles', mockProfiles);
+    fixture.detectChanges();
+
+    const options = await harness.getOptionsText();
+    expect(options).toEqual(['Custom', 'Development Environment', 'prod']);
+  });
+
+  it('emits profileSelected with selected profile ID when option is selected', async () => {
+    fixture.componentRef.setInput('profiles', mockProfiles);
+    fixture.detectChanges();
+
+    const spy = vi.fn();
+    component.profileSelected.subscribe(spy);
+
+    await harness.selectOptionByText('Development Environment');
+
+    expect(spy).toHaveBeenCalledWith('dev');
+  });
+
+  it('emits profileSelected with null when Custom option is selected', async () => {
+    fixture.componentRef.setInput('profiles', mockProfiles);
+    fixture.componentRef.setInput('selectedProfileId', 'dev');
+    fixture.detectChanges();
+
+    const spy = vi.fn();
+    component.profileSelected.subscribe(spy);
+
+    await harness.selectOptionByText('Custom');
+
+    expect(spy).toHaveBeenCalledWith(null);
+  });
+
+  it('disables selector and presents tooltip when profiles map is empty', async () => {
+    fixture.componentRef.setInput('profiles', {});
+    fixture.detectChanges();
+
+    expect(await harness.isDisabled()).toBe(true);
+    expect(component.isEmpty()).toBe(true);
+    expect(component.isDisabled()).toBe(true);
+    expect(component.tooltipMessage()).toBe('No profiles available');
+  });
+
+  it('computes profileOptions correctly based on input profiles', () => {
+    fixture.componentRef.setInput('profiles', mockProfiles);
+    fixture.detectChanges();
+
+    expect(component.profileOptions()).toEqual([
+      {id: 'dev', displayName: 'Development Environment'},
+      {id: 'prod', displayName: 'prod'},
+    ]);
+  });
+
+  it('computes tooltipMessage correctly when empty vs profiles present', () => {
+    fixture.componentRef.setInput('profiles', {});
+    fixture.detectChanges();
+    expect(component.tooltipMessage()).toBe('No profiles available');
+
+    fixture.componentRef.setInput('profiles', mockProfiles);
+    fixture.detectChanges();
+    expect(component.tooltipMessage()).toBe('');
+  });
+
+  it('sets tabindex and aria-label accessibility attributes on wrapper div when disabled due to empty profiles', () => {
+    fixture.componentRef.setInput('profiles', {});
+    fixture.detectChanges();
+
+    const containerEl = fixture.nativeElement.querySelector('.profile-selector-container');
+    expect(containerEl.getAttribute('tabindex')).toBe('0');
+    expect(containerEl.getAttribute('aria-label')).toBe('No profiles available');
+  });
+});

--- a/shell/src/app/settings/profile-selector/profile-selector.spec.ts
+++ b/shell/src/app/settings/profile-selector/profile-selector.spec.ts
@@ -120,4 +120,25 @@ describe('ProfileSelector', () => {
     expect(containerEl.getAttribute('tabindex')).toBe('0');
     expect(containerEl.getAttribute('aria-label')).toBe('No profiles available');
   });
+
+  it('returns empty profileOptions array when profiles input is an array', () => {
+    fixture.componentRef.setInput('profiles', ['invalid', 'array'] as unknown as Record<
+      string,
+      ProfileConfig
+    >);
+    fixture.detectChanges();
+
+    expect(component.profileOptions()).toEqual([]);
+  });
+
+  it('computes isEmpty as true and disables component when profiles input is an array', () => {
+    fixture.componentRef.setInput('profiles', ['invalid', 'array'] as unknown as Record<
+      string,
+      ProfileConfig
+    >);
+    fixture.detectChanges();
+
+    expect(component.isEmpty()).toBe(true);
+    expect(component.isDisabled()).toBe(true);
+  });
 });

--- a/shell/src/app/settings/profile-selector/profile-selector.ts
+++ b/shell/src/app/settings/profile-selector/profile-selector.ts
@@ -53,7 +53,7 @@ export class ProfileSelector {
 
   readonly profileOptions = computed<ProfileOption[]>(() => {
     const map = this.profiles();
-    if (!map || typeof map !== 'object') {
+    if (!map || typeof map !== 'object' || Array.isArray(map)) {
       return [];
     }
     return Object.entries(map).map(([key, config]) => ({
@@ -62,7 +62,7 @@ export class ProfileSelector {
     }));
   });
 
-  readonly isEmpty = computed<boolean>(() => Object.keys(this.profiles() ?? {}).length === 0);
+  readonly isEmpty = computed<boolean>(() => this.profileOptions().length === 0);
 
   readonly isDisabled = computed<boolean>(() => this.isEmpty());
 

--- a/shell/src/app/settings/profile-selector/profile-selector.ts
+++ b/shell/src/app/settings/profile-selector/profile-selector.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, computed, input, output} from '@angular/core';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {ProfileConfig} from '../../shell/startup-resolution/startup-resolution';
+
+/**
+ * Default tooltip message displayed when profile selection is disabled due to empty profiles.
+ */
+export const NO_PROFILES_TOOLTIP = 'No profiles available';
+
+/**
+ * Option item model for profile selection dropdowns.
+ */
+export declare interface ProfileOption {
+  id: string;
+  displayName: string;
+}
+
+/**
+ * Component for selecting configuration profiles.
+ * Provides a dropdown interface to switch between available profile presets
+ * or choose custom settings.
+ */
+@Component({
+  selector: 'a2ui-composer-profile-selector',
+  standalone: true,
+  imports: [MatFormFieldModule, MatSelectModule, MatTooltipModule],
+  templateUrl: './profile-selector.ng.html',
+  styleUrl: './profile-selector.scss',
+})
+export class ProfileSelector {
+  readonly profiles = input<Record<string, ProfileConfig> | null | undefined>({});
+  readonly selectedProfileId = input<string | null>(null);
+
+  readonly profileSelected = output<string | null>();
+
+  readonly profileOptions = computed<ProfileOption[]>(() => {
+    const map = this.profiles();
+    if (!map || typeof map !== 'object') {
+      return [];
+    }
+    return Object.entries(map).map(([key, config]) => ({
+      id: key,
+      displayName: config?.displayName || key,
+    }));
+  });
+
+  readonly isEmpty = computed<boolean>(() => Object.keys(this.profiles() ?? {}).length === 0);
+
+  readonly isDisabled = computed<boolean>(() => this.isEmpty());
+
+  readonly tooltipMessage = computed<string>(() => (this.isEmpty() ? NO_PROFILES_TOOLTIP : ''));
+
+  onSelectionChange(value: string | null): void {
+    this.profileSelected.emit(value);
+  }
+}

--- a/shell/src/app/settings/profile-selector/test/profile-selector.harness.ts
+++ b/shell/src/app/settings/profile-selector/test/profile-selector.harness.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ComponentHarness} from '@angular/cdk/testing';
+import {MatSelectHarness} from '@angular/material/select/testing';
+import {MatOptionHarness} from '@angular/material/core/testing';
+import {MatTooltipHarness} from '@angular/material/tooltip/testing';
+
+/**
+ * Harness for interacting with the ProfileSelector component in tests.
+ */
+export class ProfileSelectorHarness extends ComponentHarness {
+  static hostSelector = 'a2ui-composer-profile-selector';
+
+  protected getSelect = this.locatorFor(MatSelectHarness);
+  protected getTooltip = this.locatorForOptional(MatTooltipHarness);
+  protected getDocumentOptions: () => Promise<MatOptionHarness[]> = this.locatorFactory
+    .documentRootLocatorFactory()
+    .locatorForAll(MatOptionHarness);
+
+  async openSelect(): Promise<void> {
+    const select = await this.getSelect();
+    const selectHost = await select.host();
+    await selectHost.click();
+  }
+
+  async getOptionsText(): Promise<string[]> {
+    await this.openSelect();
+    const getOptions = this.locatorFactory
+      .documentRootLocatorFactory()
+      .locatorForAll(MatOptionHarness);
+    const options = await getOptions();
+    return Promise.all(options.map(async opt => (await opt.getText()).trim()));
+  }
+
+  async selectOptionByText(text: string): Promise<void> {
+    await this.openSelect();
+    const getOptions = this.locatorFactory
+      .documentRootLocatorFactory()
+      .locatorForAll(MatOptionHarness);
+    const options = await getOptions();
+    for (const opt of options) {
+      if ((await opt.getText()).trim() === text) {
+        await opt.click();
+        return;
+      }
+    }
+    throw new Error(`Option "${text}" not found in ProfileSelector dropdown`);
+  }
+
+  async getSelectedValueText(): Promise<string> {
+    const select = await this.getSelect();
+    return select.getValueText();
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const select = await this.getSelect();
+    return select.isDisabled();
+  }
+
+  async getTooltipText(): Promise<string | null> {
+    const tooltip = await this.getTooltip();
+    if (!tooltip) return null;
+    return tooltip.getTooltipText();
+  }
+}

--- a/shell/src/app/settings/settings-service/settings.service.spec.ts
+++ b/shell/src/app/settings/settings-service/settings.service.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {signal, WritableSignal} from '@angular/core';
+import {SettingsService} from './settings.service';
+import {StartupResolution, ProfileConfig} from '../../shell/startup-resolution/startup-resolution';
+import {AppConfigProvider} from '../app-config-provider/app-config-provider';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
+import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
+import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
+import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let mockStartupResolution: {
+    profiles: WritableSignal<Record<string, ProfileConfig>>;
+    selectedProfileId: WritableSignal<string | null>;
+    activeProfile: WritableSignal<ProfileConfig | null>;
+    setSelectedProfileId: ReturnType<typeof vi.fn>;
+  };
+  let mockConfigProvider: {
+    setRendererUrl: ReturnType<typeof vi.fn>;
+    setApiKeyFromConfig: ReturnType<typeof vi.fn>;
+    setGeminiApiKey: ReturnType<typeof vi.fn>;
+  };
+  let mockSecureStorage: {
+    getCredential: ReturnType<typeof vi.fn>;
+  };
+  let mockLocalStorage: LocalStorageInteractions;
+
+  const sampleProfiles: Record<string, ProfileConfig> = {
+    dev: {
+      displayName: 'Development',
+      rendererUrl: 'http://localhost:3000',
+      apiKey: '  dev-api-key  ',
+      allowOverrides: true,
+    },
+    locked: {
+      displayName: 'Locked Profile',
+      rendererUrl: 'http://locked-server.com',
+      allowOverrides: false,
+    },
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    mockStartupResolution = {
+      profiles: signal(sampleProfiles),
+      selectedProfileId: signal(null),
+      activeProfile: signal(null),
+      setSelectedProfileId: vi.fn((id: string | null) => {
+        mockStartupResolution.selectedProfileId.set(id);
+        mockStartupResolution.activeProfile.set(id ? sampleProfiles[id] || null : null);
+      }),
+    };
+
+    mockConfigProvider = {
+      setRendererUrl: vi.fn(),
+      setApiKeyFromConfig: vi.fn(),
+      setGeminiApiKey: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockSecureStorage = {
+      getCredential: vi.fn().mockResolvedValue('personal-indexeddb-key'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        SettingsService,
+        LocalStorageInteractions,
+        {provide: StartupResolution, useValue: mockStartupResolution},
+        {provide: AppConfigProvider, useValue: mockConfigProvider},
+        {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
+      ],
+    });
+
+    service = TestBed.inject(SettingsService);
+    mockLocalStorage = TestBed.inject(LocalStorageInteractions);
+  });
+
+  it('creates the settings service instance', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('exposes signals delegating to startup resolution', () => {
+    expect(service.profiles()).toEqual(sampleProfiles);
+    expect(service.selectedProfileId()).toBeNull();
+    expect(service.activeProfile()).toBeNull();
+  });
+
+  it('computes allowOverrides as true when active profile is null or allowOverrides is omitted', () => {
+    expect(service.allowOverrides()).toBe(true);
+
+    mockStartupResolution.activeProfile.set({
+      rendererUrl: 'http://example.com',
+    });
+    expect(service.allowOverrides()).toBe(true);
+  });
+
+  it('computes allowOverrides as false when active profile disallows overrides', () => {
+    mockStartupResolution.activeProfile.set({
+      allowOverrides: false,
+    });
+    expect(service.allowOverrides()).toBe(false);
+  });
+
+  it('persists selected profile ID to local storage and updates startup resolution when selecting profile', async () => {
+    await service.selectProfile('dev');
+
+    expect(mockLocalStorage.getItem(LocalStorageKey.SELECTED_PROFILE)).toBe('dev');
+    expect(mockStartupResolution.setSelectedProfileId).toHaveBeenCalledWith('dev');
+  });
+
+  it('removes selected profile ID from local storage when selected profile ID is null', async () => {
+    mockLocalStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'dev');
+
+    await service.selectProfile(null);
+
+    expect(mockLocalStorage.getItem(LocalStorageKey.SELECTED_PROFILE)).toBeNull();
+    expect(mockStartupResolution.setSelectedProfileId).toHaveBeenCalledWith(null);
+  });
+
+  it('applies rendererUrl and trimmed config apiKey when selected profile contains both', async () => {
+    await service.selectProfile('dev');
+
+    expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('http://localhost:3000');
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('dev-api-key');
+  });
+
+  it('resets config key state and loads personal key from secure storage when selected profile lacks apiKey', async () => {
+    await service.selectProfile('locked');
+
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
+      SecureCredentialsKey.GEMINI_API_KEY,
+    );
+    expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('personal-indexeddb-key');
+  });
+
+  it('clears rendererUrl and loads stored API key when profile is null', async () => {
+    await service.selectProfile(null);
+
+    expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
+      SecureCredentialsKey.GEMINI_API_KEY,
+    );
+    expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('personal-indexeddb-key');
+  });
+
+  it('clears rendererUrl to "" when selecting null profile', async () => {
+    await service.selectProfile('dev');
+    expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('http://localhost:3000');
+
+    await service.selectProfile(null);
+    expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('');
+  });
+
+  it('resets allowOverrides to true when selecting null after a locked profile', async () => {
+    mockStartupResolution.activeProfile.set(sampleProfiles['locked']);
+    expect(service.allowOverrides()).toBe(false);
+
+    await service.selectProfile(null);
+
+    expect(service.allowOverrides()).toBe(true);
+  });
+
+  it('trims apiKey and handles whitespace-only or non-string apiKey when selecting profile', async () => {
+    const customProfiles: Record<string, ProfileConfig> = {
+      whitespaceKey: {
+        apiKey: '   padded-key   ',
+      },
+      blankKey: {
+        apiKey: '   ',
+      },
+      nonStringKey: {
+        apiKey: 12345 as unknown as string,
+      },
+    };
+    mockStartupResolution.profiles.set(customProfiles);
+    mockStartupResolution.setSelectedProfileId.mockImplementation((id: string | null) => {
+      mockStartupResolution.selectedProfileId.set(id);
+      mockStartupResolution.activeProfile.set(id ? customProfiles[id] || null : null);
+    });
+
+    await service.selectProfile('whitespaceKey');
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('padded-key');
+
+    await service.selectProfile('blankKey');
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
+      SecureCredentialsKey.GEMINI_API_KEY,
+    );
+
+    mockConfigProvider.setApiKeyFromConfig.mockClear();
+    mockSecureStorage.getCredential.mockClear();
+
+    await service.selectProfile('nonStringKey');
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
+      SecureCredentialsKey.GEMINI_API_KEY,
+    );
+  });
+
+  it('handles error gracefully when secureCredentialsStorage throws in selectProfile', async () => {
+    mockSecureStorage.getCredential.mockRejectedValue(new Error('Secure storage error'));
+    const warnSpy = vi.spyOn(console, 'warn');
+
+    await service.selectProfile('locked');
+
+    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to retrieve credential from SecureCredentialsStorage:',
+      expect.any(Error),
+    );
+  });
+
+  it('restores selectedProfileId signal from saved local storage profile key upon startup resolution', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        SettingsService,
+        StartupResolution,
+        LocalStorageInteractions,
+        {provide: AppConfigProvider, useValue: mockConfigProvider},
+        {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
+        {provide: IS_1P_AUTH_ENABLED, useValue: true},
+      ],
+    });
+
+    const localService = TestBed.inject(SettingsService);
+    const startupRes = TestBed.inject(StartupResolution);
+    const localStorageInteractions = TestBed.inject(LocalStorageInteractions);
+
+    localStorageInteractions.setItem(LocalStorageKey.SELECTED_PROFILE, 'dev');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          profiles: {
+            dev: {
+              rendererUrl: 'http://dev-server:3000',
+            },
+          },
+        }),
+      ),
+    );
+
+    await startupRes.resolveStartupConfiguration();
+
+    expect(localService.selectedProfileId()).toBe('dev');
+  });
+});

--- a/shell/src/app/settings/settings-service/settings.service.ts
+++ b/shell/src/app/settings/settings-service/settings.service.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable, Signal, computed, inject} from '@angular/core';
+import {ProfileConfig, StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {AppConfigProvider} from '../app-config-provider/app-config-provider';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
+import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
+import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
+
+/**
+ * Facade service for settings configuration profile selection and persistence.
+ * Coordinates profile state signals with startup resolution, local storage,
+ * and secure credential storage layers.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SettingsService {
+  private readonly startupResolution = inject(StartupResolution);
+  private readonly configProvider = inject(AppConfigProvider);
+  private readonly secureCredentialsStorage = inject(SecureCredentialsStorage);
+  private readonly localStorageInteractions = inject(LocalStorageInteractions);
+
+  readonly profiles: Signal<Record<string, ProfileConfig>> = computed(() =>
+    this.startupResolution.profiles(),
+  );
+
+  readonly selectedProfileId: Signal<string | null> = computed(() =>
+    this.startupResolution.selectedProfileId(),
+  );
+
+  readonly activeProfile: Signal<ProfileConfig | null> = computed(() =>
+    this.startupResolution.activeProfile(),
+  );
+
+  readonly allowOverrides: Signal<boolean> = computed(
+    () => this.activeProfile()?.allowOverrides ?? true,
+  );
+
+  /**
+   * Switches the active configuration profile selection.
+   *
+   * @param profileId The selected profile ID string, or null to revert to Custom/Default.
+   */
+  async selectProfile(profileId: string | null): Promise<void> {
+    if (profileId) {
+      this.localStorageInteractions.setItem(LocalStorageKey.SELECTED_PROFILE, profileId);
+    } else {
+      this.localStorageInteractions.removeItem(LocalStorageKey.SELECTED_PROFILE);
+    }
+
+    this.startupResolution.setSelectedProfileId(profileId);
+
+    const active = this.activeProfile();
+
+    if (active?.rendererUrl) {
+      this.configProvider.setRendererUrl(active.rendererUrl);
+    } else {
+      this.configProvider.setRendererUrl('');
+    }
+
+    const apiKey = typeof active?.apiKey === 'string' ? active.apiKey.trim() : '';
+
+    if (apiKey) {
+      this.configProvider.setApiKeyFromConfig(apiKey);
+    } else {
+      this.configProvider.setApiKeyFromConfig('');
+      try {
+        const personalKey = await this.secureCredentialsStorage.getCredential(
+          SecureCredentialsKey.GEMINI_API_KEY,
+        );
+        const trimmedPersonalKey = personalKey ? personalKey.trim() : '';
+        await this.configProvider.setGeminiApiKey(trimmedPersonalKey);
+      } catch (err) {
+        console.warn('Failed to retrieve credential from SecureCredentialsStorage:', err);
+      }
+    }
+  }
+}

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -22,6 +22,16 @@
     <mat-card-content>
       <form [formGroup]="settingsForm" (ngSubmit)="saveSettings()">
         <div class="form-section">
+          <h3>Configuration Profile</h3>
+          <a2ui-composer-profile-selector
+            [profiles]="settingsService.profiles()"
+            [selectedProfileId]="settingsService.selectedProfileId()"
+            (profileSelected)="onProfileSelected($event)"
+          >
+          </a2ui-composer-profile-selector>
+        </div>
+
+        <div class="form-section">
           <h3>Renderer Application URL</h3>
           @if (isLocked()) {
             <div class="locked-notice">

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -20,7 +20,7 @@
       <mat-card-title>A2UI Composer Settings</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <form [formGroup]="settingsForm" (ngSubmit)="saveSettings()">
+      <form [formGroup]="settingsForm" (ngSubmit)="saveSettings()" id="settings-form">
         <div class="form-section">
           <h3>Configuration Profile</h3>
           <a2ui-composer-profile-selector
@@ -153,7 +153,13 @@
       </div>
     }
     <mat-card-actions align="end">
-      <button mat-flat-button color="primary" [disabled]="isSaving()" (click)="saveSettings()">
+      <button
+        mat-flat-button
+        color="primary"
+        type="submit"
+        form="settings-form"
+        [disabled]="isSaveDisabled()"
+      >
         {{ isSaving() ? 'Saving...' : 'Save Settings' }}
       </button>
     </mat-card-actions>

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -676,8 +676,12 @@ describe('Settings', () => {
       mockIsApiKeyProvidedByConfig.set(true);
       mockGeminiApiKey.set('server-key');
 
-      const {component} = await setupComponent();
+      const {fixture, component, harness} = await setupComponent();
       const reloadSpy = vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      await harness.setRendererUrlValue('http://new-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
 
       await component.saveSettings();
 
@@ -749,6 +753,7 @@ describe('Settings', () => {
       const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
 
       await harness.setRendererUrlValue('http://custom-renderer-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
 
       expect(selectSpy).toHaveBeenCalledWith(null);
     });
@@ -854,6 +859,133 @@ describe('Settings', () => {
       expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('');
       expect(component.settingsForm.controls.apiKey.value).toBe('');
+    });
+  });
+
+  describe('isSaveDisabled()', () => {
+    it('disables Save Settings button initially when settings match loaded values', async () => {
+      const {component, harness} = await setupComponent();
+
+      expect(component.hasUnsavedChanges()).toBe(false);
+      expect(component.isSaveDisabled()).toBe(true);
+      expect(await harness.isSaveButtonDisabled()).toBe(true);
+    });
+
+    it('enables Save Settings button when profile selection changes', async () => {
+      mockProfiles.set({
+        'profile-1': {displayName: 'Profile 1', rendererUrl: 'http://p1.com'},
+      });
+      const {fixture, component, harness} = await setupComponent();
+
+      await component.onProfileSelected('profile-1');
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+      expect(component.isSaveDisabled()).toBe(false);
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
+
+    it('enables Save Settings button when forceThirdPartyAuth changes', async () => {
+      const {fixture, component, harness} = await setupComponent();
+      vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      await harness.toggleForceThirdPartyAuth();
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+      expect(component.isSaveDisabled()).toBe(false);
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
+
+    it('enables Save Settings button when renderer URL changes', async () => {
+      const {fixture, component, harness} = await setupComponent();
+
+      await harness.setRendererUrlValue('http://updated-renderer-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+      expect(component.isSaveDisabled()).toBe(false);
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
+
+    it('enables Save Settings button when API key changes', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      const {fixture, component, harness} = await setupComponent();
+
+      await harness.setGeminiApiKeyValue('new-api-key-value');
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(true);
+      expect(component.isSaveDisabled()).toBe(false);
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
+
+    it('disables Save Settings button when form is invalid', async () => {
+      const {fixture, component, harness} = await setupComponent();
+
+      await harness.setRendererUrlValue('invalid-url-without-protocol-or-slash');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+
+      expect(component.settingsForm.invalid).toBe(true);
+      expect(component.hasUnsavedChanges()).toBe(true);
+      expect(component.isSaveDisabled()).toBe(true);
+      expect(await harness.isSaveButtonDisabled()).toBe(true);
+    });
+
+    it('disables Save Settings button after settings are saved', async () => {
+      const {fixture, component, harness} = await setupComponent();
+      vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      await harness.setRendererUrlValue('http://updated-renderer-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+
+      await component.saveSettings();
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(false);
+      expect(component.isSaveDisabled()).toBe(true);
+      expect(await harness.isSaveButtonDisabled()).toBe(true);
+    });
+
+    it('disables Save Settings button when form control value is edited back to initial snapshot value', async () => {
+      const {fixture, component, harness} = await setupComponent();
+
+      await harness.setRendererUrlValue('http://updated-renderer-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+
+      await harness.setRendererUrlValue('http://resolved-url.com');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+
+      expect(component.hasUnsavedChanges()).toBe(false);
+      expect(component.isSaveDisabled()).toBe(true);
+      expect(await harness.isSaveButtonDisabled()).toBe(true);
+    });
+
+    it('disables Save Settings button after saving values containing leading or trailing whitespace', async () => {
+      const {fixture, component, harness} = await setupComponent();
+      vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      await harness.setRendererUrlValue('http://updated-renderer-url.com  ');
+      await new Promise(resolve => queueMicrotask(resolve));
+      fixture.detectChanges();
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+
+      await component.saveSettings();
+      fixture.detectChanges();
+
+      expect(component.settingsForm.controls.rendererUrl.value).toBe(
+        'http://updated-renderer-url.com',
+      );
+      expect(component.hasUnsavedChanges()).toBe(false);
+      expect(component.isSaveDisabled()).toBe(true);
+      expect(await harness.isSaveButtonDisabled()).toBe(true);
     });
   });
 });

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -19,7 +19,7 @@ import {PlatformLocation} from '@angular/common';
 import {Settings} from './settings';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {locationAssign} from 'safevalues/dom';
-import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {StartupResolution, ProfileConfig} from '../../shell/startup-resolution/startup-resolution';
 import {describe, it, expect, beforeEach, afterEach, vi, Mock} from 'vitest';
 import {
   HostCommunication,
@@ -37,7 +37,10 @@ import {
 } from '../app-config-provider/app-config-provider';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {SettingsHarness} from './test/settings.harness';
-import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
+import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
+import {SettingsService} from '../settings-service/settings.service';
 
 vi.mock('safevalues/dom', () => {
   return {
@@ -49,10 +52,17 @@ describe('Settings', () => {
   let mockPlatformLocation: {
     getBaseHrefFromDOM: Mock<() => string | null>;
   };
+  let mockProfiles: WritableSignal<Record<string, ProfileConfig>>;
+  let mockSelectedProfileId: WritableSignal<string | null>;
+  let mockActiveProfile: WritableSignal<ProfileConfig | null>;
   let mockStartupResolution: {
     getResolvedRendererUrl: Mock<() => string | null>;
     isThirdPartyEnvironment: Mock<() => boolean>;
     isContextLocked: Mock<() => boolean>;
+    profiles: Signal<Record<string, ProfileConfig>>;
+    selectedProfileId: Signal<string | null>;
+    activeProfile: Signal<ProfileConfig | null>;
+    setSelectedProfileId: Mock<(id: string | null) => void>;
   };
   let mockLatestEnvelope: WritableSignal<MessageEnvelope | null>;
   let mockIsHandshakeInProgress: WritableSignal<boolean>;
@@ -78,16 +88,34 @@ describe('Settings', () => {
     purgeGeminiApiKey: Mock<() => void>;
   };
 
+  let mockSecureStorage: {
+    getCredential: Mock<() => Promise<string | null>>;
+  };
+
   beforeEach(() => {
     localStorage.clear();
     TestBed.resetTestingModule();
+    mockSecureStorage = {
+      getCredential: vi.fn().mockResolvedValue(null),
+    };
     mockPlatformLocation = {
       getBaseHrefFromDOM: vi.fn().mockReturnValue('/composer/pr/44/'),
     };
+    mockProfiles = signal<Record<string, ProfileConfig>>({});
+    mockSelectedProfileId = signal<string | null>(null);
+    mockActiveProfile = signal<ProfileConfig | null>(null);
+
     mockStartupResolution = {
       getResolvedRendererUrl: vi.fn().mockReturnValue('http://resolved-url.com'),
       isThirdPartyEnvironment: vi.fn().mockReturnValue(false),
       isContextLocked: vi.fn().mockReturnValue(false),
+      profiles: mockProfiles.asReadonly(),
+      selectedProfileId: mockSelectedProfileId.asReadonly(),
+      activeProfile: mockActiveProfile.asReadonly(),
+      setSelectedProfileId: vi.fn((id: string | null) => {
+        mockSelectedProfileId.set(id);
+        mockActiveProfile.set(id ? mockProfiles()[id] || null : null);
+      }),
     };
     mockLatestEnvelope = signal<MessageEnvelope | null>(null);
     mockIsHandshakeInProgress = signal<boolean>(false);
@@ -123,7 +151,7 @@ describe('Settings', () => {
         mockGeminiApiKey.set(key);
       }),
       setApiKeyFromConfig: vi.fn().mockImplementation((key: string) => {
-        mockIsApiKeyProvidedByConfig.set(true);
+        mockIsApiKeyProvidedByConfig.set(!!key);
         mockGeminiApiKey.set(key);
       }),
       setForcedAuthMode: vi.fn().mockImplementation((mode: AuthType) => {
@@ -172,7 +200,9 @@ describe('Settings', () => {
           provide: PlatformLocation,
           useValue: mockPlatformLocation,
         },
+        {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
         {provide: IS_1P_AUTH_ENABLED, useValue: enable1PAuth},
+        SettingsService,
       ],
     }).compileComponents();
 
@@ -387,6 +417,7 @@ describe('Settings', () => {
             },
           },
           {provide: IS_1P_AUTH_ENABLED, useValue: true},
+          {provide: CONFIG_URL, useValue: '/config.json'},
         ],
       }).compileComponents();
 
@@ -396,10 +427,10 @@ describe('Settings', () => {
       const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SettingsHarness);
 
       expect(component.isThirdParty()).toBe(true);
-      expect(await harness.getFormSectionsCount()).toBe(3);
+      expect(await harness.getFormSectionsCount()).toBe(4);
 
       const sections = await harness.getFormSectionsCount();
-      expect(sections).toBe(3);
+      expect(sections).toBe(4);
     } finally {
       localStorage.removeItem('a2ui_composer_force_3p');
     }
@@ -679,6 +710,150 @@ describe('Settings', () => {
       await harness.clickApiKeyToggleBtn();
       expect(component.hideApiKey()).toBe(false);
       expect(await harness.getApiKeyInputType()).toBe('text');
+    });
+
+    it('locks rendererUrl and apiKey form controls when active profile disallows overrides', async () => {
+      mockActiveProfile.set({
+        displayName: 'Locked Profile',
+        rendererUrl: 'http://locked-server.com',
+        allowOverrides: false,
+      });
+
+      const {component} = await setupComponent();
+
+      expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
+      expect(component.isLocked()).toBe(true);
+    });
+
+    it('invokes selectProfile on settings service when onProfileSelected is triggered', async () => {
+      const {component} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile').mockResolvedValue();
+
+      component.settingsForm.controls.apiKey.markAsDirty();
+      await component.onProfileSelected('dev');
+
+      expect(selectSpy).toHaveBeenCalledWith('dev');
+      expect(component.settingsForm.controls.apiKey.pristine).toBe(true);
+    });
+
+    it('clears active profile selection when rendererUrl form control value is modified', async () => {
+      mockSelectedProfileId.set('dev');
+      mockActiveProfile.set({
+        displayName: 'Development',
+        rendererUrl: 'http://localhost:3000',
+        allowOverrides: true,
+      });
+
+      const {component, harness} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
+
+      await harness.setRendererUrlValue('http://custom-renderer-url.com');
+
+      expect(selectSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('preserves profile selection when rendererUrl form control value matches active profile URL', async () => {
+      mockSelectedProfileId.set('dev');
+      mockActiveProfile.set({
+        displayName: 'Development',
+        rendererUrl: 'http://localhost:3000',
+        allowOverrides: true,
+      });
+
+      const {component} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
+
+      component.settingsForm.controls.rendererUrl.setValue('http://localhost:3000');
+
+      expect(selectSpy).not.toHaveBeenCalledWith(null);
+    });
+
+    it('resets allowOverrides lock state and enables rendererUrl and apiKey form controls when selecting Custom profile in 3P mode', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockActiveProfile.set({
+        displayName: 'Locked Profile',
+        rendererUrl: 'http://locked-server.com',
+        allowOverrides: false,
+      });
+      const {fixture, component} = await setupComponent();
+
+      expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
+
+      component.settingsForm.controls.apiKey.markAsDirty();
+      await component.onProfileSelected(null);
+      fixture.detectChanges();
+
+      expect(component.isLocked()).toBe(false);
+      expect(component.settingsForm.controls.rendererUrl.enabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.enabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.pristine).toBe(true);
+    });
+
+    it('keeps apiKey control disabled in 1P mode when selecting Custom profile', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(false);
+      mockActiveProfile.set({
+        displayName: 'Locked Profile',
+        rendererUrl: 'http://locked-server.com',
+        allowOverrides: false,
+      });
+      const {fixture, component} = await setupComponent();
+
+      expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
+
+      component.settingsForm.controls.apiKey.markAsDirty();
+      await component.onProfileSelected(null);
+      fixture.detectChanges();
+
+      expect(component.isLocked()).toBe(false);
+      expect(component.settingsForm.controls.rendererUrl.enabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
+      expect(component.settingsForm.controls.apiKey.pristine).toBe(true);
+    });
+
+    it('clears rendererUrl form control to empty string when switching to Custom profile', async () => {
+      mockRendererUrl.set('http://locked-server.com');
+      const {fixture, component} = await setupComponent();
+
+      expect(component.settingsForm.controls.rendererUrl.value).toBe('http://locked-server.com');
+
+      await component.onProfileSelected(null);
+      fixture.detectChanges();
+
+      expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('');
+      expect(component.settingsForm.controls.rendererUrl.value).toBe('');
+    });
+
+    it('populates saved personal API key into apiKey form control when switching to Custom profile in 3P mode', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockSecureStorage.getCredential.mockResolvedValue('saved-personal-api-key');
+      const {fixture, component} = await setupComponent();
+
+      await component.onProfileSelected(null);
+      fixture.detectChanges();
+
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+      expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
+        SecureCredentialsKey.GEMINI_API_KEY,
+      );
+      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('saved-personal-api-key');
+      expect(component.settingsForm.controls.apiKey.value).toBe('saved-personal-api-key');
+    });
+
+    it('resets apiKey form control to empty string when no personal key was saved in 3P mode', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockSecureStorage.getCredential.mockResolvedValue(null);
+      mockGeminiApiKey.set('old-config-key');
+      const {fixture, component} = await setupComponent();
+
+      await component.onProfileSelected(null);
+      fixture.detectChanges();
+
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('');
+      expect(component.settingsForm.controls.apiKey.value).toBe('');
     });
   });
 });

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -24,6 +24,7 @@ import {
   Signal,
   WritableSignal,
 } from '@angular/core';
+import {takeUntilDestroyed, toSignal} from '@angular/core/rxjs-interop';
 import {NonNullableFormBuilder, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -88,6 +89,11 @@ export class Settings implements OnInit {
   readonly saveErrorMessage: WritableSignal<string | null> = signal(null);
   readonly isSaving: WritableSignal<boolean> = signal(false);
 
+  private readonly initialProfileId: WritableSignal<string | null> = signal<string | null>(null);
+  private readonly initialForceThirdPartyAuth: WritableSignal<boolean> = signal<boolean>(false);
+  private readonly initialRendererUrl: WritableSignal<string> = signal<string>('');
+  private readonly initialApiKey: WritableSignal<string> = signal<string>('');
+
   readonly bridgeConnected: Signal<boolean> = computed(
     () => this.hostCommunication.latestEnvelope() !== null,
   );
@@ -111,6 +117,22 @@ export class Settings implements OnInit {
     apiKey: [''],
   });
 
+  private readonly formEvents = toSignal(this.settingsForm.events);
+
+  readonly hasUnsavedChanges: Signal<boolean> = computed(() => {
+    this.formEvents();
+    const profileChanged = this.settingsService.selectedProfileId() !== this.initialProfileId();
+    const authChanged = this.forceThirdPartyAuth() !== this.initialForceThirdPartyAuth();
+    const urlChanged = this.settingsForm.controls.rendererUrl.value !== this.initialRendererUrl();
+    const apiKeyChanged = this.settingsForm.controls.apiKey.value !== this.initialApiKey();
+    return profileChanged || authChanged || urlChanged || apiKeyChanged;
+  });
+
+  readonly isSaveDisabled: Signal<boolean> = computed(() => {
+    this.formEvents();
+    return this.isSaving() || this.settingsForm.invalid || !this.hasUnsavedChanges();
+  });
+
   constructor() {
     effect(() => {
       const currentKey = this.configProvider.geminiApiKey();
@@ -128,7 +150,7 @@ export class Settings implements OnInit {
       }
     });
 
-    this.settingsForm.controls.rendererUrl.valueChanges.subscribe(() => {
+    this.settingsForm.controls.rendererUrl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
       if (this.settingsForm.controls.rendererUrl.dirty) {
         queueMicrotask(() => {
           const selectedId = this.settingsService.selectedProfileId();
@@ -176,19 +198,40 @@ export class Settings implements OnInit {
       this.settingsForm.controls.rendererUrl.disable();
     }
     this.configureApiKeyControl(is3P);
+
+    const url = this.configProvider.rendererUrl();
+    if (
+      !this.settingsForm.controls.rendererUrl.dirty &&
+      url !== this.settingsForm.controls.rendererUrl.value
+    ) {
+      this.settingsForm.controls.rendererUrl.setValue(url, {emitEvent: false});
+    }
+
+    const key = this.configProvider.geminiApiKey();
+    if (
+      !this.settingsForm.controls.apiKey.dirty &&
+      key !== this.settingsForm.controls.apiKey.value
+    ) {
+      this.settingsForm.controls.apiKey.setValue(key, {emitEvent: false});
+    }
+
+    this.initialProfileId.set(this.settingsService.selectedProfileId());
+    this.initialForceThirdPartyAuth.set(this.forceThirdPartyAuth());
+    this.initialRendererUrl.set(this.configProvider.rendererUrl());
+    this.initialApiKey.set(this.configProvider.geminiApiKey());
   }
 
   async onProfileSelected(profileId: string | null): Promise<void> {
     await this.settingsService.selectProfile(profileId);
     if (profileId === null) {
-      this.settingsForm.controls.rendererUrl.setValue('', {emitEvent: false});
+      this.settingsForm.controls.rendererUrl.setValue('');
       this.settingsForm.controls.rendererUrl.enable({emitEvent: false});
       this.configureApiKeyControl(this.isThirdParty());
       this.settingsForm.controls.rendererUrl.markAsPristine();
     } else {
       const active = this.settingsService.activeProfile();
       if (active?.rendererUrl !== undefined) {
-        this.settingsForm.controls.rendererUrl.setValue(active.rendererUrl, {emitEvent: false});
+        this.settingsForm.controls.rendererUrl.setValue(active.rendererUrl);
         this.settingsForm.controls.rendererUrl.markAsPristine();
       }
     }
@@ -223,6 +266,10 @@ export class Settings implements OnInit {
   }
 
   async saveSettings(): Promise<void> {
+    if (this.isSaving() || !this.hasUnsavedChanges()) {
+      return;
+    }
+
     this.saveErrorMessage.set(null);
 
     if (this.settingsForm.invalid) {
@@ -234,20 +281,29 @@ export class Settings implements OnInit {
     this.isSaving.set(true);
     try {
       const values = this.settingsForm.getRawValue();
+      const trimmedUrl = values.rendererUrl.trim();
+      const trimmedApiKey = values.apiKey.trim();
 
       if (this.isThirdParty()) {
         if (!this.isLocked()) {
-          this.configProvider.setRendererUrl(values.rendererUrl.trim());
+          this.configProvider.setRendererUrl(trimmedUrl);
         }
         if (!this.isApiKeyProvidedByConfig()) {
-          await this.configProvider.setGeminiApiKey(values.apiKey.trim());
+          await this.configProvider.setGeminiApiKey(trimmedApiKey);
         }
       } else {
         await this.configProvider.purgeGeminiApiKey();
         if (!this.isLocked()) {
-          this.configProvider.setRendererUrl(values.rendererUrl.trim());
+          this.configProvider.setRendererUrl(trimmedUrl);
         }
       }
+      this.settingsForm.controls.rendererUrl.setValue(trimmedUrl, {emitEvent: false});
+      this.settingsForm.controls.apiKey.setValue(trimmedApiKey, {emitEvent: false});
+      this.initialProfileId.set(this.settingsService.selectedProfileId());
+      this.initialForceThirdPartyAuth.set(this.forceThirdPartyAuth());
+      this.initialRendererUrl.set(this.configProvider.rendererUrl());
+      this.initialApiKey.set(this.configProvider.geminiApiKey());
+      this.settingsForm.markAsPristine();
 
       this.reloadWindow();
     } catch (err) {

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -38,6 +38,8 @@ import {HostCommunication} from '../../shell/host-communication/host-communicati
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {AppConfigProvider, AuthType} from '../app-config-provider/app-config-provider';
 import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {ProfileSelector} from '../profile-selector/profile-selector';
+import {SettingsService} from '../settings-service/settings.service';
 import {locationAssign} from 'safevalues/dom';
 
 /**
@@ -56,6 +58,7 @@ import {locationAssign} from 'safevalues/dom';
     MatCardModule,
     MatChipsModule,
     MatSlideToggleModule,
+    ProfileSelector,
   ],
   templateUrl: './settings.ng.html',
   styleUrl: './settings.scss',
@@ -68,6 +71,7 @@ export class Settings implements OnInit {
   private readonly hostCommunication = inject(HostCommunication);
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly configProvider = inject(AppConfigProvider);
+  protected readonly settingsService = inject(SettingsService);
 
   protected readonly is1PAuthEnabled = inject(IS_1P_AUTH_ENABLED);
 
@@ -124,13 +128,43 @@ export class Settings implements OnInit {
       }
     });
 
+    this.settingsForm.controls.rendererUrl.valueChanges.subscribe(() => {
+      if (this.settingsForm.controls.rendererUrl.dirty) {
+        queueMicrotask(() => {
+          const selectedId = this.settingsService.selectedProfileId();
+          if (selectedId !== null) {
+            const currentVal = this.settingsForm.controls.rendererUrl.value;
+            const activeUrl = this.settingsService.activeProfile()?.rendererUrl;
+            if (currentVal !== activeUrl) {
+              this.settingsService.selectProfile(null).catch(err => {
+                console.warn('Failed to reset selected profile on renderer URL edit:', err);
+              });
+            }
+          }
+        });
+      }
+    });
+
     effect(() => {
+      const allowOverrides = this.settingsService.allowOverrides();
+      const startupLocked = this.startupResolution.isContextLocked();
+      const isUrlLocked = !allowOverrides || startupLocked;
+      this.isLocked.set(isUrlLocked);
+
+      const rendererControl = this.settingsForm.controls.rendererUrl;
+      if (isUrlLocked) {
+        rendererControl.disable({emitEvent: false});
+      } else {
+        rendererControl.enable({emitEvent: false});
+      }
+
       this.configureApiKeyControl(this.isThirdParty());
     });
   }
 
   ngOnInit(): void {
-    const locked = this.startupResolution.isContextLocked();
+    const allowOverrides = this.settingsService.allowOverrides();
+    const locked = !allowOverrides || this.startupResolution.isContextLocked();
     this.isLocked.set(locked);
 
     const is3P = this.startupResolution.isThirdPartyEnvironment();
@@ -141,10 +175,39 @@ export class Settings implements OnInit {
     if (locked) {
       this.settingsForm.controls.rendererUrl.disable();
     }
+    this.configureApiKeyControl(is3P);
+  }
+
+  async onProfileSelected(profileId: string | null): Promise<void> {
+    await this.settingsService.selectProfile(profileId);
+    if (profileId === null) {
+      this.settingsForm.controls.rendererUrl.setValue('', {emitEvent: false});
+      this.settingsForm.controls.rendererUrl.enable({emitEvent: false});
+      this.configureApiKeyControl(this.isThirdParty());
+      this.settingsForm.controls.rendererUrl.markAsPristine();
+    } else {
+      const active = this.settingsService.activeProfile();
+      if (active?.rendererUrl !== undefined) {
+        this.settingsForm.controls.rendererUrl.setValue(active.rendererUrl, {emitEvent: false});
+        this.settingsForm.controls.rendererUrl.markAsPristine();
+      }
+    }
+    this.settingsForm.controls.apiKey.markAsPristine();
   }
 
   private configureApiKeyControl(is3P: boolean): void {
     const apiKeyControl = this.settingsForm.controls.apiKey;
+    const allowOverrides = this.settingsService.allowOverrides();
+
+    if (!allowOverrides) {
+      apiKeyControl.clearValidators();
+      if (apiKeyControl.enabled) {
+        apiKeyControl.disable({emitEvent: false});
+      }
+      apiKeyControl.updateValueAndValidity({emitEvent: false});
+      return;
+    }
+
     if (is3P && !this.isApiKeyProvidedByConfig()) {
       apiKeyControl.setValidators([Validators.pattern(/\S/)]);
       if (apiKeyControl.disabled) {

--- a/shell/src/app/settings/settings-view/test/settings.harness.ts
+++ b/shell/src/app/settings/settings-view/test/settings.harness.ts
@@ -39,6 +39,9 @@ export class SettingsHarness extends ComponentHarness {
   protected getApiKeyToggleBtn = this.locatorForOptional(
     MatButtonHarness.with({selector: 'button[matSuffix]'}),
   );
+  protected getSaveButton = this.locatorFor(
+    MatButtonHarness.with({text: /Save Settings|Saving\.\.\./}),
+  );
 
   protected getBridgeBadge = this.locatorFor('.bridge-badge');
   protected getCatalogBadge = this.locatorFor('.catalog-badge');
@@ -191,5 +194,10 @@ export class SettingsHarness extends ComponentHarness {
   async getSaveErrorBannerText(): Promise<string | null> {
     const node = await this.getSaveErrorBanner();
     return node ? node.text() : null;
+  }
+
+  async isSaveButtonDisabled(): Promise<boolean> {
+    const btn = await this.getSaveButton();
+    return btn.isDisabled();
   }
 }

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -305,6 +305,22 @@ describe('StartupResolution Task 2.6', () => {
     expect(url).toBe('http://query:3000/');
   });
 
+  it('resets profiles signal state on resolveStartupConfiguration call', async () => {
+    mockFetchConfig({
+      profiles: {
+        dev: {rendererUrl: 'http://dev:3000'},
+      },
+    });
+    await service.resolveStartupConfiguration();
+    expect(service.profiles()).toEqual({
+      dev: {rendererUrl: 'http://dev:3000'},
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+    await service.resolveStartupConfiguration();
+    expect(service.profiles()).toEqual({});
+  });
+
   it('returns window search and hostname safely', () => {
     expect(typeof service.getWindowSearch()).toBe('string');
     expect(typeof service.getWindowHostname()).toBe('string');
@@ -380,7 +396,7 @@ describe('StartupResolution Task 2.6', () => {
 
       await service.resolveStartupConfiguration();
 
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
     });
 
     it('locks context strictly when allowOverrides is false regardless of apiKey presence', async () => {
@@ -425,6 +441,34 @@ describe('StartupResolution Task 2.6', () => {
     expect(service.getResolvedRendererUrl()).toBeNull();
   });
 
+  it('updates activeProfileKey signal alongside selectedProfileId signal when setSelectedProfileId is called', () => {
+    service.setSelectedProfileId('custom-profile');
+    expect(service.selectedProfileId()).toBe('custom-profile');
+    expect(service.activeProfileKey()).toBe('custom-profile');
+
+    service.setSelectedProfileId(null);
+    expect(service.selectedProfileId()).toBeNull();
+    expect(service.activeProfileKey()).toBeNull();
+  });
+
+  it('resets isLockedContext to false when setSelectedProfileId(null) is called after being locked', async () => {
+    mockFetchConfig({
+      profiles: {
+        locked: {
+          rendererUrl: 'http://locked-server:3000',
+          allowOverrides: false,
+        },
+      },
+    });
+
+    vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=locked');
+    await service.resolveStartupConfiguration();
+    expect(service.isContextLocked()).toBe(true);
+
+    service.setSelectedProfileId(null);
+    expect(service.isContextLocked()).toBe(false);
+  });
+
   describe('profile resolution', () => {
     it('loads default profile when no profile query parameter is provided', async () => {
       mockFetchConfig({
@@ -438,6 +482,57 @@ describe('StartupResolution Task 2.6', () => {
 
       const url = await service.resolveStartupConfiguration();
       expect(url).toBe('http://default-renderer:3000');
+    });
+
+    it('returns null when selectedProfileId is null or not found in profiles without falling back to default', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://default-renderer:3000',
+          },
+          dev: {
+            rendererUrl: 'http://dev-renderer:3000',
+          },
+        },
+      });
+
+      await service.resolveStartupConfiguration();
+      service.setSelectedProfileId(null);
+      expect(service.activeProfile()).toBeNull();
+
+      service.setSelectedProfileId('nonexistent');
+      expect(service.activeProfile()).toBeNull();
+    });
+
+    it('stores and retrieves profile configs containing optional displayName', async () => {
+      mockFetchConfig({
+        profiles: {
+          default: {
+            rendererUrl: 'http://base:3000',
+            displayName: 'Default Profile',
+          },
+          dev: {
+            rendererUrl: 'http://dev:3000',
+            displayName: 'Development Environment',
+          },
+        },
+      });
+
+      await service.resolveStartupConfiguration();
+      expect(service.profiles()).toEqual({
+        default: {
+          rendererUrl: 'http://base:3000',
+          displayName: 'Default Profile',
+        },
+        dev: {
+          rendererUrl: 'http://dev:3000',
+          displayName: 'Development Environment',
+        },
+      });
+      expect(service.activeProfile()).toEqual({
+        rendererUrl: 'http://base:3000',
+        displayName: 'Default Profile',
+      });
     });
 
     it('loads named profile directly when valid profile param is supplied', async () => {
@@ -477,7 +572,7 @@ describe('StartupResolution Task 2.6', () => {
 
       const url = await service.resolveStartupConfiguration();
       expect(url).toBe('http://dev-renderer:3000');
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(service.isContextLocked()).toBe(false);
     });
 
@@ -653,6 +748,130 @@ describe('StartupResolution Task 2.6', () => {
       url = await service.resolveStartupConfiguration();
       expect(url).toBe('http://default-renderer:3000');
     });
+
+    describe('4-tier profile resolution priority chain', () => {
+      it('resolves initialProfile as tier 1 priority when present in static config profiles', async () => {
+        mockFetchConfig({
+          initialProfile: 'initProfile',
+          profiles: {
+            initProfile: {
+              rendererUrl: 'http://init-renderer:3000',
+            },
+            queryProfile: {
+              rendererUrl: 'http://query-renderer:3000',
+            },
+            default: {
+              rendererUrl: 'http://default-renderer:3000',
+            },
+          },
+        });
+
+        vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=queryProfile');
+        localStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'queryProfile');
+
+        const url = await service.resolveStartupConfiguration();
+        expect(url).toBe('http://init-renderer:3000');
+        expect(service.selectedProfileId()).toBe('initProfile');
+        expect(service.activeProfileKey()).toBe('initProfile');
+      });
+
+      it('logs warning when initialProfile is defined but not present in profiles', () => {
+        const warnSpy = vi.spyOn(console, 'warn');
+        const result = service.selectActiveProfileKey({
+          initialProfile: 'missingProfile',
+          profiles: {
+            default: {rendererUrl: 'http://default:3000'},
+          },
+        });
+
+        expect(result).toBe('default');
+        expect(warnSpy).toHaveBeenCalledWith(
+          "Initial profile 'missingProfile' not found in static configuration.",
+        );
+      });
+
+      it('resolves query profile as tier 2 priority when initialProfile is absent or invalid', async () => {
+        mockFetchConfig({
+          initialProfile: 'nonExistentProfile',
+          profiles: {
+            queryProfile: {
+              rendererUrl: 'http://query-renderer:3000',
+            },
+            storageProfile: {
+              rendererUrl: 'http://storage-renderer:3000',
+            },
+            default: {
+              rendererUrl: 'http://default-renderer:3000',
+            },
+          },
+        });
+
+        vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=queryProfile');
+        localStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'storageProfile');
+
+        const url = await service.resolveStartupConfiguration();
+        expect(url).toBe('http://query-renderer:3000');
+        expect(service.selectedProfileId()).toBe('queryProfile');
+        expect(service.activeProfileKey()).toBe('queryProfile');
+      });
+
+      it('resolves local storage selected profile as tier 3 priority when initialProfile and query profile are absent or invalid', async () => {
+        mockFetchConfig({
+          profiles: {
+            storageProfile: {
+              rendererUrl: 'http://storage-renderer:3000',
+            },
+            default: {
+              rendererUrl: 'http://default-renderer:3000',
+            },
+          },
+        });
+
+        vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=nonExistentProfile');
+        localStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'storageProfile');
+
+        const url = await service.resolveStartupConfiguration();
+        expect(url).toBe('http://storage-renderer:3000');
+        expect(service.selectedProfileId()).toBe('storageProfile');
+        expect(service.activeProfileKey()).toBe('storageProfile');
+      });
+
+      it('resolves default profile as tier 4 priority when higher priority candidates are absent or invalid', async () => {
+        mockFetchConfig({
+          profiles: {
+            default: {
+              rendererUrl: 'http://default-renderer:3000',
+            },
+          },
+        });
+
+        vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=nonExistentProfile');
+        localStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'nonExistentStorage');
+
+        const url = await service.resolveStartupConfiguration();
+        expect(url).toBe('http://default-renderer:3000');
+        expect(service.selectedProfileId()).toBe('default');
+        expect(service.activeProfileKey()).toBe('default');
+      });
+
+      it('returns null when no candidate profile key exists in static config profiles', async () => {
+        mockFetchConfig({
+          profiles: {
+            customProfile: {
+              rendererUrl: 'http://custom-renderer:3000',
+            },
+          },
+        });
+
+        vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=nonExistentProfile');
+        localStorage.setItem(LocalStorageKey.SELECTED_PROFILE, 'nonExistentStorage');
+
+        const url = await service.resolveStartupConfiguration();
+        expect(url).toBeNull();
+        expect(service.selectedProfileId()).toBeNull();
+        expect(service.activeProfileKey()).toBeNull();
+      });
+    });
   });
 
   describe('apiKey resolution', () => {
@@ -710,7 +929,7 @@ describe('StartupResolution Task 2.6', () => {
       vi.spyOn(service, 'getWindowSearch').mockReturnValue('?profile=dev');
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
@@ -726,7 +945,7 @@ describe('StartupResolution Task 2.6', () => {
       });
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
@@ -741,7 +960,7 @@ describe('StartupResolution Task 2.6', () => {
       });
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
 
@@ -757,7 +976,7 @@ describe('StartupResolution Task 2.6', () => {
       });
 
       await service.resolveStartupConfiguration();
-      expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalled();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
   });

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import {Injectable, Injector, inject, signal} from '@angular/core';
+import {Injectable, Injector, computed, inject, signal} from '@angular/core';
 import {QueryParser} from '../query-parser/query-parser';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
+import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
 
 /**
  * Represents the configuration options for an application profile,
@@ -29,9 +31,11 @@ export declare interface ProfileConfig {
   rendererUrl?: string;
   apiKey?: string;
   allowOverrides?: boolean;
+  displayName?: string;
 }
 
 export declare interface AppConfig {
+  initialProfile?: string;
   profiles?: Record<string, ProfileConfig>;
 }
 
@@ -49,8 +53,43 @@ export class StartupResolution {
   private readonly is1PAuthEnabled = inject(IS_1P_AUTH_ENABLED);
   private readonly configUrl = inject(CONFIG_URL);
 
+  private readonly _profiles = signal<Record<string, ProfileConfig>>({});
+  private readonly _selectedProfileId = signal<string | null>(null);
+  private readonly _activeProfileKey = signal<string | null>(null);
+
   readonly resolvedUrl = this._resolvedUrl.asReadonly();
   readonly isLockedContext = this._isLockedContext.asReadonly();
+  readonly profiles = this._profiles.asReadonly();
+  readonly selectedProfileId = this._selectedProfileId.asReadonly();
+  readonly activeProfileKey = this._activeProfileKey.asReadonly();
+  readonly activeProfile = computed<ProfileConfig | null>(() => {
+    const profiles = this._profiles();
+    const selectedId = this._selectedProfileId();
+    if (selectedId && Object.prototype.hasOwnProperty.call(profiles, selectedId)) {
+      return profiles[selectedId];
+    }
+    return null;
+  });
+
+  setSelectedProfileId(profileId: string | null): void {
+    this._selectedProfileId.set(profileId);
+    this._activeProfileKey.set(profileId);
+    if (!profileId) {
+      this._isLockedContext.set(false);
+    } else {
+      const profiles = this._profiles();
+      const profile = profiles[profileId];
+      if (profile && profile.allowOverrides === false && profile.rendererUrl) {
+        this._isLockedContext.set(true);
+      } else {
+        this._isLockedContext.set(false);
+      }
+    }
+  }
+
+  getActiveProfileKey(): string | null {
+    return this._activeProfileKey();
+  }
 
   /**
    * Resolves the startup configuration for the application.
@@ -64,6 +103,9 @@ export class StartupResolution {
   async resolveStartupConfiguration(): Promise<string | null> {
     this._isLockedContext.set(false);
     this._resolvedUrl.set(null);
+    this._selectedProfileId.set(null);
+    this._activeProfileKey.set(null);
+    this._profiles.set({});
 
     const staticConfig = await this.fetchStaticConfig();
     if (staticConfig) {
@@ -108,61 +150,107 @@ export class StartupResolution {
   }
 
   /**
-   * Selects the active profile configuration based on static config and query parameters.
+   * Selects the active profile key based on 4-tier resolution priority.
    */
-  private selectActiveProfile(staticConfig: AppConfig): ProfileConfig {
+  selectActiveProfileKey(staticConfig: AppConfig): string | null {
     const profiles = staticConfig.profiles;
     if (!profiles || typeof profiles !== 'object' || Array.isArray(profiles)) {
-      return {};
+      return null;
     }
 
-    let defaultProfile: ProfileConfig = {};
-    if (Object.prototype.hasOwnProperty.call(profiles, 'default')) {
-      const dp = profiles['default'];
-      if (dp && typeof dp === 'object' && !Array.isArray(dp)) {
-        defaultProfile = dp;
+    const isValidProfile = (key: string): boolean => {
+      if (!Object.prototype.hasOwnProperty.call(profiles, key)) {
+        return false;
       }
+      const p = profiles[key];
+      return p !== null && typeof p === 'object' && !Array.isArray(p);
+    };
+
+    if (staticConfig.initialProfile) {
+      if (isValidProfile(staticConfig.initialProfile)) {
+        return staticConfig.initialProfile;
+      }
+      console.warn(
+        `Initial profile '${staticConfig.initialProfile}' not found in static configuration.`,
+      );
     }
 
     const requestedProfile = QueryParser.parseProfileName(this.getWindowSearch());
-    let activeProfile: ProfileConfig = defaultProfile;
-
     if (requestedProfile) {
-      let foundProfile: ProfileConfig | null = null;
-      if (Object.prototype.hasOwnProperty.call(profiles, requestedProfile)) {
-        const profileConfig = profiles[requestedProfile];
-        if (profileConfig && typeof profileConfig === 'object' && !Array.isArray(profileConfig)) {
-          foundProfile = profileConfig;
-        }
+      if (isValidProfile(requestedProfile)) {
+        return requestedProfile;
       }
-
-      if (foundProfile) {
-        activeProfile = foundProfile;
-      } else {
-        console.warn(`Requested profile '${requestedProfile}' not found in static configuration.`);
-      }
+      console.warn(`Requested profile '${requestedProfile}' not found in static configuration.`);
     }
 
-    return activeProfile;
+    const storedProfile = this.localStorageInteractions.getItem(LocalStorageKey.SELECTED_PROFILE);
+    if (storedProfile && isValidProfile(storedProfile)) {
+      return storedProfile;
+    }
+
+    if (isValidProfile('default')) {
+      return 'default';
+    }
+
+    return null;
   }
 
-  private applyApiKeyFromProfile(profile: ProfileConfig): void {
+  private async applyApiKeyFromProfile(profile: ProfileConfig): Promise<void> {
     const rawApiKey = profile.apiKey;
     const apiKey = typeof rawApiKey === 'string' ? rawApiKey.trim() : '';
-    if (apiKey) {
-      try {
-        const configProvider = this.injector.get(AppConfigProvider);
+
+    try {
+      const configProvider = this.injector.get(AppConfigProvider);
+      if (apiKey) {
         configProvider.setApiKeyFromConfig(apiKey);
-      } catch (err) {
-        console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
+      } else {
+        configProvider.setApiKeyFromConfig('');
+        try {
+          const secureStorage = this.injector.get(SecureCredentialsStorage, null);
+          if (secureStorage) {
+            const storedKey = await secureStorage.getCredential(
+              SecureCredentialsKey.GEMINI_API_KEY,
+            );
+            if (storedKey && storedKey.trim()) {
+              await configProvider.setGeminiApiKey(storedKey.trim());
+            }
+          }
+        } catch (err) {
+          console.warn(
+            'Failed to retrieve credential from SecureCredentialsStorage during startup resolution:',
+            err,
+          );
+        }
       }
+    } catch (err) {
+      console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
     }
   }
 
   private async processStaticConfig(staticConfig: AppConfig): Promise<boolean> {
     console.log('Using static config.');
-    const activeProfile = this.selectActiveProfile(staticConfig);
-    this.applyApiKeyFromProfile(activeProfile);
+    if (
+      staticConfig.profiles &&
+      typeof staticConfig.profiles === 'object' &&
+      !Array.isArray(staticConfig.profiles)
+    ) {
+      this._profiles.set(staticConfig.profiles);
+    }
+
+    const resolvedKey = this.selectActiveProfileKey(staticConfig);
+    this._selectedProfileId.set(resolvedKey);
+    this._activeProfileKey.set(resolvedKey);
+
+    const profiles = staticConfig.profiles;
+    let activeProfile: ProfileConfig = {};
+    if (resolvedKey && profiles && Object.prototype.hasOwnProperty.call(profiles, resolvedKey)) {
+      const p = profiles[resolvedKey];
+      if (p && typeof p === 'object' && !Array.isArray(p)) {
+        activeProfile = p;
+      }
+    }
+
+    await this.applyApiKeyFromProfile(activeProfile);
 
     if (activeProfile.rendererUrl) {
       this._resolvedUrl.set(activeProfile.rendererUrl);

--- a/shell/src/app/storage/models/local-storage-keys.ts
+++ b/shell/src/app/storage/models/local-storage-keys.ts
@@ -36,4 +36,6 @@ export enum LocalStorageKey {
   DOCKVIEW_LAYOUT = 'composer_dockview_layout',
   /** Key for persisting the user's theme selection (light vs dark). */
   THEME_PREFERENCE = 'a2ui_composer_theme_preference',
+  /** Key for persisting the active profile selection. */
+  SELECTED_PROFILE = 'a2ui_composer_selected_profile',
 }


### PR DESCRIPTION
# Description

Add a drop-down for users to select from the profiles defined in config.json. If there is no config.json, or no profiles are defined, the drop-down will be disabled.

When the user selects a profile, the "Renderer Application URL" will be updated and, if the profile includes an API key, it too will be updated. 

See: https://screencast.googleplex.com/cast/NTgyNjkwMTUyMzMwMDM1MnwzNjIyZTVhMy1hMA

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
