### PR TITLE
fix: prevent code from showing up in the chat panel

### DIFF
--- a/shell/src/app/chat/chat-panel/chat-panel.spec.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.spec.ts
@@ -216,6 +216,183 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     },
   );
 
+  it('classifies turns wrapped in ```jsonl code blocks as layout snapshots and calculates component counts', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content:
+          '```jsonl\n{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id":"b1","component":"Button"}, {"id":"b2","component":"Button"}]}}\n```',
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toBe('Received 2 A2UI JSON Components');
+  });
+
+  it('classifies turns containing preamble text and ```jsonl code blocks as layout snapshots', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content:
+          'Here is your layout:\n```jsonl\n{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id":"b1","component":"Button"}]}}\n```',
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toBe('Received 1 A2UI JSON Components');
+  });
+
+  it('does not classify plain text messages mentioning "version" as layout snapshots', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content: 'what version of python are you using?',
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('human-text');
+    expect(bubbles[0]).toBe('what version of python are you using?');
+  });
+
+  it('does not classify non-JSON bracketed prose as layout snapshots', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content: 'user note [draft]',
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('human-text');
+    expect(bubbles[0]).toBe('user note [draft]');
+  });
+
+  it('classifies formatted multi-line JSON arrays as layout snapshots and calculates component counts', async () => {
+    const formattedArray = JSON.stringify(
+      [
+        {version: 'v0.9', createSurface: {surfaceId: 's1', catalogId: 'test'}},
+        {
+          version: 'v0.9',
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {id: 'c1', component: 'Button'},
+              {id: 'c2', component: 'Input'},
+            ],
+          },
+        },
+      ],
+      null,
+      2,
+    );
+
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content: formattedArray,
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toBe('Received 3 A2UI JSON Components');
+  });
+
+  it('renders snapshot badges instead of text bubbles for streaming partial JSON arrays during streaming', async () => {
+    chatStateMock.isProgrammaticStreamActive.set(true);
+    const partialArray = '[\n  {\n    "version": "v0.9",\n    "createSurface": {"surfaceId": "s1"}';
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content: partialArray,
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toContain('Received');
+    expect(bubbles[0]).toContain('A2UI JSON Components');
+    expect(bubbles[0]).not.toContain(partialArray);
+  });
+
+  it('strips XML/HTML thinking tags and streaming pulse indicators when classifying layout snapshots', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content: `<thought>Thinking process...</thought>\n{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id":"b1","component":"Button"}]}} ●●●`,
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toBe('Received 1 A2UI JSON Components');
+  });
+
+  it('ignores prose text brackets when extracting JSON content for snapshot classification', async () => {
+    const historyMocks: LlmMessage[] = [
+      {
+        role: MessageRole.USER,
+        content:
+          'Here is the layout [note]: {"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id":"b1","component":"Button"}]}}',
+      },
+    ];
+
+    chatStateMock.chatHistory.set(historyMocks);
+    fixture.detectChanges();
+
+    const bubbles = await harness.getBubblesText();
+    const bubbleTypes = await harness.getBubbleTypes();
+
+    expect(bubbles.length).toBe(1);
+    expect(bubbleTypes[0]).toBe('layout-snapshot');
+    expect(bubbles[0]).toBe('Received 1 A2UI JSON Components');
+  });
+
   it(
     'bubbles and renders connection gateway diagnostic errors inside ' +
       'standard dialogue alerts log',
@@ -666,6 +843,32 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
 
       expect(captureSpy).not.toHaveBeenCalled();
       expect(submitSpy).toHaveBeenCalledWith('Add button', []);
+    });
+  });
+
+  describe('getComponentCount', () => {
+    it('counts components in JSON array of commands', () => {
+      const component = fixture.componentInstance;
+      const payload = '[{"createSurface": {}}, {"updateComponents": {"components": [{}, {}]}}]';
+      expect(component.getComponentCount(payload)).toBe(3);
+    });
+
+    it('counts components in multi-line JSONL commands', () => {
+      const component = fixture.componentInstance;
+      const payload = '{"createSurface": {}}\n{"updateComponents": {"components": [{}]}}';
+      expect(component.getComponentCount(payload)).toBe(2);
+    });
+
+    it('returns 0 for non-layout text or invalid JSON', () => {
+      const component = fixture.componentInstance;
+      expect(component.getComponentCount('invalid text')).toBe(0);
+    });
+
+    it('ignores single-line parse failures in multi-line JSONL and counts valid lines', () => {
+      const component = fixture.componentInstance;
+      const payload =
+        '{"createSurface": {}}\n{corrupted\n{"updateComponents": {"components": [{}, {}]}}';
+      expect(component.getComponentCount(payload)).toBe(3);
     });
   });
 });

