### PR TITLE
Fix expanded raw message bleed-through when switching debug tabs

### DIFF
--- a/shell/e2e/debug-drawer-and-logs.e2e.ts
+++ b/shell/e2e/debug-drawer-and-logs.e2e.ts
@@ -245,4 +245,48 @@ test.describe('Debugging Panels & Diagnostic Logs', () => {
     await eventsTab.click();
     await expect(page.locator('.events-container')).toBeVisible();
   });
+
+  test('hides expanded raw message payload when switching to another debug tab and restores visibility on return', async ({
+    page,
+  }) => {
+    const iframeBody = page.frameLocator('iframe.preview-iframe').locator('body');
+    await expect(iframeBody).toBeVisible();
+
+    const clickMsg = {
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {
+        version: 'v0.9',
+        action: {
+          name: 'e2e_raw_message_tab_switch',
+          surfaceId: 'e2e_surface',
+        },
+      },
+    };
+    await iframeBody.evaluate((_, msg) => {
+      window.parent.postMessage(msg, '*');
+    }, clickMsg);
+
+    const rawMessagesTab = page.locator('.dv-tab', {hasText: /^Raw Messages/});
+    await rawMessagesTab.click();
+    await expect(page.locator('.raw-messages-container')).toBeVisible();
+
+    const logPanel = page.locator('[data-testid="llm-log-panel"]').first();
+    await expect(logPanel).toBeVisible();
+
+    await logPanel.locator('mat-expansion-panel-header').click();
+
+    const rawPayloadPre = logPanel.locator('pre');
+    await expect(rawPayloadPre).toBeVisible();
+    await expect(rawPayloadPre).toContainText('e2e_raw_message_tab_switch');
+
+    const dataModelTab = page.locator('.dv-tab', {hasText: /^Data Model/});
+    await dataModelTab.click();
+    await expect(page.locator('.data-model-container')).toBeVisible();
+
+    await expect(rawPayloadPre).not.toBeVisible();
+
+    await rawMessagesTab.click();
+    await expect(page.locator('.raw-messages-container')).toBeVisible();
+    await expect(rawPayloadPre).toBeVisible();
+  });
 });

--- a/shell/src/app/debug/raw-messages/raw-messages.scss
+++ b/shell/src/app/debug/raw-messages/raw-messages.scss
@@ -107,6 +107,12 @@ mat-expansion-panel.llm-log-panel {
   border-radius: 4px;
   overflow: visible !important;
 
+  &.mat-expanded {
+    ::ng-deep .mat-expansion-panel-content {
+      visibility: inherit;
+    }
+  }
+
   ::ng-deep {
     .mat-expansion-panel-content-wrapper {
       overflow: hidden;

--- a/shell/src/app/debug/raw-messages/raw-messages.spec.ts
+++ b/shell/src/app/debug/raw-messages/raw-messages.spec.ts
@@ -335,4 +335,61 @@ describe('RawMessages', () => {
     expect(await harness.isMessageCollapsibleAt(3)).toBe(false);
     expect(await harness.getMessageTextAt(3)).toContain(PreviewBridgeMessageType.RENDERER_READY);
   });
+
+  it('expands and collapses collapsible message panels via harness', async () => {
+    emitMessage({
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {action: 'test_click'},
+      origin: 'http://localhost',
+      timestamp: 1000,
+    });
+    fixture.detectChanges();
+
+    expect(await harness.getLlmLogPanelsCount()).toBe(1);
+    const panel = await harness.getLlmLogPanelAt(0);
+
+    expect(await panel.isExpanded()).toBe(false);
+
+    await panel.expand();
+    expect(await panel.isExpanded()).toBe(true);
+    const content = await panel.getTextContent();
+    expect(content).toContain('test_click');
+
+    await panel.collapse();
+    expect(await panel.isExpanded()).toBe(false);
+  });
+
+  it('toggles expansion state for multiple collapsible messages independently', async () => {
+    emitMessage({
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {msg: 'message-1'},
+      origin: 'http://localhost',
+      timestamp: 1000,
+    });
+    latestLlmLogSignal.set({
+      type: LlmLogType.REQUEST,
+      payload: {prompt: 'prompt-2'},
+      timestamp: 2000,
+    });
+    fixture.detectChanges();
+
+    expect(await harness.getLlmLogPanelsCount()).toBe(2);
+    const panel0 = await harness.getLlmLogPanelAt(0);
+    const panel1 = await harness.getLlmLogPanelAt(1);
+
+    expect(await panel0.isExpanded()).toBe(false);
+    expect(await panel1.isExpanded()).toBe(false);
+
+    await panel0.expand();
+    expect(await panel0.isExpanded()).toBe(true);
+    expect(await panel1.isExpanded()).toBe(false);
+
+    await panel1.expand();
+    expect(await panel0.isExpanded()).toBe(true);
+    expect(await panel1.isExpanded()).toBe(true);
+
+    await panel0.collapse();
+    expect(await panel0.isExpanded()).toBe(false);
+    expect(await panel1.isExpanded()).toBe(true);
+  });
 });


### PR DESCRIPTION
# Description

Fix expanded raw message bleed-through when switching debug tabs

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
