### PR TITLE
fix(settings): defer profile selection persistence until save

### DIFF
--- a/shell/src/app/settings/profile-selector/test/profile-selector.harness.ts
+++ b/shell/src/app/settings/profile-selector/test/profile-selector.harness.ts
@@ -33,8 +33,7 @@ export class ProfileSelectorHarness extends ComponentHarness {
 
   async openSelect(): Promise<void> {
     const select = await this.getSelect();
-    const selectHost = await select.host();
-    await selectHost.click();
+    await select.open();
   }
 
   async getOptionsText(): Promise<string[]> {

--- a/shell/src/app/settings/settings-service/settings.service.ts
+++ b/shell/src/app/settings/settings-service/settings.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Injectable, Signal, computed, inject} from '@angular/core';
+import {computed, inject, Injectable, Signal} from '@angular/core';
 import {ProfileConfig, StartupResolution} from '../../shell/startup-resolution/startup-resolution';
 import {AppConfigProvider} from '../app-config-provider/app-config-provider';
 import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -25,7 +25,7 @@
           <h3>Configuration Profile</h3>
           <a2ui-composer-profile-selector
             [profiles]="settingsService.profiles()"
-            [selectedProfileId]="settingsService.selectedProfileId()"
+            [selectedProfileId]="draftSelectedProfileId()"
             (profileSelected)="onProfileSelected($event)"
           >
           </a2ui-composer-profile-selector>

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -18,16 +18,15 @@ import {TestBed} from '@angular/core/testing';
 import {PlatformLocation} from '@angular/common';
 import {Settings} from './settings';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
-import {locationAssign} from 'safevalues/dom';
-import {StartupResolution, ProfileConfig} from '../../shell/startup-resolution/startup-resolution';
-import {describe, it, expect, beforeEach, afterEach, vi, Mock} from 'vitest';
+import {ProfileConfig, StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {afterEach, beforeEach, describe, expect, it, Mock, vi} from 'vitest';
 import {
   HostCommunication,
   MessageEnvelope,
 } from '../../shell/host-communication/host-communication';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
 import {Catalog} from '../../storage/models/catalog-storage.model';
-import {signal, WritableSignal, Signal, computed} from '@angular/core';
+import {computed, Signal, signal, WritableSignal} from '@angular/core';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import {
   AppConfigProvider,
@@ -41,12 +40,16 @@ import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/env
 import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
 import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
 import {SettingsService} from '../settings-service/settings.service';
-
+import {ProfileSelectorHarness} from '../profile-selector/test/profile-selector.harness';
+import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {MatButtonHarness} from '@angular/material/button/testing';
 vi.mock('safevalues/dom', () => {
   return {
     locationAssign: vi.fn(),
   };
 });
+
+import {locationAssign} from 'safevalues/dom';
 
 describe('Settings', () => {
   let mockPlatformLocation: {
@@ -100,6 +103,18 @@ describe('Settings', () => {
     };
     mockPlatformLocation = {
       getBaseHrefFromDOM: vi.fn().mockReturnValue('/composer/pr/44/'),
+      onPopState: vi.fn().mockReturnValue(() => {}),
+      onHashChange: vi.fn().mockReturnValue(() => {}),
+      pathname: '/composer/pr/44/',
+      search: '',
+      hash: '',
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      forward: vi.fn(),
+      back: vi.fn(),
+      getState: vi.fn(),
+    } as unknown as {
+      getBaseHrefFromDOM: Mock<() => string | null>;
     };
     mockProfiles = signal<Record<string, ProfileConfig>>({});
     mockSelectedProfileId = signal<string | null>(null);
@@ -717,11 +732,14 @@ describe('Settings', () => {
     });
 
     it('locks rendererUrl and apiKey form controls when active profile disallows overrides', async () => {
-      mockActiveProfile.set({
-        displayName: 'Locked Profile',
-        rendererUrl: 'http://locked-server.com',
-        allowOverrides: false,
+      mockProfiles.set({
+        'locked-profile': {
+          displayName: 'Locked Profile',
+          rendererUrl: 'http://locked-server.com',
+          allowOverrides: false,
+        },
       });
+      mockSelectedProfileId.set('locked-profile');
 
       const {component} = await setupComponent();
 
@@ -730,18 +748,81 @@ describe('Settings', () => {
       expect(component.isLocked()).toBe(true);
     });
 
-    it('invokes selectProfile on settings service when onProfileSelected is triggered', async () => {
-      const {component} = await setupComponent();
-      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile').mockResolvedValue();
+    it('updates local form controls and tracks draftSelectedProfileId without calling selectProfile or writing localStorage when onProfileSelected is called', async () => {
+      mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
+      mockProfiles.set({
+        dev: {
+          displayName: 'Development',
+          rendererUrl: 'http://localhost:3000',
+          apiKey: 'dev-api-key',
+          allowOverrides: true,
+        },
+      });
+      const {component, harness} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
 
-      component.settingsForm.controls.apiKey.markAsDirty();
-      await component.onProfileSelected('dev');
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Development');
 
-      expect(selectSpy).toHaveBeenCalledWith('dev');
-      expect(component.settingsForm.controls.apiKey.pristine).toBe(true);
+      expect(component.draftSelectedProfileId()).toBe('dev');
+      expect(await harness.getRendererUrlValue()).toBe('http://localhost:3000');
+      expect(await harness.getGeminiApiKeyValue()).toBe('dev-api-key');
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(localStorage.getItem(LocalStorageKey.SELECTED_PROFILE)).toBeNull();
+      expect(localStorage.getItem(LocalStorageKey.RENDERER_URL)).toBeNull();
     });
 
-    it('clears active profile selection when rendererUrl form control value is modified', async () => {
+    it('leaves localStorage and StartupResolution untouched when selecting a profile without clicking Save Settings', async () => {
+      mockProfiles.set({
+        dev: {
+          displayName: 'Development',
+          rendererUrl: 'http://localhost:3000',
+          apiKey: 'dev-api-key',
+          allowOverrides: true,
+        },
+      });
+      const {fixture, component, harness} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
+
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Development');
+
+      fixture.destroy();
+
+      expect(selectSpy).not.toHaveBeenCalled();
+      expect(mockStartupResolution.setSelectedProfileId).not.toHaveBeenCalled();
+      expect(localStorage.getItem(LocalStorageKey.SELECTED_PROFILE)).toBeNull();
+      expect(localStorage.getItem(LocalStorageKey.RENDERER_URL)).toBeNull();
+    });
+
+    it('commits draftSelectedProfileId, saves RENDERER_URL, marks form pristine, and reloads window when saveSettings() is invoked', async () => {
+      mockProfiles.set({
+        dev: {
+          displayName: 'Development',
+          rendererUrl: 'http://localhost:3000',
+          apiKey: 'dev-api-key',
+          allowOverrides: true,
+        },
+      });
+      const {component, harness} = await setupComponent();
+      const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
+      const reloadSpy = vi.spyOn(component, 'reloadWindow').mockImplementation(() => {});
+
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Development');
+
+      expect(selectSpy).not.toHaveBeenCalled();
+
+      const saveBtn = await harness.locatorFor(MatButtonHarness.with({text: /Save Settings/}))();
+      await saveBtn.click();
+
+      expect(selectSpy).toHaveBeenCalledWith('dev');
+      expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('http://localhost:3000');
+      expect(component.settingsForm.pristine).toBe(true);
+      expect(reloadSpy).toHaveBeenCalled();
+    });
+
+    it('clears draftSelectedProfileId when rendererUrl form control value is modified', async () => {
       mockSelectedProfileId.set('dev');
       mockActiveProfile.set({
         displayName: 'Development',
@@ -752,10 +833,13 @@ describe('Settings', () => {
       const {component, harness} = await setupComponent();
       const selectSpy = vi.spyOn(component['settingsService'], 'selectProfile');
 
+      expect(component.draftSelectedProfileId()).toBe('dev');
+
       await harness.setRendererUrlValue('http://custom-renderer-url.com');
       await new Promise(resolve => queueMicrotask(resolve));
 
-      expect(selectSpy).toHaveBeenCalledWith(null);
+      expect(component.draftSelectedProfileId()).toBeNull();
+      expect(selectSpy).not.toHaveBeenCalled();
     });
 
     it('preserves profile selection when rendererUrl form control value matches active profile URL', async () => {
@@ -776,18 +860,22 @@ describe('Settings', () => {
 
     it('resets allowOverrides lock state and enables rendererUrl and apiKey form controls when selecting Custom profile in 3P mode', async () => {
       mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
-      mockActiveProfile.set({
-        displayName: 'Locked Profile',
-        rendererUrl: 'http://locked-server.com',
-        allowOverrides: false,
+      mockProfiles.set({
+        'locked-profile': {
+          displayName: 'Locked Profile',
+          rendererUrl: 'http://locked-server.com',
+          allowOverrides: false,
+        },
       });
-      const {fixture, component} = await setupComponent();
+      mockSelectedProfileId.set('locked-profile');
+      const {fixture, component, harness} = await setupComponent();
 
       expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
       expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
 
       component.settingsForm.controls.apiKey.markAsDirty();
-      await component.onProfileSelected(null);
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Custom');
       fixture.detectChanges();
 
       expect(component.isLocked()).toBe(false);
@@ -798,18 +886,22 @@ describe('Settings', () => {
 
     it('keeps apiKey control disabled in 1P mode when selecting Custom profile', async () => {
       mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(false);
-      mockActiveProfile.set({
-        displayName: 'Locked Profile',
-        rendererUrl: 'http://locked-server.com',
-        allowOverrides: false,
+      mockProfiles.set({
+        'locked-profile': {
+          displayName: 'Locked Profile',
+          rendererUrl: 'http://locked-server.com',
+          allowOverrides: false,
+        },
       });
-      const {fixture, component} = await setupComponent();
+      mockSelectedProfileId.set('locked-profile');
+      const {fixture, component, harness} = await setupComponent();
 
       expect(component.settingsForm.controls.rendererUrl.disabled).toBe(true);
       expect(component.settingsForm.controls.apiKey.disabled).toBe(true);
 
       component.settingsForm.controls.apiKey.markAsDirty();
-      await component.onProfileSelected(null);
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Custom');
       fixture.detectChanges();
 
       expect(component.isLocked()).toBe(false);
@@ -819,31 +911,46 @@ describe('Settings', () => {
     });
 
     it('clears rendererUrl form control to empty string when switching to Custom profile', async () => {
+      mockProfiles.set({
+        'profile-1': {
+          displayName: 'Profile 1',
+          rendererUrl: 'http://locked-server.com',
+        },
+      });
+      mockSelectedProfileId.set('profile-1');
       mockRendererUrl.set('http://locked-server.com');
-      const {fixture, component} = await setupComponent();
+      const {fixture, component, harness} = await setupComponent();
 
       expect(component.settingsForm.controls.rendererUrl.value).toBe('http://locked-server.com');
 
-      await component.onProfileSelected(null);
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Custom');
       fixture.detectChanges();
 
-      expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('');
+      expect(mockConfigProvider.setRendererUrl).not.toHaveBeenCalled();
       expect(component.settingsForm.controls.rendererUrl.value).toBe('');
     });
 
     it('populates saved personal API key into apiKey form control when switching to Custom profile in 3P mode', async () => {
       mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
       mockSecureStorage.getCredential.mockResolvedValue('saved-personal-api-key');
-      const {fixture, component} = await setupComponent();
+      mockProfiles.set({
+        'profile-1': {
+          displayName: 'Profile 1',
+          rendererUrl: 'http://server.com',
+        },
+      });
+      mockSelectedProfileId.set('profile-1');
+      const {fixture, component, harness} = await setupComponent();
 
-      await component.onProfileSelected(null);
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Custom');
       fixture.detectChanges();
 
-      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockSecureStorage.getCredential).toHaveBeenCalledWith(
         SecureCredentialsKey.GEMINI_API_KEY,
       );
-      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('saved-personal-api-key');
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
       expect(component.settingsForm.controls.apiKey.value).toBe('saved-personal-api-key');
     });
 
@@ -851,13 +958,20 @@ describe('Settings', () => {
       mockStartupResolution.isThirdPartyEnvironment.mockReturnValue(true);
       mockSecureStorage.getCredential.mockResolvedValue(null);
       mockGeminiApiKey.set('old-config-key');
-      const {fixture, component} = await setupComponent();
+      mockProfiles.set({
+        'profile-1': {
+          displayName: 'Profile 1',
+          rendererUrl: 'http://server.com',
+        },
+      });
+      mockSelectedProfileId.set('profile-1');
+      const {fixture, component, harness} = await setupComponent();
 
-      await component.onProfileSelected(null);
+      const selectorHarness = await harness.locatorFor(ProfileSelectorHarness)();
+      await selectorHarness.selectOptionByText('Custom');
       fixture.detectChanges();
 
-      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
-      expect(mockConfigProvider.setGeminiApiKey).toHaveBeenCalledWith('');
+      expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
       expect(component.settingsForm.controls.apiKey.value).toBe('');
     });
   });

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -33,7 +33,7 @@ import {MatIconModule} from '@angular/material/icon';
 import {MatCardModule} from '@angular/material/card';
 import {MatChipsModule} from '@angular/material/chips';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
-import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {ProfileConfig, StartupResolution} from '../../shell/startup-resolution/startup-resolution';
 import {DOCUMENT, PlatformLocation} from '@angular/common';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
@@ -41,6 +41,8 @@ import {AppConfigProvider, AuthType} from '../app-config-provider/app-config-pro
 import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
 import {ProfileSelector} from '../profile-selector/profile-selector';
 import {SettingsService} from '../settings-service/settings.service';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
+import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
 import {locationAssign} from 'safevalues/dom';
 
 /**
@@ -73,6 +75,7 @@ export class Settings implements OnInit {
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly configProvider = inject(AppConfigProvider);
   protected readonly settingsService = inject(SettingsService);
+  private readonly secureCredentialsStorage = inject(SecureCredentialsStorage);
 
   protected readonly is1PAuthEnabled = inject(IS_1P_AUTH_ENABLED);
 
@@ -88,6 +91,28 @@ export class Settings implements OnInit {
   readonly forceThirdPartyAuth: WritableSignal<boolean> = signal(false);
   readonly saveErrorMessage: WritableSignal<string | null> = signal(null);
   readonly isSaving: WritableSignal<boolean> = signal(false);
+
+  /**
+   * The currently selected profile ID in the draft form.
+   * Profile selection remains local to the draft form until `saveSettings()` is invoked.
+   */
+  protected readonly draftSelectedProfileId: WritableSignal<string | null> = signal<string | null>(
+    null,
+  );
+  /**
+   * The resolved profile object corresponding to the draft selection.
+   * Profile selection remains local to the draft form until `saveSettings()` is invoked.
+   */
+  private readonly draftProfile: Signal<ProfileConfig | null> = computed<ProfileConfig | null>(
+    () => {
+      const id = this.draftSelectedProfileId();
+      return id ? (this.settingsService.profiles()[id] ?? null) : null;
+    },
+  );
+  private readonly draftAllowOverrides: Signal<boolean> = computed<boolean>(() => {
+    const profile = this.draftProfile();
+    return profile ? (profile.allowOverrides ?? true) : true;
+  });
 
   private readonly initialProfileId: WritableSignal<string | null> = signal<string | null>(null);
   private readonly initialForceThirdPartyAuth: WritableSignal<boolean> = signal<boolean>(false);
@@ -121,7 +146,7 @@ export class Settings implements OnInit {
 
   readonly hasUnsavedChanges: Signal<boolean> = computed(() => {
     this.formEvents();
-    const profileChanged = this.settingsService.selectedProfileId() !== this.initialProfileId();
+    const profileChanged = this.draftSelectedProfileId() !== this.initialProfileId();
     const authChanged = this.forceThirdPartyAuth() !== this.initialForceThirdPartyAuth();
     const urlChanged = this.settingsForm.controls.rendererUrl.value !== this.initialRendererUrl();
     const apiKeyChanged = this.settingsForm.controls.apiKey.value !== this.initialApiKey();
@@ -152,23 +177,19 @@ export class Settings implements OnInit {
 
     this.settingsForm.controls.rendererUrl.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
       if (this.settingsForm.controls.rendererUrl.dirty) {
-        queueMicrotask(() => {
-          const selectedId = this.settingsService.selectedProfileId();
-          if (selectedId !== null) {
-            const currentVal = this.settingsForm.controls.rendererUrl.value;
-            const activeUrl = this.settingsService.activeProfile()?.rendererUrl;
-            if (currentVal !== activeUrl) {
-              this.settingsService.selectProfile(null).catch(err => {
-                console.warn('Failed to reset selected profile on renderer URL edit:', err);
-              });
-            }
+        const selectedId = this.draftSelectedProfileId();
+        if (selectedId !== null) {
+          const currentVal = this.settingsForm.controls.rendererUrl.value;
+          const activeUrl = this.draftProfile()?.rendererUrl;
+          if (currentVal !== activeUrl) {
+            this.draftSelectedProfileId.set(null);
           }
-        });
+        }
       }
     });
 
     effect(() => {
-      const allowOverrides = this.settingsService.allowOverrides();
+      const allowOverrides = this.draftAllowOverrides();
       const startupLocked = this.startupResolution.isContextLocked();
       const isUrlLocked = !allowOverrides || startupLocked;
       this.isLocked.set(isUrlLocked);
@@ -185,7 +206,8 @@ export class Settings implements OnInit {
   }
 
   ngOnInit(): void {
-    const allowOverrides = this.settingsService.allowOverrides();
+    this.draftSelectedProfileId.set(this.settingsService.selectedProfileId());
+    const allowOverrides = this.draftAllowOverrides();
     const locked = !allowOverrides || this.startupResolution.isContextLocked();
     this.isLocked.set(locked);
 
@@ -222,25 +244,45 @@ export class Settings implements OnInit {
   }
 
   async onProfileSelected(profileId: string | null): Promise<void> {
-    await this.settingsService.selectProfile(profileId);
+    this.draftSelectedProfileId.set(profileId);
     if (profileId === null) {
-      this.settingsForm.controls.rendererUrl.setValue('');
-      this.settingsForm.controls.rendererUrl.enable({emitEvent: false});
-      this.configureApiKeyControl(this.isThirdParty());
+      this.settingsForm.controls.rendererUrl.setValue('', {emitEvent: false});
       this.settingsForm.controls.rendererUrl.markAsPristine();
+      if (this.isThirdParty()) {
+        await this.populatePersonalApiKey();
+      }
     } else {
-      const active = this.settingsService.activeProfile();
+      const active = this.settingsService.profiles()[profileId] ?? null;
       if (active?.rendererUrl !== undefined) {
-        this.settingsForm.controls.rendererUrl.setValue(active.rendererUrl);
+        this.settingsForm.controls.rendererUrl.setValue(active.rendererUrl, {emitEvent: false});
         this.settingsForm.controls.rendererUrl.markAsPristine();
+      }
+      const apiKey = typeof active?.apiKey === 'string' ? active.apiKey.trim() : '';
+      if (apiKey) {
+        this.settingsForm.controls.apiKey.setValue(apiKey, {emitEvent: false});
+      } else if (this.isThirdParty()) {
+        await this.populatePersonalApiKey();
       }
     }
     this.settingsForm.controls.apiKey.markAsPristine();
   }
 
+  private async populatePersonalApiKey(): Promise<void> {
+    try {
+      const personalKey = await this.secureCredentialsStorage.getCredential(
+        SecureCredentialsKey.GEMINI_API_KEY,
+      );
+      const trimmedPersonalKey = personalKey ? personalKey.trim() : '';
+      this.settingsForm.controls.apiKey.setValue(trimmedPersonalKey, {emitEvent: false});
+    } catch (err) {
+      console.warn('Failed to retrieve credential from SecureCredentialsStorage:', err);
+      this.settingsForm.controls.apiKey.setValue('', {emitEvent: false});
+    }
+  }
+
   private configureApiKeyControl(is3P: boolean): void {
     const apiKeyControl = this.settingsForm.controls.apiKey;
-    const allowOverrides = this.settingsService.allowOverrides();
+    const allowOverrides = this.draftAllowOverrides();
 
     if (!allowOverrides) {
       apiKeyControl.clearValidators();
@@ -280,6 +322,9 @@ export class Settings implements OnInit {
 
     this.isSaving.set(true);
     try {
+      if (this.draftSelectedProfileId() !== this.initialProfileId()) {
+        await this.settingsService.selectProfile(this.draftSelectedProfileId());
+      }
       const values = this.settingsForm.getRawValue();
       const trimmedUrl = values.rendererUrl.trim();
       const trimmedApiKey = values.apiKey.trim();
@@ -300,6 +345,7 @@ export class Settings implements OnInit {
       this.settingsForm.controls.rendererUrl.setValue(trimmedUrl, {emitEvent: false});
       this.settingsForm.controls.apiKey.setValue(trimmedApiKey, {emitEvent: false});
       this.initialProfileId.set(this.settingsService.selectedProfileId());
+      this.draftSelectedProfileId.set(this.settingsService.selectedProfileId());
       this.initialForceThirdPartyAuth.set(this.forceThirdPartyAuth());
       this.initialRendererUrl.set(this.configProvider.rendererUrl());
       this.initialApiKey.set(this.configProvider.geminiApiKey());


### PR DESCRIPTION
# Description

Decouples profile dropdown selection from immediate LocalStorage and StartupResolution mutation. Profile changes in the Settings UI now update local form state only, and are persisted when saveSettings() is explicitly invoked.
## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