--- a/shell/src/app/chat/chat-panel/chat-panel.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.ts
@@ -62,6 +62,7 @@ import {StartupResolution} from '../../shell/startup-resolution/startup-resoluti
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {RenderA2uiItem} from 'a2ui-bridge';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
+import {ChatCleaner} from '../chat-service/chat-cleaner';
 
 interface AttachedFile extends Attachment {
   readonly previewUrl?: string;
@@ -92,6 +93,7 @@ interface AttachedFile extends Attachment {
 })
 export class ChatPanel {
   private readonly chatCoordinator = inject(ChatCoordinator);
+  private readonly chatCleaner = inject(ChatCleaner);
   private readonly chatState = inject(ChatState);
   private readonly dialog = inject(MatDialog);
   private readonly catalogManagement = inject(CatalogManagement);
@@ -150,7 +152,7 @@ export class ChatPanel {
       .chatHistory()
       .filter(m => m.role !== MessageRole.SYSTEM)
       .map(m => {
-        const isSnapshot = this.isLayoutSnapshot(m.content);
+        const isSnapshot = this.chatCleaner.isLayoutSnapshot(m.content);
         if (isSnapshot) {
           return {
             ...m,
@@ -251,7 +253,7 @@ export class ChatPanel {
    */
   protected getBubbleClass(message: LlmMessage): string {
     if (message.role === MessageRole.USER) {
-      return this.isLayoutSnapshot(message.content)
+      return this.chatCleaner.isLayoutSnapshot(message.content)
         ? 'bubble-user bubble-layout'
         : 'bubble-user bubble-text';
     }
@@ -265,20 +267,11 @@ export class ChatPanel {
   }
 
   /**
-   * Distinguishes user prompts from visual snap dispatch code snippets.
+   * Counts the number of A2UI components declared in the given text.
    */
-  protected isLayoutSnapshot(content: string): boolean {
-    const trimmed = content.trim();
-    return trimmed.startsWith('{"version"') || (trimmed.startsWith('[') && trimmed.endsWith(']'));
-  }
-
-  /**
-   * Dynamically parses visual turn snap contents and counts number of
-   * components declared inside.
-   */
-  protected getComponentCount(content: string): number {
+  getComponentCount(text: string): number {
     try {
-      const trimmed = content.trim();
+      const trimmed = this.chatCleaner.cleanPayload(text);
       const parsedArray = tryParseJsonArray(trimmed);
       if (parsedArray) {
         return parsedArray.reduce(
@@ -303,7 +296,7 @@ export class ChatPanel {
       }
       return count;
     } catch (e) {
-      // Swallows parse errors dynamically in visuals badge check loops
+      // Swallows parse errors dynamically
     }
     return 0;
   }

--- a/shell/src/app/chat/chat-service/chat-cleaner.spec.ts
+++ b/shell/src/app/chat/chat-service/chat-cleaner.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {describe, it, expect, beforeEach} from 'vitest';
+import {ChatCleaner} from './chat-cleaner';
+
+describe('ChatCleaner', () => {
+  let service: ChatCleaner;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ChatCleaner],
+    });
+    service = TestBed.inject(ChatCleaner);
+  });
+
+  describe('PULSE_INDICATOR & appendPulse / stripPulse', () => {
+    it('exposes readonly PULSE_INDICATOR constant', () => {
+      expect(service.PULSE_INDICATOR).toBe('●●●');
+    });
+
+    it('appends pulse indicator to text', () => {
+      expect(service.appendPulse('hello')).toBe('hello ●●●');
+    });
+
+    it('appends pulse indicator to empty string', () => {
+      expect(service.appendPulse('')).toBe(' ●●●');
+    });
+
+    it('strips trailing pulse indicator and whitespace from text', () => {
+      expect(service.stripPulse('hello world ●●●')).toBe('hello world');
+    });
+
+    it('returns text unchanged when no pulse indicator is present', () => {
+      expect(service.stripPulse('hello world')).toBe('hello world');
+    });
+
+    it('strips pulse indicator when string contains only pulse indicator', () => {
+      expect(service.stripPulse('●●●')).toBe('');
+    });
+  });
+
+  describe('stripThinkingTags', () => {
+    it('strips thought, thinking, and reasoning XML tags from text', () => {
+      expect(service.stripThinkingTags('<thought>internal</thought>{"version": "v0.9"}')).toBe(
+        '{"version": "v0.9"}',
+      );
+      expect(service.stripThinkingTags('<thinking>test</thinking>foo')).toBe('foo');
+      expect(service.stripThinkingTags('<reasoning>why</reasoning>bar')).toBe('bar');
+    });
+
+    it('handles unclosed thinking tags', () => {
+      expect(service.stripThinkingTags('<thought>unclosed')).toBe('');
+    });
+
+    it('returns text unchanged when no thinking tags are present', () => {
+      expect(service.stripThinkingTags('normal text')).toBe('normal text');
+    });
+  });
+
+  describe('extractCodeFences', () => {
+    it('extracts content from markdown code fences and sets hasFences to true', () => {
+      const result = service.extractCodeFences('```json\n{"version": "v0.9"}\n```');
+      expect(result.hasFences).toBe(true);
+      expect(result.extracted).toBe('{"version": "v0.9"}');
+    });
+
+    it('extracts and joins multiple markdown code fence blocks', () => {
+      const result = service.extractCodeFences(
+        '```json\n{"a": 1}\n```\nmiddle\n```json\n{"b": 2}\n```',
+      );
+      expect(result.hasFences).toBe(true);
+      expect(result.extracted).toBe('{"a": 1}\n{"b": 2}');
+    });
+
+    it('returns original text and sets hasFences to false when no code fences are present', () => {
+      const result = service.extractCodeFences('no fences here');
+      expect(result.hasFences).toBe(false);
+      expect(result.extracted).toBe('no fences here');
+    });
+  });
+
+  describe('cleanPayload', () => {
+    it('cleans payload by stripping pulse, thinking tags, and markdown code fences', () => {
+      const input = '<thought>hmm</thought> ```json\n{"version": "v0.9"}\n``` ●●●';
+      expect(service.cleanPayload(input)).toBe('{"version": "v0.9"}');
+    });
+
+    it('isolates opening curly brace of actual JSON content without truncating prose brackets', () => {
+      const input =
+        'Here is a list [with items] in prose, then layout:\n{"version": "v0.9", "createSurface": {}}';
+      expect(service.cleanPayload(input)).toBe('{"version": "v0.9", "createSurface": {}}');
+    });
+
+    it('isolates JSON array start without truncating prose brackets', () => {
+      const input = 'Prose [bracket] before array: [{"version": "v0.9"}]';
+      expect(service.cleanPayload(input)).toBe('[{"version": "v0.9"}]');
+    });
+
+    it('returns cleaned text when content is not JSON', () => {
+      expect(service.cleanPayload('hello world')).toBe('hello world');
+    });
+  });
+
+  describe('isLayoutSnapshot', () => {
+    it('returns true for object layout with version string', () => {
+      expect(service.isLayoutSnapshot('{"version": "v0.9", "createSurface": {}}')).toBe(true);
+    });
+
+    it('returns true for layout with prose and version string', () => {
+      expect(service.isLayoutSnapshot('Layout: {"version": "v0.9", "createSurface": {}}')).toBe(
+        true,
+      );
+    });
+
+    it('returns true for valid JSON array', () => {
+      expect(service.isLayoutSnapshot('[{"version": "v0.9"}]')).toBe(true);
+    });
+
+    it('classifies streaming partial JSON arrays containing version or surface commands as layout snapshots', () => {
+      expect(service.isLayoutSnapshot('[\n  {\n    "version": "v0.9"')).toBe(true);
+      expect(service.isLayoutSnapshot('[\n  {\n    "createSurface": {"surfaceId": "s1"}')).toBe(
+        true,
+      );
+      expect(service.isLayoutSnapshot('[\n  {\n    "updateComponents": {"surfaceId": "s1"}')).toBe(
+        true,
+      );
+    });
+
+    it('returns false for arbitrary non-layout text', () => {
+      expect(service.isLayoutSnapshot('hello world')).toBe(false);
+    });
+
+    it('returns false for object without version string', () => {
+      expect(service.isLayoutSnapshot('{"foo": "bar"}')).toBe(false);
+    });
+  });
+});

--- a/shell/src/app/chat/chat-service/chat-cleaner.spec.ts
+++ b/shell/src/app/chat/chat-service/chat-cleaner.spec.ts
@@ -111,6 +111,12 @@ describe('ChatCleaner', () => {
       expect(service.cleanPayload(input)).toBe('[{"version": "v0.9"}]');
     });
 
+    it('isolates partial JSON array start with A2UI keys when prose contains brackets', () => {
+      const input =
+        'Prose [bracket] before streaming array: [\n  {\n    "createSurface": {"surfaceId": "s1"}';
+      expect(service.cleanPayload(input)).toBe('[\n  {\n    "createSurface": {"surfaceId": "s1"}');
+    });
+
     it('returns cleaned text when content is not JSON', () => {
       expect(service.cleanPayload('hello world')).toBe('hello world');
     });

--- a/shell/src/app/chat/chat-service/chat-cleaner.ts
+++ b/shell/src/app/chat/chat-service/chat-cleaner.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core';
+import {tryParseJsonArray} from '../../utils/json';
+
+const MD_FENCE_REGEX = /```(?:jsonl?|jsonlines|a2ui|html|xml)?\s*([\s\S]*?)\s*```/gi;
+const TAG_REGEX = /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi;
+const PULSE_INDICATOR_REGEX = /\s*●●●\s*$/g;
+
+/**
+ * Service for cleaning and processing raw LLM chat messages, including
+ * pulse indicator handling, thinking tag stripping, markdown fence extraction,
+ * and layout snapshot detection.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ChatCleaner {
+  readonly PULSE_INDICATOR = '●●●';
+
+  /**
+   * Appends the streaming pulse indicator to the given text.
+   */
+  appendPulse(text: string): string {
+    return `${text} ${this.PULSE_INDICATOR}`;
+  }
+
+  /**
+   * Strips trailing streaming pulse indicators and surrounding whitespace.
+   */
+  stripPulse(text: string): string {
+    PULSE_INDICATOR_REGEX.lastIndex = 0;
+    return text.replace(PULSE_INDICATOR_REGEX, '').trim();
+  }
+
+  /**
+   * Strips XML/HTML thinking tags from the given text.
+   */
+  stripThinkingTags(text: string): string {
+    TAG_REGEX.lastIndex = 0;
+    return text.replace(TAG_REGEX, '').trim();
+  }
+
+  /**
+   * Extracts content from markdown code fences if present.
+   */
+  extractCodeFences(text: string): {extracted: string; hasFences: boolean} {
+    MD_FENCE_REGEX.lastIndex = 0;
+    const matches = Array.from(text.matchAll(MD_FENCE_REGEX));
+    if (matches.length > 0) {
+      return {
+        extracted: matches.map(m => m[1].trim()).join('\n'),
+        hasFences: true,
+      };
+    }
+    return {
+      extracted: text.trim(),
+      hasFences: false,
+    };
+  }
+
+  /**
+   * Cleans payload by stripping pulse indicators, XML/HTML thinking tags, and
+   * markdown code fences, and isolates JSON start `{` / `[` without truncating
+   * prose brackets.
+   */
+  cleanPayload(text: string): string {
+    let result = this.stripPulse(text);
+    result = this.stripThinkingTags(result);
+    const fenceResult = this.extractCodeFences(result);
+    result = fenceResult.extracted;
+
+    if (!result.startsWith('{') && !result.startsWith('[')) {
+      const jsonMatches = Array.from(result.matchAll(/[\{\[]/g));
+      for (const match of jsonMatches) {
+        if (match.index !== undefined && match.index >= 0) {
+          const candidate = result.substring(match.index).trim();
+          if (
+            (candidate.startsWith('{') && candidate.includes('"version"')) ||
+            tryParseJsonArray(candidate) !== null
+          ) {
+            result = candidate;
+            break;
+          }
+        }
+      }
+    }
+
+    return result.trim();
+  }
+
+  /**
+   * Determines if the given text represents an A2UI layout snapshot.
+   */
+  isLayoutSnapshot(text: string): boolean {
+    const trimmed = this.cleanPayload(text);
+    return (
+      trimmed.startsWith('{"version"') ||
+      (trimmed.startsWith('{') && trimmed.includes('"version"')) ||
+      (trimmed.startsWith('[') &&
+        (trimmed.includes('"version"') ||
+          trimmed.includes('"createSurface"') ||
+          trimmed.includes('"updateComponents"'))) ||
+      tryParseJsonArray(trimmed) !== null
+    );
+  }
+}

--- a/shell/src/app/chat/chat-service/chat-cleaner.ts
+++ b/shell/src/app/chat/chat-service/chat-cleaner.ts
@@ -91,6 +91,11 @@ export class ChatCleaner {
           const candidate = result.substring(match.index).trim();
           if (
             (candidate.startsWith('{') && candidate.includes('"version"')) ||
+            (candidate.startsWith('[') &&
+              /^\[\s*[\{\"]/.test(candidate) &&
+              (candidate.includes('"version"') ||
+                candidate.includes('"createSurface"') ||
+                candidate.includes('"updateComponents"'))) ||
             tryParseJsonArray(candidate) !== null
           ) {
             result = candidate;

--- a/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
@@ -697,6 +697,211 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
 
       expect(service.pipelineStatus()).toBe(PipelineStatus.FAILED);
     });
+
+    it('parses layout payloads wrapped in ```jsonl code blocks', async () => {
+      const jsonlOutput =
+        '```jsonl\n' +
+        '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([jsonlOutput]);
+        return {contentStream, complete: Promise.resolve(jsonlOutput)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {},
+      });
+
+      await service.submitPrompt('test prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+    });
+
+    it('parses multiple ```jsonl code blocks in a single response', async () => {
+      const jsonlOutput =
+        '```jsonl\n' +
+        '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}\n' +
+        '```\n' +
+        'Some intermediate text\n' +
+        '```jsonl\n' +
+        '{"version": "v0.9", "updateComponents": {"surfaceId": "s1", "components": [{"id": "c1", "component": "TextField"}]}}\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([jsonlOutput]);
+        return {contentStream, complete: Promise.resolve(jsonlOutput)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {
+          TextField: {},
+        },
+      });
+
+      await service.submitPrompt('test prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(2);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+      expect(parsed[1].updateComponents.components[0].component).toBe('TextField');
+    });
+
+    it('parses layout payloads wrapped in ```jsonlines code blocks', async () => {
+      const jsonlinesOutput =
+        '```jsonlines\n' +
+        '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([jsonlinesOutput]);
+        return {contentStream, complete: Promise.resolve(jsonlinesOutput)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {},
+      });
+
+      await service.submitPrompt('test prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+    });
+
+    it('normalizes chatHistory content by stripping markdown code wrappers and preamble text after parsing', async () => {
+      const rawPayload =
+        'Here is your layout:\n' +
+        '```jsonl\n' +
+        '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([rawPayload]);
+        return {contentStream, complete: Promise.resolve(rawPayload)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {},
+      });
+
+      await service.submitPrompt('test prompt');
+
+      const history = chatStateMock.chatHistory();
+      const modelTurn = history[history.length - 1];
+      expect(modelTurn.role).toBe(MessageRole.MODEL);
+      expect(modelTurn.content).not.toContain('Here is your layout:');
+      expect(modelTurn.content).not.toContain('```');
+      expect(modelTurn.content).toContain('"createSurface"');
+    });
+
+    it('parses formatted multi-line JSON arrays successfully', async () => {
+      const formattedJsonArrayOutput = JSON.stringify(
+        [
+          {version: 'v0.9', createSurface: {surfaceId: 's1', catalogId: 'test'}},
+          {
+            version: 'v0.9',
+            updateComponents: {
+              surfaceId: 's1',
+              components: [{id: 'c1', component: 'TextField'}],
+            },
+          },
+        ],
+        null,
+        2,
+      );
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([formattedJsonArrayOutput]);
+        return {contentStream, complete: Promise.resolve(formattedJsonArrayOutput)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {
+          TextField: {},
+        },
+      });
+
+      await service.submitPrompt('multi-line array test prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(2);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+      expect(parsed[1].updateComponents.components[0].component).toBe('TextField');
+    });
+
+    it('strips XML/HTML thinking tags and code fences before parsing JSON', async () => {
+      const payloadWithTags =
+        '<thought>Designing the surface layout...</thought>\n' +
+        '```a2ui\n' +
+        '[{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}]\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([payloadWithTags]);
+        return {contentStream, complete: Promise.resolve(payloadWithTags)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {},
+      });
+
+      await service.submitPrompt('XML tags test prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+    });
+
+    it('strips XML thinking tags containing example code fences before layout parsing', async () => {
+      const payloadWithExampleFenceInThought =
+        '<thought>Here is an example code fence:\n```json\n{"example": true}\n```\n</thought>\n' +
+        '```jsonl\n' +
+        '{"version": "v0.9", "createSurface": {"surfaceId": "s1", "catalogId": "test"}}\n' +
+        '```';
+
+      llmClientMock.chatStream = vi.fn(async (): Promise<LlmStreamResponse> => {
+        const contentStream = createMockStream([payloadWithExampleFenceInThought]);
+        return {contentStream, complete: Promise.resolve(payloadWithExampleFenceInThought)};
+      });
+
+      catalogManagementMock.activeCatalog.set({
+        catalogId: 'test',
+        components: {},
+      });
+
+      await service.submitPrompt('Example fence in thought prompt');
+
+      const committedOutput = stateSyncMock.commitLayoutFromLlm.mock.calls[0][0];
+      const parsed = JSON.parse(committedOutput);
+
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].createSurface.surfaceId).toBe('s1');
+    });
   });
 
   describe('sanitizeComponentObject', () => {

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -15,7 +15,8 @@
  */
 
 import {Injectable, inject, computed, effect, untracked} from '@angular/core';
-import {formatJson} from '../../utils/json';
+import {formatJson, tryParseJsonArray} from '../../utils/json';
+import {ChatCleaner} from './chat-cleaner';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {
   LlmMessage,
@@ -48,6 +49,7 @@ export class ChatCoordinator {
   private readonly stateSync = inject(StateSync);
   private readonly chatState = inject(ChatState);
   private readonly llmClient = inject(LlmClient);
+  private readonly chatCleaner = inject(ChatCleaner);
 
   /** Reactively mapped rendering pipeline execution milestones. */
   readonly pipelineStatus = this.chatState.pipelineStatus;
@@ -151,7 +153,7 @@ export class ChatCoordinator {
       ...h,
       {
         role: MessageRole.MODEL,
-        content: ' ●●●',
+        content: this.chatCleaner.appendPulse(''),
       },
     ]);
 
@@ -186,7 +188,7 @@ export class ChatCoordinator {
           if (updated[lastIdx]?.role === MessageRole.MODEL) {
             updated[lastIdx] = {
               role: MessageRole.MODEL,
-              content: accumulatedRawText + ' ●●●',
+              content: this.chatCleaner.appendPulse(accumulatedRawText),
               thinking: accumulatedThinking,
             };
           }
@@ -295,6 +297,19 @@ export class ChatCoordinator {
       // editor draft
       const finalLayoutText = formatJson(parsedBlocks);
 
+      // Update latest MODEL turn message in history to normalized JSON string
+      this.chatState.updateChatHistory(history => {
+        const updated = [...history];
+        const lastIdx = updated.length - 1;
+        if (updated[lastIdx]?.role === MessageRole.MODEL) {
+          updated[lastIdx] = {
+            ...updated[lastIdx],
+            content: finalLayoutText,
+          };
+        }
+        return updated;
+      });
+
       // Commit layout synchronously to editor viewport before releasing
       // lockout
       this.stateSync.commitLayoutFromLlm(finalLayoutText);
@@ -314,14 +329,26 @@ export class ChatCoordinator {
    * repairs.
    */
   private parseAndHealJsonLines(text: string): unknown[] {
-    let content = text.trim();
-
-    // Markdown Extraction: If output has Markdown wrappers, extract content
-    const mdJsonRegex = /```json\s*([\s\S]*?)\s*```/;
-    const match = content.match(mdJsonRegex);
-    if (match && match[1]) {
+    if (this.chatCleaner.extractCodeFences(text).hasFences) {
       this.chatState.setPipelineStatus(PipelineStatus.HEALING);
-      content = match[1].trim();
+    }
+    const content = this.chatCleaner.cleanPayload(text);
+
+    // Attempt full JSON parsing before line-by-line processing
+    const parsedArray = tryParseJsonArray(content);
+    if (parsedArray) {
+      return parsedArray;
+    }
+    try {
+      const parsedSingle = JSON.parse(content);
+      if (Array.isArray(parsedSingle)) {
+        return parsedSingle;
+      }
+      if (parsedSingle && typeof parsedSingle === 'object') {
+        return [parsedSingle];
+      }
+    } catch {
+      // Continue to line-by-line healing
     }
 
     const lines = content

--- a/shell/src/app/chat/llm-client/llm-client.spec.ts
+++ b/shell/src/app/chat/llm-client/llm-client.spec.ts
@@ -37,6 +37,7 @@ interface MockGenAiConfig {
 
 interface MockPart {
   text?: string;
+  thought?: boolean;
   inlineData?: {
     mimeType: string;
     data: string;
@@ -59,7 +60,12 @@ interface MockGenerateContentParameters {
 }
 
 interface MockGenerateContentResponse {
-  text: string;
+  text?: string;
+  candidates?: Array<{
+    content?: {
+      parts?: MockPart[];
+    };
+  }>;
 }
 
 const mockConstructor = vi.fn<(config: MockGenAiConfig) => void>();
@@ -445,6 +451,121 @@ describe('LlmClient Facade and Standalone Provider Integration', () => {
 
       const finalSynchronizerValue = await streamResponse.complete;
       expect(finalSynchronizerValue).toBe('Starting streaming handshakes.');
+    });
+
+    it('separates thought parts from content parts during stream processing', async () => {
+      const mockChunksList: MockGenerateContentResponse[] = [
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {thought: true, text: 'Thinking about the user request...'},
+                  {thought: false, text: 'Hello, '},
+                ],
+              },
+            },
+          ],
+        },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [{thought: false, text: 'world!'}],
+              },
+            },
+          ],
+        },
+      ];
+
+      const mockAsyncStream = {
+        async *[Symbol.asyncIterator]() {
+          for (const chunk of mockChunksList) {
+            yield chunk;
+          }
+        },
+      };
+
+      mockGenerateContentStream.mockResolvedValue(mockAsyncStream);
+
+      const streamResponse = await client.chatStream([{role: MessageRole.USER, content: 'Hi'}]);
+
+      const collectedChunks: LlmResponse[] = [];
+      for await (const chunk of streamResponse.contentStream) {
+        collectedChunks.push(chunk);
+      }
+
+      expect(collectedChunks).toEqual([
+        {content: 'Hello, ', thinking: 'Thinking about the user request...', isComplete: false},
+        {content: 'world!', thinking: '', isComplete: false},
+      ]);
+
+      const completeText = await streamResponse.complete;
+      expect(completeText).toBe('Hello, world!');
+    });
+
+    it('extracts XML/HTML thinking tags from chunk text into thinking property and strips tags from content', async () => {
+      const mockChunksList: MockGenerateContentResponse[] = [
+        {text: '<thought>Internal thought here</thought>Response text '},
+        {text: '<thinking>Another thought</thinking>more response'},
+      ];
+
+      const mockAsyncStream = {
+        async *[Symbol.asyncIterator]() {
+          for (const chunk of mockChunksList) {
+            yield chunk;
+          }
+        },
+      };
+
+      mockGenerateContentStream.mockResolvedValue(mockAsyncStream);
+
+      const streamResponse = await client.chatStream([{role: MessageRole.USER, content: 'Hi'}]);
+
+      const collectedChunks: LlmResponse[] = [];
+      for await (const chunk of streamResponse.contentStream) {
+        collectedChunks.push(chunk);
+      }
+
+      expect(collectedChunks).toEqual([
+        {content: 'Response text ', thinking: 'Internal thought here', isComplete: false},
+        {content: 'more response', thinking: 'Another thought', isComplete: false},
+      ]);
+
+      const completeText = await streamResponse.complete;
+      expect(completeText).toBe('Response text more response');
+    });
+
+    it('handles multi-chunk streaming XML thinking tags split across chunks', async () => {
+      const mockChunksList: MockGenerateContentResponse[] = [
+        {text: '<thought>thinking...'},
+        {text: 'more thoughts</thought>main content'},
+      ];
+
+      const mockAsyncStream = {
+        async *[Symbol.asyncIterator]() {
+          for (const chunk of mockChunksList) {
+            yield chunk;
+          }
+        },
+      };
+
+      mockGenerateContentStream.mockResolvedValue(mockAsyncStream);
+
+      const streamResponse = await client.chatStream([{role: MessageRole.USER, content: 'Hi'}]);
+
+      const collectedChunks: LlmResponse[] = [];
+      for await (const chunk of streamResponse.contentStream) {
+        collectedChunks.push(chunk);
+      }
+
+      expect(collectedChunks).toEqual([
+        {content: '', thinking: 'thinking...', isComplete: false},
+        {content: 'main content', thinking: 'more thoughts', isComplete: false},
+      ]);
+
+      const completeText = await streamResponse.complete;
+      expect(completeText).toBe('main content');
     });
 
     it('resolves dynamic streaming complete promise without consuming stream', async () => {

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -254,10 +254,10 @@ export class Standalone3pLlmClient extends LlmClient {
     return {chunkContent, nativeThoughtVal};
   }
 
-  private extractXmlThoughts(
-    accumulatedRawText: string,
-    state: StreamProcessingState,
-  ): {cleanText: string; totalExtractedThinking: string} {
+  private extractXmlThoughts(accumulatedRawText: string): {
+    cleanText: string;
+    totalExtractedThinking: string;
+  } {
     let totalExtractedThinking = '';
     TAG_REGEX.lastIndex = 0;
     const cleanText = accumulatedRawText.replace(TAG_REGEX, (_, _tag, innerText) => {
@@ -283,7 +283,6 @@ export class Standalone3pLlmClient extends LlmClient {
 
         const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(
           state.accumulatedRawText,
-          state,
         );
 
         const contentVal = cleanText.slice(state.emittedContentLength);

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -30,6 +30,7 @@ import {
   GenerateContentParameters,
   Part,
   GenerateContentConfig,
+  GenerateContentResponse,
 } from '@google/genai';
 
 const TAG_REGEX = /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi;
@@ -228,7 +229,10 @@ export class Standalone3pLlmClient extends LlmClient {
     };
   }
 
-  private parseChunkParts(chunk: any): {chunkContent: string; nativeThoughtVal: string} {
+  private parseChunkParts(chunk: GenerateContentResponse): {
+    chunkContent: string;
+    nativeThoughtVal: string;
+  } {
     let chunkContent = '';
     let nativeThoughtVal = '';
     const parts = chunk.candidates?.[0]?.content?.parts;
@@ -264,7 +268,7 @@ export class Standalone3pLlmClient extends LlmClient {
   }
 
   private async consumeStream(
-    responseStream: any,
+    responseStream: AsyncIterable<GenerateContentResponse>,
     state: StreamProcessingState,
     buffer: LlmResponse[],
     notify: () => void,

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -32,6 +32,17 @@ import {
   GenerateContentConfig,
 } from '@google/genai';
 
+const TAG_REGEX = /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi;
+
+interface StreamProcessingState {
+  accumulatedText: string;
+  accumulatedRawText: string;
+  emittedContentLength: number;
+  emittedThinkingLength: number;
+  isDone: boolean;
+  streamError: unknown;
+}
+
 /**
  * Standard public endpoint authentication client utilizing user developer keys.
  * Implements a standalone third-party developer integration facade matching
@@ -133,30 +144,21 @@ export class Standalone3pLlmClient extends LlmClient {
       apiKey: apiKeyVal,
     });
 
-    const {systemInstruction, contents} = this.parseMessages(messages);
-
     const abortController = new AbortController();
-
-    const config: GenerateContentConfig = systemInstruction ? {systemInstruction} : {};
-    config.abortSignal = abortController.signal;
-    config.thinkingConfig = {
-      includeThoughts: true,
-      thinkingBudget: 1024,
-    };
-
-    const params: GenerateContentParameters = {
-      model: 'gemini-3.5-flash',
-      contents,
-      config,
-    };
+    const params = this.buildGenerateContentParams(messages, abortController.signal);
 
     // Instantiate response generator stream eagerly
     const responseStream = await ai.models.generateContentStream(params);
 
     const buffer: LlmResponse[] = [];
-    let accumulatedText = '';
-    let isDone = false;
-    let streamError: unknown = null;
+    const state: StreamProcessingState = {
+      accumulatedText: '',
+      accumulatedRawText: '',
+      emittedContentLength: 0,
+      emittedThinkingLength: 0,
+      isDone: false,
+      streamError: null,
+    };
     const listeners: (() => void)[] = [];
 
     let resolveComplete!: (val: string) => void;
@@ -175,65 +177,166 @@ export class Standalone3pLlmClient extends LlmClient {
     };
 
     // Eager background thread to pull chunks from standard SDK stream instantly
-    void (async () => {
-      try {
-        for await (const chunk of responseStream) {
-          const textVal = chunk.text || '';
-
-          let thoughtVal = '';
-          const parts = chunk.candidates?.[0]?.content?.parts;
-          if (parts) {
-            for (const part of parts) {
-              if (part.thought && part.text) {
-                thoughtVal += part.text;
-              }
-            }
-          }
-
-          accumulatedText += textVal;
-
-          buffer.push({content: textVal, thinking: thoughtVal, isComplete: false});
-          notifyListeners();
-        }
-        isDone = true;
-        resolveComplete(accumulatedText);
-        notifyListeners();
-      } catch (err: unknown) {
-        let finalErr = err;
-        if (err && typeof err === 'object' && 'name' in err && err.name === CANCEL_ERROR_NAME) {
-          finalErr = err;
-        }
-
-        if (
-          finalErr &&
-          typeof finalErr === 'object' &&
-          'name' in finalErr &&
-          finalErr.name === CANCEL_ERROR_NAME
-        ) {
-          isDone = true;
-          streamError = finalErr;
-          rejectComplete(finalErr);
-          notifyListeners();
-          return;
-        }
-        streamError = finalErr;
-        rejectComplete(finalErr);
-        notifyListeners();
-      }
-    })();
+    void this.consumeStream(
+      responseStream,
+      state,
+      buffer,
+      notifyListeners,
+      resolveComplete,
+      rejectComplete,
+    );
 
     // Independent pointer-safe AsyncIterable reader mapping
-    const contentStream: AsyncIterable<LlmResponse> = {
+    const contentStream = this.createContentStream(buffer, state, listeners);
+
+    return {
+      contentStream,
+      complete,
+      cancel: () => {
+        const cancelErr = new Error('Cancelled');
+        cancelErr.name = CANCEL_ERROR_NAME;
+        abortController.abort(cancelErr);
+      },
+    };
+  }
+
+  private buildGenerateContentConfig(
+    systemInstruction?: string,
+    abortSignal?: AbortSignal,
+  ): GenerateContentConfig {
+    const config: GenerateContentConfig = systemInstruction ? {systemInstruction} : {};
+    if (abortSignal) {
+      config.abortSignal = abortSignal;
+    }
+    config.thinkingConfig = {
+      includeThoughts: true,
+      thinkingBudget: 1024,
+    };
+    return config;
+  }
+
+  private buildGenerateContentParams(
+    messages: LlmMessage[],
+    abortSignal: AbortSignal,
+  ): GenerateContentParameters {
+    const {systemInstruction, contents} = this.parseMessages(messages);
+    const config = this.buildGenerateContentConfig(systemInstruction, abortSignal);
+    return {
+      model: 'gemini-3.5-flash',
+      contents,
+      config,
+    };
+  }
+
+  private parseChunkParts(chunk: any): {chunkContent: string; nativeThoughtVal: string} {
+    let chunkContent = '';
+    let nativeThoughtVal = '';
+    const parts = chunk.candidates?.[0]?.content?.parts;
+    if (parts && parts.length > 0) {
+      for (const part of parts) {
+        if (part.thought === true) {
+          if (part.text) {
+            nativeThoughtVal += part.text;
+          }
+        } else {
+          if (part.text) {
+            chunkContent += part.text;
+          }
+        }
+      }
+    } else {
+      chunkContent = chunk.text || '';
+    }
+    return {chunkContent, nativeThoughtVal};
+  }
+
+  private extractXmlThoughts(
+    accumulatedRawText: string,
+    state: StreamProcessingState,
+  ): {cleanText: string; totalExtractedThinking: string} {
+    let totalExtractedThinking = '';
+    TAG_REGEX.lastIndex = 0;
+    const cleanText = accumulatedRawText.replace(TAG_REGEX, (_, _tag, innerText) => {
+      totalExtractedThinking += innerText;
+      return '';
+    });
+    return {cleanText, totalExtractedThinking};
+  }
+
+  private async consumeStream(
+    responseStream: any,
+    state: StreamProcessingState,
+    buffer: LlmResponse[],
+    notify: () => void,
+    resolveComplete: (val: string) => void,
+    rejectComplete: (err: unknown) => void,
+  ): Promise<void> {
+    try {
+      for await (const chunk of responseStream) {
+        const {chunkContent, nativeThoughtVal} = this.parseChunkParts(chunk);
+
+        state.accumulatedRawText += chunkContent;
+
+        const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(
+          state.accumulatedRawText,
+          state,
+        );
+
+        const contentVal = cleanText.slice(state.emittedContentLength);
+        const tagThought = totalExtractedThinking.slice(state.emittedThinkingLength);
+        const thoughtVal = nativeThoughtVal + tagThought;
+
+        state.emittedContentLength = cleanText.length;
+        state.emittedThinkingLength = totalExtractedThinking.length;
+
+        state.accumulatedText += contentVal;
+
+        buffer.push({content: contentVal, thinking: thoughtVal, isComplete: false});
+        notify();
+      }
+      state.isDone = true;
+      resolveComplete(state.accumulatedText);
+      notify();
+    } catch (err: unknown) {
+      let finalErr = err;
+      if (err && typeof err === 'object' && 'name' in err && err.name === CANCEL_ERROR_NAME) {
+        finalErr = err;
+      }
+
+      if (
+        finalErr &&
+        typeof finalErr === 'object' &&
+        'name' in finalErr &&
+        finalErr.name === CANCEL_ERROR_NAME
+      ) {
+        state.isDone = true;
+        state.streamError = finalErr;
+        rejectComplete(finalErr);
+        notify();
+        return;
+      }
+      state.streamError = finalErr;
+      rejectComplete(finalErr);
+      notify();
+    }
+  }
+
+  private createContentStream(
+    buffer: LlmResponse[],
+    state: StreamProcessingState,
+    listeners: (() => void)[],
+  ): AsyncIterable<LlmResponse> {
+    return {
       [Symbol.asyncIterator]() {
         let localBufferIndex = 0;
         return {
           async next(): Promise<IteratorResult<LlmResponse>> {
             // Wait in-loop while buffer is exhausted and stream is active/errored
-            while (localBufferIndex >= buffer.length && !isDone && !streamError) {
+            while (localBufferIndex >= buffer.length && !state.isDone && !state.streamError) {
               await new Promise<void>((resolve, reject) => {
                 listeners.push(() => {
-                  if (streamError) {
-                    reject(streamError);
+                  if (state.streamError) {
+                    reject(state.streamError);
                   } else {
                     resolve();
                   }
@@ -242,8 +345,8 @@ export class Standalone3pLlmClient extends LlmClient {
             }
 
             // Throw connection exceptions immediately upon exhausting successful yields
-            if (localBufferIndex >= buffer.length && streamError) {
-              throw streamError;
+            if (localBufferIndex >= buffer.length && state.streamError) {
+              throw state.streamError;
             }
 
             // Yield buffered chunks
@@ -256,16 +359,6 @@ export class Standalone3pLlmClient extends LlmClient {
             return {value: undefined, done: true};
           },
         };
-      },
-    };
-
-    return {
-      contentStream,
-      complete,
-      cancel: () => {
-        const cancelErr = new Error('Cancelled');
-        cancelErr.name = CANCEL_ERROR_NAME;
-        abortController.abort(cancelErr);
       },
     };
   }


### PR DESCRIPTION
# Description

Create new ChatCleaner service to handle all the cleansing.

Strip markdown code fences and XML/HTML.

Separate thought candidate parts into thinking property in LLM client. Handle cross-chunk streaming XML/HTML thinking tags (<thought>, <thinking>, <reasoning>) and multi-line formatted JSON arrays. Prevent false-positive layout snapshot classification on non-JSON bracketed text.

Refactor Standalone3pLlmClient.chatStream into a high-level coordinator method delegating parameter construction, chunk part parsing, XML thought extraction, and stream consumption to private helper methods.

Recognize partial JSON arrays starting with '[' and containing A2UI keys ("version", "createSurface", or "updateComponents"). This prevents raw incomplete JSON text from displaying in the chat bubble during active LLM streaming.


## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
