### PR TITLE
Expose React and Lit renderers the same as we do Angular

### DIFF
--- a/samples/lit-basic-catalog/vite.config.ts
+++ b/samples/lit-basic-catalog/vite.config.ts
@@ -17,6 +17,7 @@
 import {defineConfig} from 'vite';
 
 export default defineConfig({
+  base: './',
   build: {
     target: 'esnext',
     rollupOptions: {

--- a/samples/react-basic-catalog/index.html
+++ b/samples/react-basic-catalog/index.html
@@ -56,6 +56,6 @@
   </head>
   <body>
     <div id="app-root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/samples/react-basic-catalog/vite.config.ts
+++ b/samples/react-basic-catalog/vite.config.ts
@@ -19,6 +19,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
   server: {
     port: 3458,

--- a/shell/angular.json
+++ b/shell/angular.json
@@ -33,6 +33,16 @@
               },
               {
                 "glob": "**/*",
+                "input": "node_modules/lit-basic-catalog/dist",
+                "output": "samples/lit-basic-catalog"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/react-basic-catalog/dist",
+                "output": "samples/react-basic-catalog"
+              },
+              {
+                "glob": "**/*",
                 "input": "node_modules/monaco-editor/min/vs",
                 "output": "assets/monaco/vs"
               }

--- a/shell/package.json
+++ b/shell/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "start": "yarn workspace ng-basic-catalog build && yarn workspace lit-basic-catalog build && yarn workspace react-basic-catalog build && ng serve",
-    "build": "yarn lint && ng build",
+    "build": "yarn lint && yarn workspace ng-basic-catalog build && yarn workspace lit-basic-catalog build && yarn workspace react-basic-catalog build && ng build",
     "test": "vitest run --coverage",
     "e2e": "playwright test",
     "e2e-headless": "E2E_HEADLESS=true playwright test",

--- a/shell/package.json
+++ b/shell/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "scripts": {
-    "start": "yarn workspace ng-basic-catalog build && ng serve",
+    "start": "yarn workspace ng-basic-catalog build && yarn workspace lit-basic-catalog build && yarn workspace react-basic-catalog build && ng serve",
     "build": "yarn lint && ng build",
     "test": "vitest run --coverage",
     "e2e": "playwright test",
@@ -49,8 +49,10 @@
     "angular-eslint": "22.1.0",
     "eslint": "10.7.0",
     "jsdom": "29.1.1",
+    "lit-basic-catalog": "0.1.0",
     "ng-basic-catalog": "0.1.0",
     "prettier": "3.9.6",
+    "react-basic-catalog": "0.1.0",
     "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",
     "vitest": "4.1.10"

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -14,7 +14,7 @@
     }
   },
   "apiKeys": {
-    "default": {
+    "fake": {
       "apiKey": "this will not work",
       "displayName": "Fake key"
     }

--- a/shell/src/config.json
+++ b/shell/src/config.json
@@ -4,13 +4,25 @@
       "rendererUrl": "https://a2ui-project.github.io/composer/samples/ng-basic-catalog/",
       "displayName": "Angular Basic (github)"
     },
-    "dev": {
+    "angular-dev": {
       "rendererUrl": "http://localhost:4200/samples/ng-basic-catalog/",
       "displayName": "Angular Basic (local)"
     },
+    "lit": {
+      "rendererUrl": "https://a2ui-project.github.io/composer/samples/lit-basic-catalog/",
+      "displayName": "Lit Basic (github)"
+    },
+    "lit-dev": {
+      "rendererUrl": "http://localhost:4200/samples/lit-basic-catalog/",
+      "displayName": "Lit Basic (local)"
+    },
     "react": {
-      "rendererUrl": "http://localhost:3459",
-      "displayName": "React (local)"
+      "rendererUrl": "https://a2ui-project.github.io/composer/samples/react-basic-catalog/",
+      "displayName": "React Basic (github)"
+    },
+    "react-dev": {
+      "rendererUrl": "http://localhost:4200/samples/react-basic-catalog/",
+      "displayName": "React Basic (local)"
     }
   },
   "apiKeys": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5952,9 +5952,11 @@ __metadata:
     dockview: "npm:7.0.3"
     eslint: "npm:10.7.0"
     jsdom: "npm:29.1.1"
+    lit-basic-catalog: "npm:0.1.0"
     monaco-editor: "npm:0.56.0"
     ng-basic-catalog: "npm:0.1.0"
     prettier: "npm:3.9.6"
+    react-basic-catalog: "npm:0.1.0"
     rxjs: "npm:7.8.2"
     safevalues: "npm:1.2.0"
     tslib: "npm:2.8.1"
@@ -9361,7 +9363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lit-basic-catalog@workspace:samples/lit-basic-catalog":
+"lit-basic-catalog@npm:0.1.0, lit-basic-catalog@workspace:samples/lit-basic-catalog":
   version: 0.0.0-use.local
   resolution: "lit-basic-catalog@workspace:samples/lit-basic-catalog"
   dependencies:
@@ -11069,7 +11071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-basic-catalog@workspace:samples/react-basic-catalog":
+"react-basic-catalog@npm:0.1.0, react-basic-catalog@workspace:samples/react-basic-catalog":
   version: 0.0.0-use.local
   resolution: "react-basic-catalog@workspace:samples/react-basic-catalog"
   dependencies:


### PR DESCRIPTION
# Description

Expose the Lit & React renderers the same as we do for Angular. This makes a better demo.

Also made the "Fake key" not the `default`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

