### PR TITLE
Fix failing Playwright tests in settings and user journey suites

### DIFF
--- a/shell/e2e/settings-and-configuration.e2e.ts
+++ b/shell/e2e/settings-and-configuration.e2e.ts
@@ -36,15 +36,21 @@ test.describe('Settings and Client Configuration', () => {
     });
 
     test('persists configuration immediately upon selection', async ({page}) => {
-      await page.locator('.add-api-key-button').click();
-      await page.locator('#api-key-name-input').fill('Test Key');
-      await page.locator('#api-key-value-input').fill('test-api-key');
-      await page.getByRole('dialog').getByRole('button', {name: 'Add', exact: true}).click();
+      await page.getByRole('button', {name: 'Add Gemini API key'}).click();
+      const apiKeyDialog = page.getByRole('dialog', {name: 'Add Gemini API Key'});
+      await expect(apiKeyDialog).toBeVisible();
+      await apiKeyDialog.getByLabel('Name', {exact: true}).fill('Test Key');
+      await apiKeyDialog.getByLabel('API Key', {exact: true}).fill('test-api-key');
+      await apiKeyDialog.getByRole('button', {name: 'Add', exact: true}).click();
+      await expect(apiKeyDialog).toBeHidden();
 
-      await page.locator('.add-renderer-button').click();
-      await page.locator('#renderer-name-input').fill('Test Renderer');
-      await page.locator('#renderer-url-input').fill('http://localhost:9090');
-      await page.getByRole('dialog').getByRole('button', {name: 'Add', exact: true}).click();
+      await page.getByRole('button', {name: 'Add custom renderer'}).click();
+      const rendererDialog = page.getByRole('dialog', {name: 'Add Custom Renderer'});
+      await expect(rendererDialog).toBeVisible();
+      await rendererDialog.getByLabel('Name', {exact: true}).fill('Test Renderer');
+      await rendererDialog.getByLabel('Renderer URL', {exact: true}).fill('http://localhost:9090');
+      await rendererDialog.getByRole('button', {name: 'Add', exact: true}).click();
+      await expect(rendererDialog).toBeHidden();
 
       await page.waitForFunction(() => !!localStorage.getItem('a2ui_composer_selected_renderer'));
       await page.waitForFunction(() => !!localStorage.getItem('a2ui_composer_selected_api_key'));
@@ -69,10 +75,13 @@ test.describe('Settings and Client Configuration', () => {
     test('persists configuration immediately with default relative renderer URL and loads workspace with pre-populated draft', async ({
       page,
     }) => {
-      await page.locator('.add-api-key-button').click();
-      await page.locator('#api-key-name-input').fill('Unique Key');
-      await page.locator('#api-key-value-input').fill('new-unique-api-key');
-      await page.getByRole('dialog').getByRole('button', {name: 'Add', exact: true}).click();
+      await page.getByRole('button', {name: 'Add Gemini API key'}).click();
+      const apiKeyDialog = page.getByRole('dialog', {name: 'Add Gemini API Key'});
+      await expect(apiKeyDialog).toBeVisible();
+      await apiKeyDialog.getByLabel('Name', {exact: true}).fill('Unique Key');
+      await apiKeyDialog.getByLabel('API Key', {exact: true}).fill('new-unique-api-key');
+      await apiKeyDialog.getByRole('button', {name: 'Add', exact: true}).click();
+      await expect(apiKeyDialog).toBeHidden();
 
       await page.waitForFunction(() =>
         localStorage.getItem('a2ui_composer_selected_api_key')?.startsWith('custom-'),

--- a/shell/e2e/user-journey.e2e.ts
+++ b/shell/e2e/user-journey.e2e.ts
@@ -52,10 +52,13 @@ test.describe('E2E Workspace User Journey', () => {
     await expect(page.getByText('Gemini API Provisioning')).toBeVisible();
 
     // 5. Provide API key to unlock workspace
-    await page.locator('.add-api-key-button').click();
-    await page.locator('#api-key-name-input').fill('Test Key');
-    await page.locator('#api-key-value-input').fill('test-api-key');
-    await page.getByRole('dialog').getByRole('button', {name: 'Add', exact: true}).click();
+    await page.getByRole('button', {name: 'Add Gemini API key'}).click();
+    const apiKeyDialog = page.getByRole('dialog', {name: 'Add Gemini API Key'});
+    await expect(apiKeyDialog).toBeVisible();
+    await apiKeyDialog.getByLabel('Name', {exact: true}).fill('Test Key');
+    await apiKeyDialog.getByLabel('API Key', {exact: true}).fill('test-api-key');
+    await apiKeyDialog.getByRole('button', {name: 'Add', exact: true}).click();
+    await expect(apiKeyDialog).toBeHidden();
 
     // 6. Navigate back to workspace
     await page.getByRole('link', {name: 'Composer Workspace'}).click();
@@ -100,6 +103,13 @@ test.describe('E2E Workspace User Journey', () => {
   });
 
   test('prevents empty chat bubbles when invalid JSON is entered in editor', async ({page}) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('a2ui_composer_selected_api_key', 'fake');
+      } catch (e) {}
+    });
+    await page.goto('/');
+
     // Wait for Monaco to load
     const editorLocator = page.locator('a2ui-composer-monaco-editor .monaco-editor').first();
     await expect(editorLocator).toBeVisible();


### PR DESCRIPTION
# Description

- In settings-and-configuration.e2e.ts and user-journey.e2e.ts, replace unscoped DOM ID locators with accessible role- and label-based locators scoped to dialog elements, and assert explicit dialog visibility and dismissal to eliminate modal animation race conditions.
- In user-journey.e2e.ts, initialize a static API key in localStorage for the invalid JSON editor test to satisfy the chat panel workspace prerequisite.


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
