### PR TITLE
Synchronize document.body theme classes and attributes in PreviewBridge

### DIFF
--- a/bridge/src/preview-bridge.spec.ts
+++ b/bridge/src/preview-bridge.spec.ts
@@ -2073,15 +2073,14 @@ describe('PreviewBridge Core API Runtime', () => {
       });
     });
 
-    it('short-circuits applyThemeToDom when setting the same theme repeatedly', () => {
-      const setAttributeSpy = vi.spyOn(document.documentElement, 'setAttribute');
+    it('re-applies theme styles to document.documentElement and document.body cleanly on repeated calls', () => {
+      bridge.applyThemeToDom(ThemePreference.DARK);
+      expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
 
       bridge.applyThemeToDom(ThemePreference.DARK);
-      expect(setAttributeSpy).toHaveBeenCalledWith('data-theme', 'dark');
-      setAttributeSpy.mockClear();
-
-      bridge.applyThemeToDom(ThemePreference.DARK);
-      expect(setAttributeSpy).not.toHaveBeenCalled();
+      expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
     });
 
     it('logs error if onThemeChange callback throws an exception', () => {

--- a/bridge/src/preview-bridge.spec.ts
+++ b/bridge/src/preview-bridge.spec.ts
@@ -1942,6 +1942,9 @@ describe('PreviewBridge Core API Runtime', () => {
       expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
       expect(document.documentElement.style.colorScheme).toBe('dark');
       expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.style.colorScheme).toBe('dark');
+      expect(document.body.getAttribute('data-theme')).toBe('dark');
 
       themeBridge.destroy();
       window.location = originalLocation;
@@ -1949,6 +1952,7 @@ describe('PreviewBridge Core API Runtime', () => {
 
     it('applies initial theme from window.location.search on instantiation when theme=light', () => {
       document.documentElement.classList.add('dark-theme');
+      document.body.classList.add('dark-theme');
       const originalLocation = window.location;
       delete (window as unknown as {location?: unknown}).location;
       window.location = new URL('http://localhost/?theme=light') as unknown as Location;
@@ -1957,6 +1961,9 @@ describe('PreviewBridge Core API Runtime', () => {
       expect(document.documentElement.classList.contains('dark-theme')).toBe(false);
       expect(document.documentElement.style.colorScheme).toBe('light');
       expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+      expect(document.body.style.colorScheme).toBe('light');
+      expect(document.body.getAttribute('data-theme')).toBe('light');
 
       themeBridge.destroy();
       window.location = originalLocation;
@@ -1986,6 +1993,9 @@ describe('PreviewBridge Core API Runtime', () => {
       expect(document.documentElement.classList.contains('dark-theme')).toBe(true);
       expect(document.documentElement.style.colorScheme).toBe('dark');
       expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.style.colorScheme).toBe('dark');
+      expect(document.body.getAttribute('data-theme')).toBe('dark');
       expect(onThemeChange).toHaveBeenCalledWith(ThemePreference.DARK);
 
       window.dispatchEvent(
@@ -2001,7 +2011,48 @@ describe('PreviewBridge Core API Runtime', () => {
       expect(document.documentElement.classList.contains('dark-theme')).toBe(false);
       expect(document.documentElement.style.colorScheme).toBe('light');
       expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+      expect(document.body.style.colorScheme).toBe('light');
+      expect(document.body.getAttribute('data-theme')).toBe('light');
       expect(onThemeChange).toHaveBeenCalledWith(ThemePreference.LIGHT);
+    });
+
+    it('synchronizes document.body theme styles when attachRenderer is called with active theme', () => {
+      bridge.applyThemeToDom(ThemePreference.DARK);
+      document.body.classList.remove('dark-theme');
+      document.body.style.colorScheme = 'light';
+      document.body.removeAttribute('data-theme');
+
+      const mockGroup = {onSurfaceCreated: {subscribe: vi.fn()}};
+      const processor = {processMessages: vi.fn()};
+
+      bridge.attachRenderer(processor, {
+        surfaceGroup: mockGroup as unknown as SurfaceGroupLike,
+        onSurfaceReady: vi.fn(),
+      });
+
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(document.body.style.colorScheme).toBe('dark');
+      expect(document.body.getAttribute('data-theme')).toBe('dark');
+    });
+
+    it('synchronizes document.body theme styles when attachRenderer is called with light theme', () => {
+      bridge.applyThemeToDom(ThemePreference.LIGHT);
+      document.body.classList.add('dark-theme');
+      document.body.style.colorScheme = 'dark';
+      document.body.setAttribute('data-theme', 'dark');
+
+      const mockGroup = {onSurfaceCreated: {subscribe: vi.fn()}};
+      const processor = {processMessages: vi.fn()};
+
+      bridge.attachRenderer(processor, {
+        surfaceGroup: mockGroup as unknown as SurfaceGroupLike,
+        onSurfaceReady: vi.fn(),
+      });
+
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+      expect(document.body.style.colorScheme).toBe('light');
+      expect(document.body.getAttribute('data-theme')).toBe('light');
     });
 
     it('logs warning if SET_THEME payload format is invalid', () => {

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -165,7 +165,7 @@ export class PreviewBridge {
   }
 
   /**
-   * Applies light/dark mode theme styles and attributes to document.documentElement.
+   * Applies light/dark mode theme styles and attributes to document.documentElement and document.body.
    * Toggles the `.dark-theme` class, sets `color-scheme` CSS style, and `data-theme` attribute.
    *
    * @param theme The target theme ('light' or 'dark').
@@ -177,11 +177,17 @@ export class PreviewBridge {
     this.currentAppliedTheme = theme;
     if (theme === ThemePreference.DARK) {
       document.documentElement.classList.add('dark-theme');
+      document.body?.classList.add('dark-theme');
     } else {
       document.documentElement.classList.remove('dark-theme');
+      document.body?.classList.remove('dark-theme');
     }
     document.documentElement.style.colorScheme = theme;
+    if (document.body) {
+      document.body.style.colorScheme = theme;
+    }
     document.documentElement.setAttribute('data-theme', theme);
+    document.body?.setAttribute('data-theme', theme);
   }
 
   private initThemeFromUrl(): void {
@@ -227,14 +233,25 @@ export class PreviewBridge {
       activeSurfaceIds,
     };
 
-    if (this.currentAppliedTheme && config.onThemeChange) {
-      try {
-        config.onThemeChange(this.currentAppliedTheme);
-      } catch (error) {
-        console.error(
-          'PreviewBridge: Error inside onThemeChange callback during attachment:',
-          error,
-        );
+    if (this.currentAppliedTheme) {
+      if (typeof document !== 'undefined' && document.body) {
+        if (this.currentAppliedTheme === ThemePreference.DARK) {
+          document.body.classList.add('dark-theme');
+        } else {
+          document.body.classList.remove('dark-theme');
+        }
+        document.body.style.colorScheme = this.currentAppliedTheme;
+        document.body.setAttribute('data-theme', this.currentAppliedTheme);
+      }
+      if (config.onThemeChange) {
+        try {
+          config.onThemeChange(this.currentAppliedTheme);
+        } catch (error) {
+          console.error(
+            'PreviewBridge: Error inside onThemeChange callback during attachment:',
+            error,
+          );
+        }
       }
     }
 

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -172,22 +172,19 @@ export class PreviewBridge {
    */
   applyThemeToDom(theme: ThemePreference): void {
     if (typeof document === 'undefined' || !document.documentElement) return;
-    if (this.currentAppliedTheme === theme) return;
 
     this.currentAppliedTheme = theme;
-    if (theme === ThemePreference.DARK) {
-      document.documentElement.classList.add('dark-theme');
-      document.body?.classList.add('dark-theme');
-    } else {
-      document.documentElement.classList.remove('dark-theme');
-      document.body?.classList.remove('dark-theme');
-    }
+    const isDark = theme === ThemePreference.DARK;
+
+    document.documentElement.classList.toggle('dark-theme', isDark);
     document.documentElement.style.colorScheme = theme;
-    if (document.body) {
-      document.body.style.colorScheme = theme;
-    }
     document.documentElement.setAttribute('data-theme', theme);
-    document.body?.setAttribute('data-theme', theme);
+
+    if (document.body) {
+      document.body.classList.toggle('dark-theme', isDark);
+      document.body.style.colorScheme = theme;
+      document.body.setAttribute('data-theme', theme);
+    }
   }
 
   private initThemeFromUrl(): void {
@@ -234,15 +231,7 @@ export class PreviewBridge {
     };
 
     if (this.currentAppliedTheme) {
-      if (typeof document !== 'undefined' && document.body) {
-        if (this.currentAppliedTheme === ThemePreference.DARK) {
-          document.body.classList.add('dark-theme');
-        } else {
-          document.body.classList.remove('dark-theme');
-        }
-        document.body.style.colorScheme = this.currentAppliedTheme;
-        document.body.setAttribute('data-theme', this.currentAppliedTheme);
-      }
+      this.applyThemeToDom(this.currentAppliedTheme);
       if (config.onThemeChange) {
         try {
           config.onThemeChange(this.currentAppliedTheme);


### PR DESCRIPTION
# Description

Updates PreviewBridge.applyThemeToDom and attachRenderer to apply the dark-theme CSS class, color-scheme CSS style, and data-theme attribute to document.body in addition to document.documentElement. This ensures proper theme propagation in frameworks and renderers where dark mode styling rules target document.body.

This fix was suggested to help with renderer apps that may be looking for dark/light mode CSS on the `body`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
