### PR TITLE
CSS fix to display component gallery content.

### DIFF
--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -41,12 +41,12 @@
   overflow: hidden;
   display: flex;
 
-  ::ng-deep > .mat-drawer {
+  > ::ng-deep .mat-drawer {
     position: relative !important;
     transform: none !important;
   }
 
-  ::ng-deep > .mat-drawer-content {
+  > ::ng-deep .mat-drawer-content {
     flex: 1;
     min-width: 0;
     margin-left: 0 !important;

--- a/shell/src/app/shell/composer-shell/composer-shell.scss
+++ b/shell/src/app/shell/composer-shell/composer-shell.scss
@@ -41,12 +41,12 @@
   overflow: hidden;
   display: flex;
 
-  ::ng-deep .mat-drawer {
+  ::ng-deep > .mat-drawer {
     position: relative !important;
     transform: none !important;
   }
 
-  ::ng-deep .mat-drawer-content {
+  ::ng-deep > .mat-drawer-content {
     flex: 1;
     min-width: 0;
     margin-left: 0 !important;


### PR DESCRIPTION
# Description

The `::ng-deep` was forcing itself all the way down the component tree. This limits its effects to just the direct children.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
