### PR TITLE
Add analytics

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Build Core Bridge Dependency
         run: yarn workspace a2ui-bridge build
 
+      - name: Inject GA4 Measurement ID
+        env:
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
+        run: |
+          if [ -n "$GA_MEASUREMENT_ID" ]; then
+            echo "Injecting GA4 measurement ID..."
+            sed -i "s/enabled: false,/enabled: true,/g" shell/src/app/usage-tracking/usage-tracking.service.ts
+            sed -i "s/measurementId: ''/measurementId: '$GA_MEASUREMENT_ID'/g" shell/src/app/usage-tracking/usage-tracking.service.ts
+          fi
+
       - name: Build Production Shell & Catalogs with Correct Base URLs
         run: |
           yarn workspace ng-basic-catalog run build --base-href=/composer/samples/ng-basic-catalog/

--- a/shell/src/app/app.config.ts
+++ b/shell/src/app/app.config.ts
@@ -20,14 +20,18 @@ import {
   provideAppInitializer,
   inject,
 } from '@angular/core';
-import {provideRouter} from '@angular/router';
+import {provideRouter, Router, NavigationEnd} from '@angular/router';
 import {provideAnimations} from '@angular/platform-browser/animations';
+import {filter} from 'rxjs/operators';
 import {routes} from './app.routes';
 import {StartupResolution} from './shell/startup-resolution/startup-resolution';
 import {AppConfigProvider} from './settings/app-config-provider/app-config-provider';
 import {LocalStorageAppConfigProvider} from './settings/local-storage-config-provider/local-storage-config.provider';
 import {LlmClient} from './chat/llm-client/llm-client';
 import {Standalone3pLlmClient} from './chat/llm-client/standalone-3p-llm-client';
+import {USAGE_TRACKING_CONFIG, UsageTrackingService} from './usage-tracking/usage-tracking.service';
+import {Ga4UsageTrackingService} from './usage-tracking/ga4-usage-tracking.service';
+import {NoopUsageTrackingService} from './usage-tracking/noop-usage-tracking.service';
 
 /**
  * Application-wide Angular configuration defining core providers,
@@ -41,9 +45,19 @@ export const appConfig: ApplicationConfig = {
     provideAppInitializer(() => {
       const startupResolution = inject(StartupResolution);
       const configProvider = inject(AppConfigProvider);
-      return startupResolution.resolveStartupConfiguration().then(() => {
-        return configProvider.initialize();
-      });
+      const usageTrackingService = inject(UsageTrackingService);
+      const router = inject(Router);
+
+      router.events
+        .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+        .subscribe(event => {
+          usageTrackingService.trackPageView({pagePath: event.urlAfterRedirects});
+        });
+
+      return startupResolution
+        .resolveStartupConfiguration()
+        .then(() => configProvider.initialize())
+        .then(() => usageTrackingService.initialize());
     }),
     {
       provide: AppConfigProvider,
@@ -52,6 +66,16 @@ export const appConfig: ApplicationConfig = {
     {
       provide: LlmClient,
       useExisting: Standalone3pLlmClient,
+    },
+    {
+      provide: UsageTrackingService,
+      useFactory: () => {
+        const config = inject(USAGE_TRACKING_CONFIG);
+        if (config.enabled && config.measurementId) {
+          return inject(Ga4UsageTrackingService);
+        }
+        return inject(NoopUsageTrackingService);
+      },
     },
   ],
 };

--- a/shell/src/app/app.routes.spec.ts
+++ b/shell/src/app/app.routes.spec.ts
@@ -36,6 +36,8 @@ import {CatalogManagement} from './storage/catalog-management/catalog-management
 import {IndexedDbStorage} from './storage/indexed-db-storage/indexed-db-storage';
 import {LocalStorageInteractions} from './storage/local-storage-interactions/local-storage-interactions';
 import {PipelineStatus} from './chat/pipeline-status/pipeline-status';
+import {UsageTrackingService} from './usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from './usage-tracking/noop-usage-tracking.service';
 
 class MockStartupResolution {
   readonly resolvedUrl = signal('http://localhost:4200');
@@ -131,6 +133,7 @@ describe('App Routes Active Verification', () => {
           provide: LocalStorageInteractions,
           useValue: {removeItem: vi.fn(), getItem: vi.fn().mockReturnValue(null)},
         },
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     }).compileComponents();
 

--- a/shell/src/app/app.spec.ts
+++ b/shell/src/app/app.spec.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {App} from './app';
-import {provideRouter} from '@angular/router';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideRouter, Router} from '@angular/router';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {App} from './app';
+import {appConfig} from './app.config';
 import {AppHarness} from './test/app.harness';
-import {describe, it, expect, beforeEach} from 'vitest';
+import {Ga4UsageTrackingService} from './usage-tracking/ga4-usage-tracking.service';
+import {NoopUsageTrackingService} from './usage-tracking/noop-usage-tracking.service';
+import {USAGE_TRACKING_CONFIG, UsageTrackingService} from './usage-tracking/usage-tracking.service';
 
 describe('App', () => {
   let fixture: ComponentFixture<App>;
@@ -38,5 +42,72 @@ describe('App', () => {
 
   it('creates the root application component via test harness', async () => {
     expect(harness).toBeTruthy();
+  });
+});
+
+describe('appConfig UsageTracking wiring', () => {
+  it('resolves NoopUsageTrackingService by default when disabled', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: appConfig.providers,
+    });
+
+    const service = TestBed.inject(UsageTrackingService);
+    expect(service).toBeInstanceOf(NoopUsageTrackingService);
+  });
+
+  it('resolves Ga4UsageTrackingService when enabled with measurement ID', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        ...appConfig.providers,
+        {
+          provide: USAGE_TRACKING_CONFIG,
+          useValue: {enabled: true, measurementId: 'G-APPCONFIG123'},
+        },
+      ],
+    });
+
+    const service = TestBed.inject(UsageTrackingService);
+    expect(service).toBeInstanceOf(Ga4UsageTrackingService);
+  });
+
+  it('invokes usageTrackingService.initialize during bootstrap', async () => {
+    const mockTrackingService = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      trackPageView: vi.fn(),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        ...appConfig.providers,
+        {provide: UsageTrackingService, useValue: mockTrackingService},
+      ],
+    });
+
+    // Resolve app initializer
+    const service = TestBed.inject(UsageTrackingService);
+    expect(service).toBe(mockTrackingService);
+  });
+
+  it('tracks virtual page views on NavigationEnd events during routing', async () => {
+    const mockTrackingService = {
+      initialize: vi.fn().mockResolvedValue(undefined),
+      trackPageView: vi.fn(),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        ...appConfig.providers,
+        {provide: UsageTrackingService, useValue: mockTrackingService},
+      ],
+    });
+
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/settings');
+
+    expect(mockTrackingService.trackPageView).toHaveBeenCalledWith({pagePath: '/settings'});
   });
 });

--- a/shell/src/app/chat/chat-panel/chat-panel.ng.html
+++ b/shell/src/app/chat/chat-panel/chat-panel.ng.html
@@ -147,7 +147,11 @@
                         color="primary"
                         class="retry-button"
                         [disabled]="isLocked()"
-                        (click)="retryPrompt(turn.originalPrompt || '', turn.attachments || [])"
+                        (click)="
+                          retryPrompt(turn.originalPrompt || '', turn.attachments || [], {
+                            promptId: turn.promptId,
+                          })
+                        "
                       >
                         <mat-icon aria-hidden="true">refresh</mat-icon>
                         Retry Request

--- a/shell/src/app/chat/chat-panel/chat-panel.spec.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.spec.ts
@@ -74,6 +74,7 @@ class MockChatCoordinator {
   private readonly chatState = inject(ChatState) as unknown as MockChatState;
 
   readonly systemPrompt = signal<string>('Initial system prompt instructions block');
+  readonly currentTurnIndex = signal<number>(0);
 
   get pipelineStatus() {
     return this.chatState.pipelineStatus;
@@ -83,7 +84,13 @@ class MockChatCoordinator {
     return this.chatState.isProgrammaticStreamActive;
   }
 
-  submitPrompt = vi.fn(async (prompt: string, attachments: Attachment[] = []): Promise<void> => {});
+  submitPrompt = vi.fn(
+    async (
+      prompt: string,
+      attachments: Attachment[] = [],
+      options?: {promptId?: string; promptTurnIndex?: number; retryOfPromptId?: string},
+    ): Promise<void> => {},
+  );
   cancelActiveStream = vi.fn();
 }
 
@@ -501,7 +508,15 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     await harness.clickRetryButtonAt(0);
     fixture.detectChanges();
 
-    expect(submitSpy).toHaveBeenCalledWith('create standard button', []);
+    expect(submitSpy).toHaveBeenCalledWith(
+      'create standard button',
+      [],
+      expect.objectContaining({
+        promptId: expect.any(String),
+        promptTurnIndex: 1,
+        retryOfPromptId: undefined,
+      }),
+    );
   });
 
   it(
@@ -522,7 +537,7 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
       fixture.detectChanges();
 
       // Verify submit service call made with sanitized, trimmed inputs
-      expect(submitSpy).toHaveBeenCalledWith('Make a pretty dashboard layout', []);
+      expect(submitSpy).toHaveBeenCalledWith('Make a pretty dashboard layout', [], undefined);
 
       // Verify textbox cleared out instantly
       expect(await harness.getPromptText()).toBe('');
@@ -539,7 +554,7 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
       await harness.pressKeyOnPrompt('Enter', {shiftKey: false});
       fixture.detectChanges();
 
-      expect(submitSpy).toHaveBeenCalledWith('Add Column', []);
+      expect(submitSpy).toHaveBeenCalledWith('Add Column', [], undefined);
       expect(await harness.getPromptText()).toBe('');
     },
   );
@@ -833,14 +848,18 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    expect(submitSpy).toHaveBeenCalledWith('Analyze this image', [
-      {
-        name: 'test-image.png',
-        mimeType: 'image/png',
-        data: 'base64data...',
-        previewUrl: 'data:image/png;base64,base64data...',
-      },
-    ]);
+    expect(submitSpy).toHaveBeenCalledWith(
+      'Analyze this image',
+      [
+        {
+          name: 'test-image.png',
+          mimeType: 'image/png',
+          data: 'base64data...',
+          previewUrl: 'data:image/png;base64,base64data...',
+        },
+      ],
+      undefined,
+    );
     expect(component.attachedFiles().length).toBe(0);
     expect(component.userPrompt()).toBe('');
   });
@@ -875,13 +894,17 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
       fixture.detectChanges();
 
       expect(captureSpy).toHaveBeenCalledTimes(1);
-      expect(submitSpy).toHaveBeenCalledWith('Add button', [
-        {
-          name: 'screenshot.png',
-          mimeType: 'image/png',
-          data: 'mockScreenshot',
-        },
-      ]);
+      expect(submitSpy).toHaveBeenCalledWith(
+        'Add button',
+        [
+          {
+            name: 'screenshot.png',
+            mimeType: 'image/png',
+            data: 'mockScreenshot',
+          },
+        ],
+        undefined,
+      );
     });
 
     it('does not capture or attach screenshot when sending prompt with includeScreenshot disabled', async () => {
@@ -897,7 +920,37 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
       fixture.detectChanges();
 
       expect(captureSpy).not.toHaveBeenCalled();
-      expect(submitSpy).toHaveBeenCalledWith('Add button', []);
+      expect(submitSpy).toHaveBeenCalledWith('Add button', [], undefined);
+    });
+
+    it('correlates retryPrompt telemetry options with parent promptId', async () => {
+      const submitSpy = chatServiceMock.submitPrompt;
+      chatServiceMock.currentTurnIndex.set(2);
+
+      const historyMocks: LlmMessage[] = [
+        {
+          role: MessageRole.ERROR,
+          content: 'error',
+          isRetryable: true,
+          originalPrompt: 'Build table',
+          promptId: 'prompt-123-abc',
+        },
+      ];
+      chatStateMock.chatHistory.set(historyMocks);
+      fixture.detectChanges();
+
+      await harness.clickRetryButtonAt(0);
+      fixture.detectChanges();
+
+      expect(submitSpy).toHaveBeenCalledWith(
+        'Build table',
+        [],
+        expect.objectContaining({
+          promptId: expect.any(String),
+          promptTurnIndex: 3,
+          retryOfPromptId: 'prompt-123-abc',
+        }),
+      );
     });
   });
 

--- a/shell/src/app/chat/chat-panel/chat-panel.spec.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.spec.ts
@@ -508,15 +508,9 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
     await harness.clickRetryButtonAt(0);
     fixture.detectChanges();
 
-    expect(submitSpy).toHaveBeenCalledWith(
-      'create standard button',
-      [],
-      expect.objectContaining({
-        promptId: expect.any(String),
-        promptTurnIndex: 1,
-        retryOfPromptId: undefined,
-      }),
-    );
+    expect(submitSpy).toHaveBeenCalledWith('create standard button', [], {
+      retryOfPromptId: undefined,
+    });
   });
 
   it(
@@ -942,15 +936,9 @@ describe('ChatPanel Gemini Dialogue Panel Integration', () => {
       await harness.clickRetryButtonAt(0);
       fixture.detectChanges();
 
-      expect(submitSpy).toHaveBeenCalledWith(
-        'Build table',
-        [],
-        expect.objectContaining({
-          promptId: expect.any(String),
-          promptTurnIndex: 3,
-          retryOfPromptId: 'prompt-123-abc',
-        }),
-      );
+      expect(submitSpy).toHaveBeenCalledWith('Build table', [], {
+        retryOfPromptId: 'prompt-123-abc',
+      });
     });
   });
 

--- a/shell/src/app/chat/chat-panel/chat-panel.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.ts
@@ -360,8 +360,6 @@ export class ChatPanel {
     this.userPrompt.set(prompt);
     this.attachedFiles.set(attachments);
     await this.submitPrompt({
-      promptId: crypto.randomUUID(),
-      promptTurnIndex: this.chatCoordinator.currentTurnIndex() + 1,
       retryOfPromptId: options?.promptId,
     });
   }

--- a/shell/src/app/chat/chat-panel/chat-panel.ts
+++ b/shell/src/app/chat/chat-panel/chat-panel.ts
@@ -16,14 +16,34 @@
 
 import {
   Component,
-  inject,
-  signal,
   computed,
-  ElementRef,
   Directive,
-  input,
   effect,
+  ElementRef,
+  inject,
+  input,
+  signal,
 } from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatButtonModule} from '@angular/material/button';
+import {MatDialog, MatDialogModule} from '@angular/material/dialog';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatIconModule} from '@angular/material/icon';
+import {MatInputModule} from '@angular/material/input';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {RouterLink} from '@angular/router';
+import {RenderA2uiItem} from 'a2ui-bridge';
+import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
+import {HostCommunication} from '../../shell/host-communication/host-communication';
+import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {tryParseJsonArray} from '../../utils/json';
+import {ChatCleaner} from '../chat-service/chat-cleaner';
+import {ChatCoordinator} from '../chat-service/chat-coordinator';
+import {ChatState} from '../chat-state/chat-state';
+import {Attachment, LlmMessage, MessageRole} from '../llm-client/llm-client';
+import {PipelineStatus} from '../pipeline-status/pipeline-status';
+import {SystemInstructionsDialog} from '../system-instructions-dialog/system-instructions-dialog';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
@@ -43,26 +63,6 @@ export class AutoScroll {
     });
   }
 }
-import {ChatCoordinator} from '../chat-service/chat-coordinator';
-import {ChatState} from '../chat-state/chat-state';
-import {LlmMessage, MessageRole, Attachment} from '../llm-client/llm-client';
-import {PipelineStatus} from '../pipeline-status/pipeline-status';
-import {MatFormFieldModule} from '@angular/material/form-field';
-import {MatInputModule} from '@angular/material/input';
-import {MatButtonModule} from '@angular/material/button';
-import {FormsModule} from '@angular/forms';
-import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
-import {MatIconModule} from '@angular/material/icon';
-import {MatDialogModule, MatDialog} from '@angular/material/dialog';
-import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
-import {SystemInstructionsDialog} from '../system-instructions-dialog/system-instructions-dialog';
-import {tryParseJsonArray} from '../../utils/json';
-import {RouterLink} from '@angular/router';
-import {StartupResolution} from '../../shell/startup-resolution/startup-resolution';
-import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
-import {RenderA2uiItem} from 'a2ui-bridge';
-import {HostCommunication} from '../../shell/host-communication/host-communication';
-import {ChatCleaner} from '../chat-service/chat-cleaner';
 
 interface AttachedFile extends Attachment {
   readonly previewUrl?: string;
@@ -195,7 +195,11 @@ export class ChatPanel {
   /**
    * Delegates plain instructions text queries to GenAI pipeline.
    */
-  protected async submitPrompt(): Promise<void> {
+  protected async submitPrompt(options?: {
+    promptId?: string;
+    promptTurnIndex?: number;
+    retryOfPromptId?: string;
+  }): Promise<void> {
     const textVal = this.userPrompt().trim();
     const attachments = [...this.attachedFiles()];
     if ((!textVal && attachments.length === 0) || this.isLocked()) {
@@ -234,7 +238,7 @@ export class ChatPanel {
     this.attachedFiles.set([]);
 
     // Trigger vertex async pipeline stream completions
-    await this.chatCoordinator.submitPrompt(textVal, attachments);
+    await this.chatCoordinator.submitPrompt(textVal, attachments, options);
   }
 
   /**
@@ -348,10 +352,18 @@ export class ChatPanel {
    * Re-dispatches a failed dynamic Human prompt turn, bypassing standard
    * inputs validations.
    */
-  protected async retryPrompt(prompt: string, attachments: AttachedFile[] = []): Promise<void> {
+  protected async retryPrompt(
+    prompt: string,
+    attachments: AttachedFile[] = [],
+    options?: {promptId?: string},
+  ): Promise<void> {
     this.userPrompt.set(prompt);
     this.attachedFiles.set(attachments);
-    await this.submitPrompt();
+    await this.submitPrompt({
+      promptId: crypto.randomUUID(),
+      promptTurnIndex: this.chatCoordinator.currentTurnIndex() + 1,
+      retryOfPromptId: options?.promptId,
+    });
   }
 
   protected parseMessage(text: string | undefined): Array<{text: string; isRedacted: boolean}> {

--- a/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
@@ -1021,7 +1021,6 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
 
       expect(promptSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          promptId: expect.any(String),
           turnIndex: 1,
           turnType: PromptTurnType.INITIAL,
           hasScreenshot: true,
@@ -1046,6 +1045,7 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
           promptId: 'custom-retry-id',
           turnIndex: 5,
           attemptNumber: 2,
+          retryOfPromptId: 'parent-prompt-id',
         }),
       );
       expect(service.currentTurnIndex()).toBe(5);

--- a/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.spec.ts
@@ -39,6 +39,8 @@ import {
   CANCEL_ERROR_NAME,
 } from '../llm-client/llm-client';
 import {PipelineStatus} from '../pipeline-status/pipeline-status';
+import {PromptTurnType, UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 
 class MockCatalogManagement {
   readonly activeCatalog = signal<Catalog | null>(null);
@@ -149,6 +151,7 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
         {provide: AppConfigProvider, useClass: MockAppConfigProvider},
         {provide: StateSync, useClass: MockStateSync},
         {provide: LlmClient, useClass: MockLlmClient},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     });
 
@@ -1003,6 +1006,112 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
     it('prevents double redaction of already redacted keys', () => {
       const input = 'Invalid API key: redacted for your protection';
       expect(redactApiKey(input)).toBe(input);
+    });
+  });
+
+  describe('Telemetry Tracking', () => {
+    it('tracks prompt turns upon submitPrompt', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const promptSpy = vi.spyOn(trackingService, 'trackChatPrompt');
+
+      await service.submitPrompt('Build a landing page', [
+        {name: 'screenshot.png', mimeType: 'image/png', data: 'data'},
+        {name: 'data.json', mimeType: 'application/json', data: 'json'},
+      ]);
+
+      expect(promptSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptId: expect.any(String),
+          turnIndex: 1,
+          turnType: PromptTurnType.INITIAL,
+          hasScreenshot: true,
+          attachmentCount: 1,
+        }),
+      );
+      expect(service.currentTurnIndex()).toBe(1);
+    });
+
+    it('tracks prompt turn as retry when retryOfPromptId is specified', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const retrySpy = vi.spyOn(trackingService, 'trackChatRetry');
+
+      await service.submitPrompt('Try again', [], {
+        promptId: 'custom-retry-id',
+        promptTurnIndex: 5,
+        retryOfPromptId: 'parent-prompt-id',
+      });
+
+      expect(retrySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptId: 'custom-retry-id',
+          turnIndex: 5,
+          attemptNumber: 2,
+        }),
+      );
+      expect(service.currentTurnIndex()).toBe(5);
+    });
+
+    it('tracks cancelled prompt when cancelActiveStream is triggered', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const cancelSpy = vi.spyOn(trackingService, 'trackChatCancel');
+
+      let cancelCalled = false;
+      const completePromise = new Promise<string>((_, reject) => {
+        const check = setInterval(() => {
+          if (cancelCalled) {
+            clearInterval(check);
+            const err = new Error('Cancelled');
+            err.name = CANCEL_ERROR_NAME;
+            reject(err);
+          }
+        }, 10);
+      });
+      completePromise.catch(() => {});
+
+      llmClientMock.chatStream = vi.fn(async () => {
+        const contentStream: AsyncIterable<{content: string; thinking?: string}> = {
+          [Symbol.asyncIterator]() {
+            return {
+              async next(): Promise<IteratorResult<{content: string; thinking?: string}>> {
+                if (cancelCalled) {
+                  const err = new Error('Cancelled');
+                  err.name = CANCEL_ERROR_NAME;
+                  throw err;
+                }
+                await new Promise<void>((_, reject) => {
+                  const check = setInterval(() => {
+                    if (cancelCalled) {
+                      clearInterval(check);
+                      const err = new Error('Cancelled');
+                      err.name = CANCEL_ERROR_NAME;
+                      reject(err);
+                    }
+                  }, 10);
+                });
+                return {value: undefined as unknown as {content: string}, done: true};
+              },
+            };
+          },
+        };
+        return {
+          contentStream,
+          complete: completePromise,
+          cancel: () => {
+            cancelCalled = true;
+          },
+        };
+      });
+
+      const submitPromise = service.submitPrompt('Long running prompt');
+      service.cancelActiveStream();
+      await submitPromise;
+
+      expect(cancelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptId: expect.any(String),
+          turnIndex: 1,
+        }),
+      );
     });
   });
 });

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -15,9 +15,14 @@
  */
 
 import {computed, effect, inject, Injectable, signal, untracked} from '@angular/core';
-import {formatJson, tryParseJsonArray} from '../../utils/json';
-import {ChatCleaner} from './chat-cleaner';
+import {A2uiComponentInstance, PreviewBridgeMessageType, RenderA2uiItem} from 'a2ui-bridge';
+import {COMMON_TYPES_SCHEMA} from '../../gallery/schema/common-types-schema';
+import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
+import {CrossFrameValidator} from '../../shell/cross-frame-validator/cross-frame-validator';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {PromptTurnType, UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {formatJson, tryParseJsonArray} from '../../utils/json';
+import {ChatState, LlmLogType} from '../chat-state/chat-state';
 import {
   Attachment,
   CANCEL_ERROR_NAME,
@@ -27,13 +32,9 @@ import {
   MessageRole,
 } from '../llm-client/llm-client';
 import {PipelineStatus} from '../pipeline-status/pipeline-status';
-import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {StateSync} from '../state-sync/state-sync';
-import {ChatState, LlmLogType} from '../chat-state/chat-state';
-import {CrossFrameValidator} from '../../shell/cross-frame-validator/cross-frame-validator';
-import {A2uiComponentInstance, PreviewBridgeMessageType, RenderA2uiItem} from 'a2ui-bridge';
+import {ChatCleaner} from './chat-cleaner';
 import {cleanErrorMessage, redactApiKey} from './error-utils';
-import {COMMON_TYPES_SCHEMA} from '../../gallery/schema/common-types-schema';
 
 @Injectable({
   providedIn: 'root',
@@ -51,6 +52,7 @@ export class ChatCoordinator {
   private readonly chatState = inject(ChatState);
   private readonly llmClient = inject(LlmClient);
   private readonly chatCleaner = inject(ChatCleaner);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   /** Reactively mapped rendering pipeline execution milestones. */
   readonly pipelineStatus = this.chatState.pipelineStatus;
@@ -64,6 +66,7 @@ export class ChatCoordinator {
   /** Turn index counter for telemetry. */
   readonly currentTurnIndex = signal(0);
 
+  private activePromptId: string | null = null;
   private lastSeenRendererUrl = '';
   private isFirstUrlEffectRun = true;
 
@@ -90,6 +93,8 @@ export class ChatCoordinator {
    * Resets turns logs history, overlays milestones, and locks indicators.
    */
   wipeEnvironmentCache(): void {
+    this.currentTurnIndex.set(0);
+    this.activePromptId = null;
     this.chatState.setChatHistory([]);
     this.chatState.setPipelineStatus(PipelineStatus.IDLE);
     this.chatState.setProgrammaticStreamActive(false);
@@ -118,9 +123,58 @@ export class ChatCoordinator {
    */
   cancelActiveStream(): void {
     this.isCancelRequested = true;
+    if (this.activePromptId) {
+      this.usageTrackingService.trackChatCancel({
+        promptId: this.activePromptId,
+        turnIndex: this.currentTurnIndex(),
+        pipelineStatus: this.pipelineStatus(),
+      });
+    }
     if (this.activeStreamResponse && this.activeStreamResponse.cancel) {
       this.activeStreamResponse.cancel();
     }
+  }
+
+  private emitPromptTracking(
+    prompt: string,
+    attachments: Attachment[],
+    options?: {promptId?: string; promptTurnIndex?: number; retryOfPromptId?: string},
+  ): string {
+    const promptId = options?.promptId || crypto.randomUUID();
+    const isRetry = !!options?.retryOfPromptId;
+    const promptTurnIndex = options?.promptTurnIndex ?? this.currentTurnIndex() + 1;
+    this.currentTurnIndex.set(promptTurnIndex);
+
+    const catalogObj = this.catalogManagement.activeCatalog();
+    const catalogId = catalogObj ? catalogObj.catalogId || catalogObj.$id || '' : '';
+
+    const hasScreenshot = attachments.some(
+      a => a.name === 'screenshot.png' || a.mimeType?.startsWith('image/'),
+    );
+    const nonScreenshotAttachments = attachments.filter(
+      a => a.name !== 'screenshot.png' && !a.mimeType?.startsWith('image/'),
+    );
+
+    if (isRetry) {
+      this.usageTrackingService.trackChatRetry({
+        promptId,
+        catalogId,
+        turnIndex: promptTurnIndex,
+        attemptNumber: 2,
+      });
+    } else {
+      this.usageTrackingService.trackChatPrompt({
+        promptId,
+        catalogId,
+        turnType: promptTurnIndex === 1 ? PromptTurnType.INITIAL : PromptTurnType.FOLLOWUP,
+        turnIndex: promptTurnIndex,
+        attemptNumber: 1,
+        hasScreenshot,
+        attachmentCount: nonScreenshotAttachments.length,
+      });
+    }
+
+    return promptId;
   }
 
   /**
@@ -128,9 +182,16 @@ export class ChatCoordinator {
    * in-stream, buffers packets, runs auto-repair healing and schema
    * validation blocks.
    */
-  async submitPrompt(prompt: string, attachments: Attachment[] = []): Promise<void> {
+  async submitPrompt(
+    prompt: string,
+    attachments: Attachment[] = [],
+    options?: {promptId?: string; promptTurnIndex?: number; retryOfPromptId?: string},
+  ): Promise<void> {
     const trimmed = prompt.trim();
     if (!trimmed && attachments.length === 0) return;
+
+    const promptId = this.emitPromptTracking(trimmed, attachments, options);
+    this.activePromptId = promptId;
 
     // Lock UI controls and transition state indicators to receiving stream
     this.chatState.setProgrammaticStreamActive(true);
@@ -143,6 +204,7 @@ export class ChatCoordinator {
         role: MessageRole.USER,
         content: trimmed,
         attachments: attachments.length > 0 ? attachments : undefined,
+        promptId,
       },
     ]);
 
@@ -239,7 +301,7 @@ export class ChatCoordinator {
           return updated;
         });
       } else {
-        this.handleConnectivityError(err, trimmed, attachments);
+        this.handleConnectivityError(err, trimmed, attachments, promptId);
       }
     } finally {
       this.activeStreamResponse = undefined;
@@ -732,6 +794,7 @@ export class ChatCoordinator {
     err: unknown,
     originalPrompt?: string,
     attachments: Attachment[] = [],
+    promptId?: string,
   ): void {
     const rawError = err instanceof Error ? err.message : String(err);
     const lowerMsg = rawError.toLowerCase();
@@ -776,6 +839,7 @@ export class ChatCoordinator {
         errorMessage: redactedErrorMessage,
         errorDetails: redactedErrorDetails,
         errorTip: redactedErrorTip,
+        promptId,
         ...(parsed.isRetryable ? {isRetryable: true, originalPrompt, attachments} : {}),
       };
       if (lastIdx >= 0 && updated[lastIdx].role === MessageRole.MODEL) {

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -140,7 +140,6 @@ export class ChatCoordinator {
     attachments: Attachment[],
     options?: {promptId?: string; promptTurnIndex?: number; retryOfPromptId?: string},
   ): string {
-    const promptId = options?.promptId || crypto.randomUUID();
     const isRetry = !!options?.retryOfPromptId;
     const promptTurnIndex = options?.promptTurnIndex ?? this.currentTurnIndex() + 1;
     this.currentTurnIndex.set(promptTurnIndex);
@@ -156,15 +155,16 @@ export class ChatCoordinator {
     );
 
     if (isRetry) {
-      this.usageTrackingService.trackChatRetry({
-        promptId,
+      return this.usageTrackingService.trackChatRetry({
+        promptId: options?.promptId,
         catalogId,
         turnIndex: promptTurnIndex,
         attemptNumber: 2,
+        retryOfPromptId: options?.retryOfPromptId,
       });
     } else {
-      this.usageTrackingService.trackChatPrompt({
-        promptId,
+      return this.usageTrackingService.trackChatPrompt({
+        promptId: options?.promptId,
         catalogId,
         turnType: promptTurnIndex === 1 ? PromptTurnType.INITIAL : PromptTurnType.FOLLOWUP,
         turnIndex: promptTurnIndex,
@@ -173,8 +173,6 @@ export class ChatCoordinator {
         attachmentCount: nonScreenshotAttachments.length,
       });
     }
-
-    return promptId;
   }
 
   /**

--- a/shell/src/app/chat/chat-service/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-service/chat-coordinator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {computed, effect, inject, Injectable, untracked} from '@angular/core';
+import {computed, effect, inject, Injectable, signal, untracked} from '@angular/core';
 import {formatJson, tryParseJsonArray} from '../../utils/json';
 import {ChatCleaner} from './chat-cleaner';
 import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
@@ -60,6 +60,9 @@ export class ChatCoordinator {
    * during streams.
    */
   readonly isProgrammaticStreamActive = this.chatState.isProgrammaticStreamActive;
+
+  /** Turn index counter for telemetry. */
+  readonly currentTurnIndex = signal(0);
 
   private lastSeenRendererUrl = '';
   private isFirstUrlEffectRun = true;

--- a/shell/src/app/chat/llm-client/llm-client.ts
+++ b/shell/src/app/chat/llm-client/llm-client.ts
@@ -59,6 +59,9 @@ export declare interface LlmMessage {
   /** Holds the optional model thinking or thought process. */
   readonly thinking?: string;
 
+  /** Unique identifier for correlating prompts and retries. */
+  readonly promptId?: string;
+
   /** Indicates whether a failed gateway transaction is retryable. */
   readonly isRetryable?: boolean;
 

--- a/shell/src/app/debug/data-model/data-model.spec.ts
+++ b/shell/src/app/debug/data-model/data-model.spec.ts
@@ -27,6 +27,8 @@ import {
   MessageEnvelope,
 } from '../../shell/host-communication/host-communication';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 
 describe('DataModel', () => {
   let fixture: ComponentFixture<DataModel>;
@@ -47,7 +49,11 @@ describe('DataModel', () => {
 
     await TestBed.configureTestingModule({
       imports: [DataModel],
-      providers: [provideNoopAnimations(), {provide: HostCommunication, useValue: mockHostComm}],
+      providers: [
+        provideNoopAnimations(),
+        {provide: HostCommunication, useValue: mockHostComm},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DataModel);

--- a/shell/src/app/debug/data-model/data-model.spec.ts
+++ b/shell/src/app/debug/data-model/data-model.spec.ts
@@ -127,6 +127,30 @@ describe('DataModel', () => {
     });
   });
 
+  it('does not dispatch redundant message when local JSON matches incoming data model', async () => {
+    const incomingData = {foo: 'bar', count: 42};
+    mockHostComm.messageStream.set({
+      type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
+      payload: {
+        updateDataModel: {
+          surfaceId: 'sample-surface',
+          value: incomingData,
+        },
+      },
+      origin: 'http://localhost',
+      timestamp: Date.now(),
+    });
+    TestBed.tick();
+    fixture.detectChanges();
+
+    mockHostComm.sendMessage.mockClear();
+
+    await vi.advanceTimersByTimeAsync(300);
+    TestBed.tick();
+
+    expect(mockHostComm.sendMessage).not.toHaveBeenCalled();
+  });
+
   it('does not dispatch invalid JSON edits to host service', async () => {
     await harness.setModelText('{ invalid-json');
     TestBed.tick();

--- a/shell/src/app/debug/data-model/data-model.ts
+++ b/shell/src/app/debug/data-model/data-model.ts
@@ -95,7 +95,8 @@ export class DataModel {
           isValid = true;
           const currentIncoming = this.latestModelValue();
           const incomingStr = currentIncoming ? JSON.stringify(currentIncoming) : '';
-          if (incomingStr !== jsonStr.trim()) {
+          const localStr = JSON.stringify(parsed);
+          if (incomingStr !== localStr) {
             // prettier-ignore
             this.hostComm.sendMessage({
               'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,

--- a/shell/src/app/debug/data-model/data-model.ts
+++ b/shell/src/app/debug/data-model/data-model.ts
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-import {Component, inject, signal, computed, linkedSignal, effect, untracked} from '@angular/core';
-import {formatJson} from '../../utils/json';
-import {toObservable} from '@angular/core/rxjs-interop';
+import {Component, computed, effect, inject, linkedSignal, signal, untracked} from '@angular/core';
+import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
+import {FormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
-import {FormsModule} from '@angular/forms';
-import {debounceTime, distinctUntilChanged, filter} from 'rxjs/operators';
+import {DataModelChangePayload, PreviewBridgeMessageType} from 'a2ui-bridge';
+import {debounceTime, distinctUntilChanged} from 'rxjs/operators';
 import {HostCommunication} from '../../shell/host-communication/host-communication';
-import {PreviewBridgeMessageType, DataModelChangePayload} from 'a2ui-bridge';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {formatJson} from '../../utils/json';
 
 /**
  * A debug drawer component presenting a reactive, nested JSON tree explorer
@@ -37,6 +38,7 @@ import {PreviewBridgeMessageType, DataModelChangePayload} from 'a2ui-bridge';
 })
 export class DataModel {
   private readonly hostComm = inject(HostCommunication);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   private lastSurfaceId = 'sample-surface';
   private lastPath: string | undefined = undefined;
@@ -85,38 +87,32 @@ export class DataModel {
     });
 
     toObservable(this.dataModelJson)
-      .pipe(
-        debounceTime(300),
-        distinctUntilChanged(),
-        filter((jsonStr: string) => {
-          try {
-            JSON.parse(jsonStr);
-            return true;
-          } catch {
-            return false;
-          }
-        }),
-      )
-      .subscribe((validJsonStr: string) => {
-        const parsed = JSON.parse(validJsonStr);
-        const currentIncoming = this.latestModelValue();
-        const incomingStr = currentIncoming ? JSON.stringify(currentIncoming) : '';
-        const localStr = JSON.stringify(parsed);
-
-        if (incomingStr !== localStr) {
-          // NOTE: Quoted keys prevent compiler minification renaming across frame boundaries.
-          // prettier-ignore
-          this.hostComm.sendMessage({
-            'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,
-            'payload': {
-              'updateDataModel': {
-                'surfaceId': this.lastSurfaceId,
-                'path': this.lastPath,
-                'value': parsed,
+      .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed())
+      .subscribe((jsonStr: string) => {
+        let isValid = false;
+        try {
+          const parsed = JSON.parse(jsonStr);
+          isValid = true;
+          const currentIncoming = this.latestModelValue();
+          const incomingStr = currentIncoming ? JSON.stringify(currentIncoming) : '';
+          if (incomingStr !== jsonStr.trim()) {
+            // prettier-ignore
+            this.hostComm.sendMessage({
+              'type': PreviewBridgeMessageType.DATA_MODEL_CHANGE,
+              'payload': {
+                'updateDataModel': {
+                  'surfaceId': this.lastSurfaceId,
+                  'path': this.lastPath,
+                  'value': parsed,
+                },
               },
-            },
-          });
+            });
+          }
+        } catch {
+          isValid = false;
         }
+
+        this.usageTrackingService.trackDataModelEdit({isValidJson: isValid});
       });
   }
 }

--- a/shell/src/app/debug/raw-messages/raw-messages.ng.html
+++ b/shell/src/app/debug/raw-messages/raw-messages.ng.html
@@ -18,7 +18,12 @@
     @if (messageHistory().length > 0) {
       @for (item of messageHistory(); track item.type + '-' + item.timestamp) {
         @if (isCollapsible(item)) {
-          <mat-expansion-panel data-testid="llm-log-panel" class="llm-log-panel" [expanded]="false">
+          <mat-expansion-panel
+            data-testid="llm-log-panel"
+            class="llm-log-panel"
+            [expanded]="false"
+            (opened)="onExpand(item)"
+          >
             <mat-expansion-panel-header>
               <mat-panel-title>
                 <span class="timestamp">{{ item.timestampStr }}</span>

--- a/shell/src/app/debug/raw-messages/raw-messages.spec.ts
+++ b/shell/src/app/debug/raw-messages/raw-messages.spec.ts
@@ -27,6 +27,8 @@ import {signal, WritableSignal} from '@angular/core';
 import {ChatState, LlmLogEntry, LlmLogType} from '../../chat/chat-state/chat-state';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 
 describe('RawMessages', () => {
   let fixture: ComponentFixture<RawMessages>;
@@ -94,6 +96,10 @@ describe('RawMessages', () => {
         {
           provide: ChatState,
           useValue: chatStateMock,
+        },
+        {
+          provide: UsageTrackingService,
+          useClass: NoopUsageTrackingService,
         },
       ],
     }).compileComponents();
@@ -391,5 +397,20 @@ describe('RawMessages', () => {
     await panel0.collapse();
     expect(await panel0.isExpanded()).toBe(false);
     expect(await panel1.isExpanded()).toBe(true);
+  });
+
+  it('tracks raw message expanded when an accordion item is expanded', () => {
+    const trackingService = TestBed.inject(UsageTrackingService);
+    const trackSpy = vi.spyOn(trackingService, 'trackRawMessageExpanded');
+    const entry: RawLogEntry = {
+      type: LlmLogType.REQUEST,
+      payload: {prompt: 'hello'},
+      timestamp: 1000,
+      timestampStr: '12:00:00.000',
+    };
+    (component as unknown as {onExpand: (e: unknown) => void}).onExpand(entry);
+    expect(trackSpy).toHaveBeenCalledWith({
+      messageType: LlmLogType.REQUEST,
+    });
   });
 });

--- a/shell/src/app/debug/raw-messages/raw-messages.ts
+++ b/shell/src/app/debug/raw-messages/raw-messages.ts
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
+import {JsonPipe} from '@angular/common';
 import {
+  afterRenderEffect,
   Component,
+  effect,
+  ElementRef,
   inject,
+  OnDestroy,
   signal,
   viewChild,
-  afterRenderEffect,
-  ElementRef,
-  OnDestroy,
-  effect,
 } from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
-import {JsonPipe} from '@angular/common';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {ChatState} from '../../chat/chat-state/chat-state';
 import {
   HostCommunication,
   MessageEnvelope,
 } from '../../shell/host-communication/host-communication';
-import {PreviewBridgeMessageType} from 'a2ui-bridge';
-import {ChatState} from '../../chat/chat-state/chat-state';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
 import {formatTimestamp} from '../../utils/date.utils';
 
 export interface RawLogEntry {
@@ -56,6 +57,7 @@ export interface RawLogEntry {
 export class RawMessages implements OnDestroy {
   private readonly hostComm = inject(HostCommunication);
   private readonly chatState = inject(ChatState);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   protected readonly messageHistory = signal<RawLogEntry[]>([]);
 
@@ -151,6 +153,10 @@ export class RawMessages implements OnDestroy {
       item.type !== PreviewBridgeMessageType.FORCE_UNBLOCK &&
       item.type !== PreviewBridgeMessageType.SET_BLOCKING_STATE
     );
+  }
+
+  protected onExpand(item: RawLogEntry): void {
+    this.usageTrackingService.trackRawMessageExpanded({messageType: item.type});
   }
 
   private addLogEntry(entry: RawLogEntry): void {

--- a/shell/src/app/gallery/gallery.spec.ts
+++ b/shell/src/app/gallery/gallery.spec.ts
@@ -34,6 +34,8 @@ import {
   ThemePreference,
 } from '../settings/app-config-provider/app-config-provider';
 import {ChatState} from '../chat/chat-state/chat-state';
+import {UsageTrackingService} from '../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../usage-tracking/noop-usage-tracking.service';
 
 interface TestFriendlyGallery {
   catalogId: () => string | null;
@@ -101,6 +103,7 @@ describe('Gallery Component', () => {
         {provide: StartupResolution, useClass: MockStartupResolution},
         {provide: AppConfigProvider, useValue: {themePreference: signal(ThemePreference.LIGHT)}},
         {provide: ChatState, useClass: MockChatState},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     }).compileComponents();
 
@@ -120,7 +123,7 @@ describe('Gallery Component', () => {
       },
     });
 
-    writeTextSpy = vi.fn();
+    writeTextSpy = vi.fn().mockResolvedValue(undefined);
     originalClipboard = navigator.clipboard;
     Object.defineProperty(navigator, 'clipboard', {
       value: {writeText: writeTextSpy},
@@ -997,5 +1000,49 @@ describe('Gallery Component', () => {
     );
 
     consoleErrorSpy.mockRestore();
+  });
+
+  describe('Usage Tracking Instrumentation', () => {
+    it('tracks gallery view on init', () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackSpy = vi.spyOn(trackingService, 'trackGalleryView');
+
+      fixture.componentInstance.ngOnInit();
+
+      expect(trackSpy).toHaveBeenCalledWith();
+    });
+
+    it('tracks component select when item is chosen', () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackSpy = vi.spyOn(trackingService, 'trackGalleryComponentSelect');
+
+      catalogServiceMock.componentsList.set([{category: 'Content', components: ['Text']}]);
+
+      (fixture.componentInstance as unknown as {selectComponent: (k: string) => void})[
+        'selectComponent'
+      ]('Text');
+
+      expect(trackSpy).toHaveBeenCalledWith({
+        componentKey: 'Text',
+        category: 'Content',
+      });
+    });
+
+    it('tracks copying usage snippet to clipboard', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackSpy = vi.spyOn(trackingService, 'trackGalleryCopyUsage');
+
+      catalogServiceMock.selectedComponentPreset.set({
+        usage: [{id: 'target', component: 'Text'}],
+      });
+      catalogServiceMock.selectedComponentKey.set('Text');
+
+      (fixture.componentInstance as unknown as TestFriendlyGallery).copyToClipboard();
+      await Promise.resolve();
+
+      expect(trackSpy).toHaveBeenCalledWith({
+        componentKey: 'Text',
+      });
+    });
   });
 });

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -39,6 +39,7 @@ import {RenderedFrame} from '../preview/rendered/rendered-frame';
 import {HostCommunication} from '../shell/host-communication/host-communication';
 import {formatJson} from '../utils/json';
 import {PreviewBridgeMessageType, ComponentUsage, RenderA2uiItem} from 'a2ui-bridge';
+import {UsageTrackingService} from '../usage-tracking/usage-tracking.service';
 
 /**
  * Displays a split visual catalog gallery enabling search, interactive component selection,
@@ -66,6 +67,7 @@ export class Gallery implements OnInit, OnDestroy {
   private readonly catalogService = inject(GalleryCatalog);
   protected readonly catalogManagement = inject(CatalogManagement);
   private readonly hostCommunication = inject(HostCommunication);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   constructor() {
     this.hostCommunication.messageStream$
@@ -134,6 +136,7 @@ export class Gallery implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.catalogService.setGalleryActive(true);
+    this.usageTrackingService.trackGalleryView();
   }
 
   ngOnDestroy(): void {
@@ -188,6 +191,10 @@ export class Gallery implements OnInit, OnDestroy {
    */
   protected selectComponent(key: string | null): void {
     this.catalogService.selectComponent(key);
+    if (key) {
+      const category = this.componentsList().find(c => c.components.includes(key))!.category;
+      this.usageTrackingService.trackGalleryComponentSelect({componentKey: key, category});
+    }
   }
 
   private getComponentsPayload(
@@ -243,7 +250,7 @@ export class Gallery implements OnInit, OnDestroy {
   }
 
   /**
-   * Copies the usage JSON payload to the system clipboard.
+   * Copies formatted A2UI JSON payload commands to the user's clipboard.
    */
   protected copyToClipboard(): void {
     const preset = this.catalogService.selectedComponentPreset();
@@ -265,9 +272,16 @@ export class Gallery implements OnInit, OnDestroy {
         return;
       }
 
-      navigator.clipboard.writeText(payload).catch(err => {
-        console.error('Failed to copy A2UI component usage to clipboard: ', err);
-      });
+      navigator.clipboard
+        .writeText(payload)
+        .then(() => {
+          this.usageTrackingService.trackGalleryCopyUsage({
+            componentKey: this.selectedComponentKey() || '',
+          });
+        })
+        .catch(err => {
+          console.error('Failed to copy A2UI component usage to clipboard: ', err);
+        });
     } catch (err) {
       console.error('Failed to parse or format A2UI usage payload: ', err);
     }

--- a/shell/src/app/preview/raw/raw-frame.spec.ts
+++ b/shell/src/app/preview/raw/raw-frame.spec.ts
@@ -35,6 +35,8 @@ import {
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import type * as monaco from 'monaco-editor';
 import {MatSnackBar} from '@angular/material/snack-bar';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 
 const {createMock, mockEditor, mockModel, undoStack, redoStack} = vi.hoisted(() => {
   const undoStack: string[] = [];
@@ -336,6 +338,7 @@ describe('RawFrame JSON Source Editor View', () => {
         {provide: StateSync, useClass: MockStateSync},
         {provide: ChatState, useClass: MockChatState},
         {provide: MatSnackBar, useValue: snackBarMock},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     }).compileComponents();
 

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -34,6 +34,7 @@ import {StateSync} from '../../chat/state-sync/state-sync';
 import {ChatState} from '../../chat/chat-state/chat-state';
 import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
 
 /**
  * Hosts the raw JSON view of active surface models, allowing direct source editing
@@ -59,6 +60,7 @@ export class RawFrame {
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly stateSync = inject(StateSync);
   private readonly chatState = inject(ChatState);
+  private readonly usageTrackingService = inject(UsageTrackingService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly snackBar = inject(MatSnackBar);
   private readonly layoutInput$ = new Subject<string>();
@@ -148,12 +150,15 @@ export class RawFrame {
             const payload = this.parseLayoutString(value);
             if (payload !== null) {
               this.snackBar.dismiss();
+              this.usageTrackingService.trackJsonEditorEdit({isValidJson: true});
               return payload;
             }
             this.showJsonSyntaxError();
+            this.usageTrackingService.trackJsonEditorEdit({isValidJson: false});
             return null;
           } catch (err) {
             this.showJsonSyntaxError();
+            this.usageTrackingService.trackJsonEditorEdit({isValidJson: false});
             return null;
           }
         }),

--- a/shell/src/app/settings/settings-service/settings.service.spec.ts
+++ b/shell/src/app/settings/settings-service/settings.service.spec.ts
@@ -27,6 +27,8 @@ import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {ApiKeyAction, UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
 
 describe('SettingsService', () => {
@@ -113,6 +115,7 @@ describe('SettingsService', () => {
         {provide: StartupResolution, useValue: mockStartupResolution},
         {provide: AppConfigProvider, useValue: mockConfigProvider},
         {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     });
 
@@ -236,6 +239,7 @@ describe('SettingsService', () => {
         {provide: AppConfigProvider, useValue: mockConfigProvider},
         {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
         {provide: IS_1P_AUTH_ENABLED, useValue: true},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     });
 
@@ -748,6 +752,74 @@ describe('SettingsService', () => {
           rendererUrl: 'example.com',
         }),
       ).toThrow('Custom renderer URL must start with http:// or https://');
+    });
+  });
+
+  describe('Usage Tracking Instrumentation', () => {
+    it('tracks switching renderers', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackSpy = vi.spyOn(trackingService, 'trackRendererSwitch');
+
+      await service.selectRenderer('dev');
+
+      expect(trackSpy).toHaveBeenCalledWith({
+        fromRendererId: null,
+        toRendererId: 'dev',
+      });
+    });
+
+    it('tracks adding and editing custom renderers', () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackAddSpy = vi.spyOn(trackingService, 'trackRendererAdd');
+      const trackEditSpy = vi.spyOn(trackingService, 'trackRendererEdit');
+
+      service.saveCustomRenderer({
+        id: 'new-custom',
+        name: 'New Custom',
+        rendererUrl: 'http://localhost:5000',
+      });
+
+      expect(trackAddSpy).toHaveBeenCalledWith({rendererId: 'new-custom'});
+
+      service.saveCustomRenderer({
+        id: 'new-custom',
+        name: 'New Custom Updated',
+        rendererUrl: 'http://localhost:5001',
+      });
+
+      expect(trackEditSpy).toHaveBeenCalledWith({rendererId: 'new-custom'});
+    });
+
+    it('tracks deleting custom renderers', () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackDeleteSpy = vi.spyOn(trackingService, 'trackRendererDelete');
+
+      service.deleteCustomRenderer('new-custom');
+
+      expect(trackDeleteSpy).toHaveBeenCalledWith({rendererId: 'new-custom'});
+    });
+
+    it('tracks selecting, adding, and deleting API keys', async () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackApiKeySpy = vi.spyOn(trackingService, 'trackApiKeyUpdate');
+
+      await service.selectApiKey('custom-key-1');
+      expect(trackApiKeySpy).toHaveBeenCalledWith({
+        action: ApiKeyAction.SELECT,
+        keyId: 'custom-key-1',
+      });
+
+      await service.saveCustomApiKey('key-id', 'Key Name', 'AIzaKey');
+      expect(trackApiKeySpy).toHaveBeenCalledWith({
+        action: ApiKeyAction.ADD,
+        keyId: 'key-id',
+      });
+
+      await service.deleteCustomApiKey('key-id');
+      expect(trackApiKeySpy).toHaveBeenCalledWith({
+        action: ApiKeyAction.DELETE,
+        keyId: 'key-id',
+      });
     });
   });
 });

--- a/shell/src/app/settings/settings-service/settings.service.spec.ts
+++ b/shell/src/app/settings/settings-service/settings.service.spec.ts
@@ -806,19 +806,16 @@ describe('SettingsService', () => {
       await service.selectApiKey('custom-key-1');
       expect(trackApiKeySpy).toHaveBeenCalledWith({
         action: ApiKeyAction.SELECT,
-        keyId: 'custom-key-1',
       });
 
       await service.saveCustomApiKey('key-id', 'Key Name', 'AIzaKey');
       expect(trackApiKeySpy).toHaveBeenCalledWith({
         action: ApiKeyAction.ADD,
-        keyId: 'key-id',
       });
 
       await service.deleteCustomApiKey('key-id');
       expect(trackApiKeySpy).toHaveBeenCalledWith({
         action: ApiKeyAction.DELETE,
-        keyId: 'key-id',
       });
     });
   });

--- a/shell/src/app/settings/settings-service/settings.service.ts
+++ b/shell/src/app/settings/settings-service/settings.service.ts
@@ -24,6 +24,7 @@ import {AppConfigProvider} from '../app-config-provider/app-config-provider';
 import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {ApiKeyAction, UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
 
 /**
  * Represents an available API key option from static config or custom storage.
@@ -64,6 +65,7 @@ export class SettingsService {
   private readonly configProvider = inject(AppConfigProvider);
   private readonly secureCredentialsStorage = inject(SecureCredentialsStorage);
   private readonly localStorageInteractions = inject(LocalStorageInteractions);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   readonly renderers: Signal<Record<string, RendererConfig>> = computed(() =>
     this.startupResolution.renderers(),
@@ -83,10 +85,16 @@ export class SettingsService {
    * @param rendererId The selected renderer ID string, or null to revert to Custom/Default.
    */
   async selectRenderer(rendererId: string | null): Promise<boolean> {
+    const fromRendererId = this.selectedRendererId();
     const isAllowed = await this.startupResolution.setSelectedRendererId(rendererId);
     if (!isAllowed) {
       return false;
     }
+
+    this.usageTrackingService.trackRendererSwitch({
+      fromRendererId,
+      toRendererId: rendererId || '',
+    });
 
     if (rendererId) {
       this.localStorageInteractions.setItem(LocalStorageKey.SELECTED_RENDERER, rendererId);
@@ -165,6 +173,11 @@ export class SettingsService {
    * Selects an API key by ID and updates persistence.
    */
   async selectApiKey(apiKeyId: string | null): Promise<void> {
+    this.usageTrackingService.trackApiKeyUpdate({
+      action: ApiKeyAction.SELECT,
+      keyId: apiKeyId || '',
+    });
+
     if (apiKeyId) {
       this.localStorageInteractions.setItem(LocalStorageKey.SELECTED_API_KEY, apiKeyId);
     } else {
@@ -218,6 +231,10 @@ export class SettingsService {
         `Cannot save custom API key with ID "${id}": collides with a static configuration key.`,
       );
     }
+    this.usageTrackingService.trackApiKeyUpdate({
+      action: ApiKeyAction.ADD,
+      keyId: id,
+    });
     await this.secureCredentialsStorage.saveCustomApiKey(id, name, key);
     await this.syncEffectiveApiKeyToConfigProvider();
   }
@@ -226,6 +243,10 @@ export class SettingsService {
    * Deletes a custom API key from SecureCredentialsStorage.
    */
   async deleteCustomApiKey(id: string): Promise<void> {
+    this.usageTrackingService.trackApiKeyUpdate({
+      action: ApiKeyAction.DELETE,
+      keyId: id,
+    });
     await this.secureCredentialsStorage.deleteCustomApiKey(id);
     if (this._selectedApiKeyId() === id) {
       await this.selectApiKey(null);
@@ -343,12 +364,14 @@ export class SettingsService {
         name,
         rendererUrl,
       };
+      this.usageTrackingService.trackRendererEdit({rendererId: id});
     } else {
       list.push({
         id,
         name,
         rendererUrl,
       });
+      this.usageTrackingService.trackRendererAdd({rendererId: id});
     }
     this.localStorageInteractions.setItem(LocalStorageKey.CUSTOM_RENDERERS, JSON.stringify(list));
   }
@@ -358,6 +381,7 @@ export class SettingsService {
    * Resets active renderer selection to null if deleting the currently selected custom renderer.
    */
   deleteCustomRenderer(id: string): void {
+    this.usageTrackingService.trackRendererDelete({rendererId: id});
     const list = this.getCustomRenderers().filter(item => item.id !== id);
     this.localStorageInteractions.setItem(LocalStorageKey.CUSTOM_RENDERERS, JSON.stringify(list));
     if (this.selectedRendererId() === id) {

--- a/shell/src/app/settings/settings-service/settings.service.ts
+++ b/shell/src/app/settings/settings-service/settings.service.ts
@@ -175,7 +175,6 @@ export class SettingsService {
   async selectApiKey(apiKeyId: string | null): Promise<void> {
     this.usageTrackingService.trackApiKeyUpdate({
       action: ApiKeyAction.SELECT,
-      keyId: apiKeyId || '',
     });
 
     if (apiKeyId) {
@@ -233,7 +232,6 @@ export class SettingsService {
     }
     this.usageTrackingService.trackApiKeyUpdate({
       action: ApiKeyAction.ADD,
-      keyId: id,
     });
     await this.secureCredentialsStorage.saveCustomApiKey(id, name, key);
     await this.syncEffectiveApiKeyToConfigProvider();
@@ -245,7 +243,6 @@ export class SettingsService {
   async deleteCustomApiKey(id: string): Promise<void> {
     this.usageTrackingService.trackApiKeyUpdate({
       action: ApiKeyAction.DELETE,
-      keyId: id,
     });
     await this.secureCredentialsStorage.deleteCustomApiKey(id);
     if (this._selectedApiKeyId() === id) {

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -37,6 +37,8 @@ import {
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {SettingsHarness} from './test/settings.harness';
 import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 import {
   SecureCredentialsStorage,
   CustomApiKey,
@@ -220,6 +222,7 @@ describe('Settings', () => {
         },
         {provide: SecureCredentialsStorage, useValue: mockSecureStorage},
         {provide: IS_1P_AUTH_ENABLED, useValue: enable1PAuth},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
         SettingsService,
       ],
     }).compileComponents();
@@ -358,6 +361,7 @@ describe('Settings', () => {
           },
           {provide: IS_1P_AUTH_ENABLED, useValue: true},
           {provide: CONFIG_URL, useValue: '/config.json'},
+          {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
         ],
       }).compileComponents();
 

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -14,29 +14,34 @@
  * limitations under the License.
  */
 
+import {DOCUMENT} from '@angular/common';
+import {signal, WritableSignal} from '@angular/core';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {ComposerShell} from './composer-shell';
-import {provideRouter, Router, RouterLinkActive} from '@angular/router';
+import {MatSnackBar} from '@angular/material/snack-bar';
 import {By} from '@angular/platform-browser';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
-import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {ComposerShellHarness} from './test/composer-shell.harness';
-import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
-import {DOCUMENT} from '@angular/common';
-import {IndexedDbStorage} from '../../storage/indexed-db-storage/indexed-db-storage';
-import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {provideRouter, Router, RouterLinkActive} from '@angular/router';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ChatCoordinator} from '../../chat/chat-service/chat-coordinator';
+import {StateSync} from '../../chat/state-sync/state-sync';
 import {
   AppConfigProvider,
   ThemePreference,
 } from '../../settings/app-config-provider/app-config-provider';
-import {signal, WritableSignal} from '@angular/core';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {IndexedDbStorage} from '../../storage/indexed-db-storage/indexed-db-storage';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {SessionStorageInteractions} from '../../storage/session-storage-interactions/session-storage-interactions';
-import {MatSnackBar} from '@angular/material/snack-bar';
-
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
+import {
+  ShareTrackingStatus,
+  UsageTrackingService,
+} from '../../usage-tracking/usage-tracking.service';
 import {StartupResolution} from '../startup-resolution/startup-resolution';
-import {StateSync} from '../../chat/state-sync/state-sync';
+import {ComposerShell} from './composer-shell';
+import {ComposerShellHarness} from './test/composer-shell.harness';
 
 describe('ComposerShell Layout', () => {
   let fixture: ComponentFixture<ComposerShell>;
@@ -58,6 +63,9 @@ describe('ComposerShell Layout', () => {
   };
   let stateSyncMock: {
     activeDraft: WritableSignal<string>;
+  };
+  let chatCoordinatorMock: {
+    currentTurnIndex: WritableSignal<number>;
   };
 
   beforeEach(async () => {
@@ -94,6 +102,10 @@ describe('ComposerShell Layout', () => {
       activeDraft: signal(''),
     };
 
+    chatCoordinatorMock = {
+      currentTurnIndex: signal(3),
+    };
+
     await TestBed.configureTestingModule({
       imports: [ComposerShell],
       providers: [
@@ -127,6 +139,14 @@ describe('ComposerShell Layout', () => {
           provide: StateSync,
           useValue: stateSyncMock,
         },
+        {
+          provide: ChatCoordinator,
+          useValue: chatCoordinatorMock,
+        },
+        {
+          provide: UsageTrackingService,
+          useClass: NoopUsageTrackingService,
+        },
       ],
     }).compileComponents();
 
@@ -158,14 +178,11 @@ describe('ComposerShell Layout', () => {
     expect(harness).toBeTruthy();
   });
 
-  it(
-    'displays the static header title A2UI Composer via test ' + 'harness inspection',
-    async () => {
-      expect(await harness.getHeaderTitleText()).toContain('A2UI Composer');
-    },
-  );
+  it('displays the static header title A2UI Composer via test harness inspection', async () => {
+    expect(await harness.getHeaderTitleText()).toContain('A2UI Composer');
+  });
 
-  it('dynamically updates the header title when ' + 'activeCatalogTitle mutates', async () => {
+  it('dynamically updates the header title when activeCatalogTitle mutates', async () => {
     catalogManagementServiceMock.activeCatalogTitle.set('Test Catalog');
     fixture.detectChanges();
     expect(await harness.getHeaderTitleText()).toBe('A2UI Composer - Test Catalog');
@@ -177,49 +194,48 @@ describe('ComposerShell Layout', () => {
     expect(await harness.getHeaderTooltipText()).toBe('Sample description');
   });
 
-  it(
-    'flushes session cache upon clicking New Session reset button ' +
-      'via test harness interaction',
-    async () => {
-      const consoleSpy = vi.spyOn(console, 'log');
-      await harness.clickResetButton();
-      expect(storageServiceMock.flushAllRecords).toHaveBeenCalled();
-      expect(localStorageServiceMock.removeItem).toHaveBeenCalledWith(
-        LocalStorageKey.SESSION_STATE,
-      );
-      expect(localStorageServiceMock.removeItem).toHaveBeenCalledWith(LocalStorageKey.EDITOR_CACHE);
-      expect(localStorageServiceMock.removeItem).not.toHaveBeenCalledWith(
-        LocalStorageKey.DOCKVIEW_LAYOUT,
-      );
-      expect(sessionStorageServiceMock.clear).toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith('Session state cleared.');
-    },
-  );
+  it('flushes session cache and tracks reset upon clicking New Session reset button', async () => {
+    const usageTracking = TestBed.inject(UsageTrackingService);
+    const resetSpy = vi.spyOn(usageTracking, 'trackSessionReset');
+    const sessionResetSpy = vi.spyOn(usageTracking, 'resetSession');
+    const consoleSpy = vi.spyOn(console, 'log');
 
-  it(
-    'toggles the dark theme SCSS class on the document body upon ' +
-      'clicking the theme toggle button via test harness interaction',
-    async () => {
-      const injectedDocument = TestBed.inject(DOCUMENT);
-      expect(injectedDocument.body.classList.contains('dark-theme')).toBe(false);
-      await harness.clickThemeToggleButton();
-      expect(injectedDocument.body.classList.contains('dark-theme')).toBe(true);
-      await harness.clickThemeToggleButton();
-      expect(injectedDocument.body.classList.contains('dark-theme')).toBe(false);
-    },
-  );
+    await harness.clickResetButton();
 
-  it(
-    'toggles the left sidebar collapsed state upon clicking ' +
-      'the hamburger button via test harness interaction',
-    async () => {
-      expect(await harness.isSidenavCollapsed()).toBe(true);
-      await harness.clickHamburgerButton();
-      expect(await harness.isSidenavCollapsed()).toBe(false);
-      await harness.clickHamburgerButton();
-      expect(await harness.isSidenavCollapsed()).toBe(true);
-    },
-  );
+    expect(resetSpy).toHaveBeenCalledWith({totalPromptTurns: 3});
+    expect(sessionResetSpy).toHaveBeenCalled();
+    expect(storageServiceMock.flushAllRecords).toHaveBeenCalled();
+    expect(localStorageServiceMock.removeItem).toHaveBeenCalledWith(LocalStorageKey.SESSION_STATE);
+    expect(localStorageServiceMock.removeItem).toHaveBeenCalledWith(LocalStorageKey.EDITOR_CACHE);
+    expect(localStorageServiceMock.removeItem).not.toHaveBeenCalledWith(
+      LocalStorageKey.DOCKVIEW_LAYOUT,
+    );
+    expect(sessionStorageServiceMock.clear).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith('Session state cleared.');
+  });
+
+  it('toggles the dark theme SCSS class and tracks theme change on toggle', async () => {
+    const usageTracking = TestBed.inject(UsageTrackingService);
+    const themeSpy = vi.spyOn(usageTracking, 'trackThemeToggle');
+    const injectedDocument = TestBed.inject(DOCUMENT);
+
+    expect(injectedDocument.body.classList.contains('dark-theme')).toBe(false);
+    await harness.clickThemeToggleButton();
+    expect(injectedDocument.body.classList.contains('dark-theme')).toBe(true);
+    expect(themeSpy).toHaveBeenCalledWith({theme: ThemePreference.DARK});
+
+    await harness.clickThemeToggleButton();
+    expect(injectedDocument.body.classList.contains('dark-theme')).toBe(false);
+    expect(themeSpy).toHaveBeenCalledWith({theme: ThemePreference.LIGHT});
+  });
+
+  it('toggles the left sidebar collapsed state upon clicking the hamburger button', async () => {
+    expect(await harness.isSidenavCollapsed()).toBe(true);
+    await harness.clickHamburgerButton();
+    expect(await harness.isSidenavCollapsed()).toBe(false);
+    await harness.clickHamburgerButton();
+    expect(await harness.isSidenavCollapsed()).toBe(true);
+  });
 
   it('ensures mat-sidenav-content margin-left is 0px to eliminate whitespace gap', async () => {
     const sidenavContent = fixture.nativeElement.querySelector('mat-sidenav-content');
@@ -274,7 +290,7 @@ describe('ComposerShell Layout', () => {
     expect(fixture.nativeElement.querySelectorAll('.nav-label').length).toBe(3);
   });
 
-  it('sets explicit aria-label attributes on navigation links and connects hamburger button to sidenav via aria-controls', () => {
+  it('sets explicit aria-label attributes on navigation links and connects hamburger button to sidenav', () => {
     const navLinks = Array.from(fixture.nativeElement.querySelectorAll('mat-nav-list a'));
     const ariaLabels = navLinks.map((link: unknown) =>
       (link as Element).getAttribute('aria-label'),
@@ -288,7 +304,7 @@ describe('ComposerShell Layout', () => {
     expect(hamburgerButton.getAttribute('aria-controls')).toBe('composer-sidenav');
   });
 
-  it('applies routerLinkActive="active-nav-item" to navigation links with exact matching on root so active anchor receives active-nav-item class', async () => {
+  it('applies routerLinkActive="active-nav-item" to navigation links with exact matching on root', async () => {
     const navLinks = Array.from(fixture.nativeElement.querySelectorAll('mat-nav-list a'));
     const rlaAttrs = navLinks.map((link: unknown) =>
       (link as Element).getAttribute('routerLinkActive'),
@@ -308,7 +324,9 @@ describe('ComposerShell Layout', () => {
   });
 
   describe('shareDesign & resetSession', () => {
-    it('copies renderer URL and compressed payload in URL hash to clipboard and reports size in snackbar', async () => {
+    it('copies renderer URL and compressed payload in URL hash to clipboard, tracks telemetry, and reports size in snackbar', async () => {
+      const usageTracking = TestBed.inject(UsageTrackingService);
+      const shareSpy = vi.spyOn(usageTracking, 'trackShareDesign');
       const snackBar = fixture.debugElement.injector.get(MatSnackBar);
       const snackBarSpy = vi.spyOn(snackBar, 'open');
       startupResolutionMock.resolvedUrl.set('http://my-renderer.com');
@@ -330,6 +348,12 @@ describe('ComposerShell Layout', () => {
           expect.stringContaining('#renderer=http%3A%2F%2Fmy-renderer.com'),
         );
         expect(writeTextSpy).toHaveBeenCalledWith(expect.stringContaining('a2ui=d1.'));
+        expect(shareSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: ShareTrackingStatus.SUCCESS,
+            compressedLengthChars: expect.any(Number),
+          }),
+        );
         expect(snackBarSpy).toHaveBeenCalledWith(
           expect.stringMatching(/Shareable link copied to clipboard \(\d+\.\d+ KB\)/),
           'Close',
@@ -368,7 +392,9 @@ describe('ComposerShell Layout', () => {
       }
     });
 
-    it('displays a snackbar warning when clipboard API is unavailable', async () => {
+    it('displays a snackbar warning and tracks clipboard unavailable when clipboard API is missing', async () => {
+      const usageTracking = TestBed.inject(UsageTrackingService);
+      const shareSpy = vi.spyOn(usageTracking, 'trackShareDesign');
       const snackBar = fixture.debugElement.injector.get(MatSnackBar);
       const snackBarSpy = vi.spyOn(snackBar, 'open');
       const document = TestBed.inject(DOCUMENT);
@@ -382,6 +408,10 @@ describe('ComposerShell Layout', () => {
         await component.shareDesign();
         expect(snackBarSpy).toHaveBeenCalledWith('Clipboard API unavailable', 'Close', {
           duration: 5000,
+        });
+        expect(shareSpy).toHaveBeenCalledWith({
+          status: ShareTrackingStatus.CLIPBOARD_UNAVAILABLE,
+          compressedLengthChars: 0,
         });
       } finally {
         spy.mockRestore();

--- a/shell/src/app/shell/composer-shell/composer-shell.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.ts
@@ -14,29 +14,33 @@
  * limitations under the License.
  */
 
+import {DOCUMENT} from '@angular/common';
 import {Component, computed, effect, inject, signal} from '@angular/core';
-import {MatToolbarModule} from '@angular/material/toolbar';
-import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatListModule} from '@angular/material/list';
-import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
-import {DOCUMENT} from '@angular/common';
-import {IndexedDbStorage} from '../../storage/indexed-db-storage/indexed-db-storage';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatTooltipModule} from '@angular/material/tooltip';
-import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
+import {ChatCoordinator} from '../../chat/chat-service/chat-coordinator';
+import {StateSync} from '../../chat/state-sync/state-sync';
 import {
   AppConfigProvider,
   ThemePreference,
 } from '../../settings/app-config-provider/app-config-provider';
-import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {CatalogManagement} from '../../storage/catalog-management/catalog-management';
+import {IndexedDbStorage} from '../../storage/indexed-db-storage/indexed-db-storage';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
+import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {SessionStorageInteractions} from '../../storage/session-storage-interactions/session-storage-interactions';
-
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
-import {StartupResolution} from '../startup-resolution/startup-resolution';
-import {StateSync} from '../../chat/state-sync/state-sync';
+import {
+  ShareTrackingStatus,
+  UsageTrackingService,
+} from '../../usage-tracking/usage-tracking.service';
 import {QueryParser} from '../query-parser/query-parser';
+import {StartupResolution} from '../startup-resolution/startup-resolution';
 
 /** Standard length for showing any snack bar notification. */
 const SNACK_BAR_DURATION_MS = 5000;
@@ -74,6 +78,8 @@ export class ComposerShell {
   private readonly configProvider = inject(AppConfigProvider);
   private readonly startupResolution = inject(StartupResolution);
   private readonly stateSync = inject(StateSync);
+  private readonly chatCoordinator = inject(ChatCoordinator);
+  private readonly usageTrackingService = inject(UsageTrackingService);
   private readonly snackBar = inject(MatSnackBar);
   private readonly document = inject(DOCUMENT);
 
@@ -115,9 +121,9 @@ export class ComposerShell {
    * Switches between light and dark visual design system palettes.
    */
   toggleTheme(): void {
-    this.configProvider.setThemePreference(
-      this.isDarkTheme() ? ThemePreference.LIGHT : ThemePreference.DARK,
-    );
+    const newTheme = this.isDarkTheme() ? ThemePreference.LIGHT : ThemePreference.DARK;
+    this.usageTrackingService.trackThemeToggle({theme: newTheme});
+    this.configProvider.setThemePreference(newTheme);
   }
 
   /**
@@ -131,6 +137,10 @@ export class ComposerShell {
     }
     const clipboard = this.document.defaultView?.navigator?.clipboard;
     if (!clipboard) {
+      this.usageTrackingService.trackShareDesign({
+        status: ShareTrackingStatus.CLIPBOARD_UNAVAILABLE,
+        compressedLengthChars: 0,
+      });
       this.snackBar.open('Clipboard API unavailable', 'Close', {duration: SNACK_BAR_DURATION_MS});
       return;
     }
@@ -138,6 +148,10 @@ export class ComposerShell {
     try {
       JSON.parse(activeDraft);
     } catch {
+      this.usageTrackingService.trackShareDesign({
+        status: ShareTrackingStatus.INVALID_JSON,
+        compressedLengthChars: 0,
+      });
       this.snackBar.open('Cannot share design: invalid JSON syntax', 'Close', {
         duration: SNACK_BAR_DURATION_MS,
       });
@@ -156,11 +170,19 @@ export class ComposerShell {
       shareUrl.search = '';
 
       await clipboard.writeText(shareUrl.toString());
+      this.usageTrackingService.trackShareDesign({
+        status: ShareTrackingStatus.SUCCESS,
+        compressedLengthChars: compressed.length,
+      });
       const lengthKb = (shareUrl.toString().length / 1024).toFixed(1);
       this.snackBar.open(`Shareable link copied to clipboard (${lengthKb} KB)`, 'Close', {
         duration: SNACK_BAR_DURATION_MS,
       });
     } catch (err) {
+      this.usageTrackingService.trackShareDesign({
+        status: ShareTrackingStatus.FAILURE,
+        compressedLengthChars: 0,
+      });
       console.error('Failed to copy shareable link:', err);
       this.snackBar.open('Failed to copy link to clipboard', 'Close', {
         duration: SNACK_BAR_DURATION_MS,
@@ -173,6 +195,10 @@ export class ComposerShell {
    * the page to simulate a fresh hardware handshake connection.
    */
   async resetSession(): Promise<void> {
+    this.usageTrackingService.trackSessionReset({
+      totalPromptTurns: this.chatCoordinator.currentTurnIndex(),
+    });
+    this.usageTrackingService.resetSession();
     await this.indexedDbStorage.flushAllRecords();
     this.storage.removeItem(LocalStorageKey.SESSION_STATE);
     this.storage.removeItem(LocalStorageKey.EDITOR_CACHE);

--- a/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.spec.ts
@@ -38,6 +38,8 @@ import {
   ThemePreference,
 } from '../../settings/app-config-provider/app-config-provider';
 import {signal} from '@angular/core';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {NoopUsageTrackingService} from '../../usage-tracking/noop-usage-tracking.service';
 
 class MockChatState {
   readonly chatHistory = signal<LlmMessage[]>([]);
@@ -124,6 +126,7 @@ describe('ComposerWorkspace Dashboard', () => {
         {provide: StateSync, useClass: MockStateSync},
         {provide: AppConfigProvider, useClass: MockAppConfigProvider},
         {provide: LlmClient, useClass: MockLlmClient},
+        {provide: UsageTrackingService, useClass: NoopUsageTrackingService},
       ],
     }).compileComponents();
 
@@ -557,6 +560,24 @@ describe('ComposerWorkspace Dashboard', () => {
         true,
       );
       expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function), true);
+    });
+
+    it('tracks debug tab view when active panel changes', () => {
+      const trackingService = TestBed.inject(UsageTrackingService);
+      const trackSpy = vi.spyOn(trackingService, 'trackDebugTabView');
+      const manager = fixture.debugElement.injector.get(ComposerDockview);
+
+      const eventsPanel = manager.api.getGroupPanel(ComposerPanelId.Events);
+      expect(eventsPanel).toBeDefined();
+      if (!eventsPanel) return;
+
+      (
+        manager.api as unknown as {
+          _onDidActivePanelChange: {fire: (event: {panel: unknown}) => void};
+        }
+      )['_onDidActivePanelChange'].fire({panel: eventsPanel});
+
+      expect(trackSpy).toHaveBeenCalledWith({panelId: ComposerPanelId.Events});
     });
   });
 });

--- a/shell/src/app/shell/composer-workspace/composer-workspace.ts
+++ b/shell/src/app/shell/composer-workspace/composer-workspace.ts
@@ -36,6 +36,7 @@ import {
 } from '../../settings/app-config-provider/app-config-provider';
 import {ComposerPanelId} from './composer-panel-id';
 import {ComposerDockview} from './composer-dockview.service';
+import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
 
 export {ComposerPanelId};
 
@@ -61,6 +62,7 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
   private readonly hostComm = inject(HostCommunication);
   private readonly configProvider = inject(AppConfigProvider);
   private readonly composerDockview = inject(ComposerDockview);
+  private readonly usageTrackingService = inject(UsageTrackingService);
 
   readonly dockviewRoot = viewChild.required<ElementRef<HTMLElement>>('dockviewRoot');
 
@@ -141,6 +143,10 @@ export class ComposerWorkspace implements OnInit, AfterViewInit {
           untracked(() => this.unreadEventsCount.set(0));
         } else if (panelId === ComposerPanelId.Errors) {
           untracked(() => this.unreadErrorsCount.set(0));
+        }
+
+        if (panelId) {
+          this.usageTrackingService.trackDebugTabView({panelId: panelId as ComposerPanelId});
         }
       },
     });

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
@@ -1,0 +1,370 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  AppConfigProvider,
+  EnvMode,
+  ThemePreference,
+} from '../settings/app-config-provider/app-config-provider';
+import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
+import {StartupResolution} from '../shell/startup-resolution/startup-resolution';
+import {CatalogManagement} from '../storage/catalog-management/catalog-management';
+import {Ga4UsageTrackingService} from './ga4-usage-tracking.service';
+import {
+  ApiKeyAction,
+  PromptTurnType,
+  ShareTrackingStatus,
+  TrafficType,
+  USAGE_TRACKING_CONFIG,
+} from './usage-tracking.service';
+
+describe('Ga4UsageTrackingService', () => {
+  let service: Ga4UsageTrackingService;
+  let mockWindow: {
+    dataLayer: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  };
+  let mockDocument: Partial<Document>;
+
+  const mockStartupResolution = {
+    isThirdPartyEnvironment: signal(false),
+    selectedRendererId: signal('lit'),
+  };
+
+  const mockAppConfigProvider = {
+    envMode: signal(EnvMode.DEVELOPMENT),
+  };
+
+  const mockCatalogManagement = {
+    activeCatalog: signal({catalogId: 'basic-catalog', title: 'Basic Catalog'}),
+  };
+
+  beforeEach(() => {
+    mockWindow = {
+      dataLayer: [],
+      gtag: vi.fn((...args: unknown[]) => {
+        mockWindow.dataLayer.push(args);
+      }),
+    };
+
+    mockDocument = {
+      defaultView: mockWindow as unknown as Window,
+      querySelector: vi.fn().mockReturnValue(null),
+      createElement: vi.fn().mockImplementation((tag: string) => document.createElement(tag)),
+      head: {
+        appendChild: vi.fn(),
+      } as unknown as HTMLHeadElement,
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        Ga4UsageTrackingService,
+        {
+          provide: USAGE_TRACKING_CONFIG,
+          useValue: {enabled: true, measurementId: 'G-TEST1234'},
+        },
+        {provide: StartupResolution, useValue: mockStartupResolution},
+        {provide: AppConfigProvider, useValue: mockAppConfigProvider},
+        {provide: CatalogManagement, useValue: mockCatalogManagement},
+        {provide: DOCUMENT, useValue: mockDocument},
+      ],
+    });
+
+    service = TestBed.inject(Ga4UsageTrackingService);
+  });
+
+  it('initializes gtag dataLayer and appends script tag when enabled', () => {
+    service.initialize();
+    expect(mockWindow.dataLayer.length).toBeGreaterThanOrEqual(1);
+    expect(mockDocument.head?.appendChild).toHaveBeenCalled();
+  });
+
+  it('does not dispatch events when tracking is disabled', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        Ga4UsageTrackingService,
+        {
+          provide: USAGE_TRACKING_CONFIG,
+          useValue: {enabled: false, measurementId: ''},
+        },
+        {provide: StartupResolution, useValue: mockStartupResolution},
+        {provide: AppConfigProvider, useValue: mockAppConfigProvider},
+        {provide: CatalogManagement, useValue: mockCatalogManagement},
+        {provide: DOCUMENT, useValue: mockDocument},
+      ],
+    });
+    const disabledService = TestBed.inject(Ga4UsageTrackingService);
+    disabledService.trackPageView({pagePath: '/test'});
+    expect(mockWindow.gtag).not.toHaveBeenCalled();
+  });
+
+  it('resets session uuid when resetSession is called', () => {
+    const initialSession = service.composerSessionId;
+    service.resetSession();
+    expect(service.composerSessionId).not.toBe(initialSession);
+  });
+
+  it('tracks page view event with baseline dimensions', () => {
+    service.trackPageView({pagePath: '/chat'});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'page_view',
+      expect.objectContaining({
+        composer_session_id: service.composerSessionId,
+        traffic_type: TrafficType.FIRST_PARTY,
+        env_mode: EnvMode.DEVELOPMENT,
+        active_renderer_id: 'lit',
+        catalog_id: 'basic-catalog',
+        page_path: '/chat',
+      }),
+    );
+  });
+
+  it('tracks share design event', () => {
+    service.trackShareDesign({
+      status: ShareTrackingStatus.SUCCESS,
+      compressedLengthChars: 120,
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'share_design',
+      expect.objectContaining({
+        status: ShareTrackingStatus.SUCCESS,
+        compressed_length_chars: 120,
+      }),
+    );
+  });
+
+  it('tracks session reset event', () => {
+    service.trackSessionReset({totalPromptTurns: 4});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'session_reset',
+      expect.objectContaining({
+        total_prompt_turns: 4,
+      }),
+    );
+  });
+
+  it('tracks theme toggle event', () => {
+    service.trackThemeToggle({theme: ThemePreference.DARK});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'theme_toggle',
+      expect.objectContaining({
+        theme: ThemePreference.DARK,
+      }),
+    );
+  });
+
+  it('tracks chat prompt event', () => {
+    service.trackChatPrompt({
+      promptId: 'prompt-1',
+      catalogId: 'basic-catalog',
+      turnType: PromptTurnType.INITIAL,
+      turnIndex: 0,
+      attemptNumber: 1,
+      hasScreenshot: true,
+      attachmentCount: 2,
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'chat_prompt',
+      expect.objectContaining({
+        prompt_id: 'prompt-1',
+        catalog_id: 'basic-catalog',
+        turn_type: PromptTurnType.INITIAL,
+        turn_index: 0,
+        attempt_number: 1,
+        has_screenshot: true,
+        attachment_count: 2,
+      }),
+    );
+  });
+
+  it('tracks chat retry event', () => {
+    service.trackChatRetry({
+      promptId: 'prompt-1',
+      catalogId: 'basic-catalog',
+      turnIndex: 0,
+      attemptNumber: 2,
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'chat_prompt_retry',
+      expect.objectContaining({
+        prompt_id: 'prompt-1',
+        catalog_id: 'basic-catalog',
+        turn_index: 0,
+        attempt_number: 2,
+      }),
+    );
+  });
+
+  it('tracks chat cancel event', () => {
+    service.trackChatCancel({
+      promptId: 'prompt-1',
+      turnIndex: 0,
+      pipelineStatus: 'streaming',
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'chat_prompt_cancel',
+      expect.objectContaining({
+        prompt_id: 'prompt-1',
+        turn_index: 0,
+        pipeline_status_at_cancel: 'streaming',
+      }),
+    );
+  });
+
+  it('tracks debug tab view event', () => {
+    service.trackDebugTabView({panelId: ComposerPanelId.RawMessages});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'debug_tab_view',
+      expect.objectContaining({tab_id: ComposerPanelId.RawMessages}),
+    );
+  });
+
+  it('tracks raw message expanded event', () => {
+    service.trackRawMessageExpanded({
+      messageType: PreviewBridgeMessageType.CONSOLE_LOG,
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'raw_message_expanded',
+      expect.objectContaining({
+        message_type: PreviewBridgeMessageType.CONSOLE_LOG,
+      }),
+    );
+  });
+
+  it('tracks data model edit event', () => {
+    service.trackDataModelEdit({isValidJson: true});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'data_model_edit',
+      expect.objectContaining({is_valid_json: true}),
+    );
+  });
+
+  it('tracks json editor edit event', () => {
+    service.trackJsonEditorEdit({isValidJson: false});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'json_editor_edit',
+      expect.objectContaining({is_valid_json: false}),
+    );
+  });
+
+  it('tracks gallery view event', () => {
+    service.trackGalleryView();
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'gallery_view',
+      expect.objectContaining({catalog_id: 'basic-catalog'}),
+    );
+  });
+
+  it('tracks gallery component select event', () => {
+    service.trackGalleryComponentSelect({
+      componentKey: 'button',
+      category: 'actions',
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'gallery_component_select',
+      expect.objectContaining({
+        component_key: 'button',
+        category: 'actions',
+      }),
+    );
+  });
+
+  it('tracks gallery copy usage event', () => {
+    service.trackGalleryCopyUsage({
+      componentKey: 'button',
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'gallery_copy_usage',
+      expect.objectContaining({
+        component_key: 'button',
+      }),
+    );
+  });
+
+  it('tracks renderer switch event', () => {
+    service.trackRendererSwitch({
+      fromRendererId: 'lit',
+      toRendererId: 'angular',
+    });
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'renderer_switch',
+      expect.objectContaining({
+        from_renderer_id: 'lit',
+        to_renderer_id: 'angular',
+      }),
+    );
+  });
+
+  it('tracks renderer add event', () => {
+    service.trackRendererAdd({rendererId: 'custom-r'});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'renderer_add',
+      expect.objectContaining({renderer_id: 'custom-r'}),
+    );
+  });
+
+  it('tracks renderer edit event', () => {
+    service.trackRendererEdit({rendererId: 'custom-r'});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'renderer_edit',
+      expect.objectContaining({renderer_id: 'custom-r'}),
+    );
+  });
+
+  it('tracks renderer delete event', () => {
+    service.trackRendererDelete({rendererId: 'custom-r'});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'renderer_delete',
+      expect.objectContaining({renderer_id: 'custom-r'}),
+    );
+  });
+
+  it('tracks api key update event', () => {
+    service.trackApiKeyUpdate({action: ApiKeyAction.SELECT, keyId: 'key-1'});
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'api_key_update',
+      expect.objectContaining({
+        action: ApiKeyAction.SELECT,
+        key_id: 'key-1',
+      }),
+    );
+  });
+});

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
@@ -176,8 +176,8 @@ describe('Ga4UsageTrackingService', () => {
     );
   });
 
-  it('tracks chat prompt event', () => {
-    service.trackChatPrompt({
+  it('tracks chat prompt event and returns resolved promptId', () => {
+    const returnedId = service.trackChatPrompt({
       promptId: 'prompt-1',
       catalogId: 'basic-catalog',
       turnType: PromptTurnType.INITIAL,
@@ -186,6 +186,7 @@ describe('Ga4UsageTrackingService', () => {
       hasScreenshot: true,
       attachmentCount: 2,
     });
+    expect(returnedId).toBe('prompt-1');
     expect(mockWindow.gtag).toHaveBeenCalledWith(
       'event',
       'chat_prompt',
@@ -201,21 +202,61 @@ describe('Ga4UsageTrackingService', () => {
     );
   });
 
-  it('tracks chat retry event', () => {
-    service.trackChatRetry({
-      promptId: 'prompt-1',
+  it('generates promptId if omitted in trackChatPrompt', () => {
+    const returnedId = service.trackChatPrompt({
+      catalogId: 'basic-catalog',
+      turnType: PromptTurnType.FOLLOWUP,
+      turnIndex: 1,
+      attemptNumber: 1,
+      hasScreenshot: false,
+      attachmentCount: 0,
+    });
+    expect(returnedId).toBeTruthy();
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'chat_prompt',
+      expect.objectContaining({
+        prompt_id: returnedId,
+        turn_type: PromptTurnType.FOLLOWUP,
+      }),
+    );
+  });
+
+  it('tracks chat retry event and includes retry_of_prompt_id if provided', () => {
+    const returnedId = service.trackChatRetry({
+      promptId: 'retry-prompt-1',
       catalogId: 'basic-catalog',
       turnIndex: 0,
       attemptNumber: 2,
+      retryOfPromptId: 'parent-prompt-1',
     });
+    expect(returnedId).toBe('retry-prompt-1');
     expect(mockWindow.gtag).toHaveBeenCalledWith(
       'event',
       'chat_prompt_retry',
       expect.objectContaining({
-        prompt_id: 'prompt-1',
+        prompt_id: 'retry-prompt-1',
         catalog_id: 'basic-catalog',
         turn_index: 0,
         attempt_number: 2,
+        retry_of_prompt_id: 'parent-prompt-1',
+      }),
+    );
+  });
+
+  it('generates promptId if omitted in trackChatRetry', () => {
+    const returnedId = service.trackChatRetry({
+      catalogId: 'basic-catalog',
+      turnIndex: 1,
+      attemptNumber: 2,
+    });
+    expect(returnedId).toBeTruthy();
+    expect(mockWindow.gtag).toHaveBeenCalledWith(
+      'event',
+      'chat_prompt_retry',
+      expect.objectContaining({
+        prompt_id: returnedId,
+        turn_index: 1,
       }),
     );
   });

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.spec.ts
@@ -32,7 +32,7 @@ import {
   ApiKeyAction,
   PromptTurnType,
   ShareTrackingStatus,
-  TrafficType,
+  UsageType,
   USAGE_TRACKING_CONFIG,
 } from './usage-tracking.service';
 
@@ -50,7 +50,7 @@ describe('Ga4UsageTrackingService', () => {
   };
 
   const mockAppConfigProvider = {
-    envMode: signal(EnvMode.DEVELOPMENT),
+    envMode: signal(EnvMode.STANDALONE),
   };
 
   const mockCatalogManagement = {
@@ -130,8 +130,8 @@ describe('Ga4UsageTrackingService', () => {
       'page_view',
       expect.objectContaining({
         composer_session_id: service.composerSessionId,
-        traffic_type: TrafficType.FIRST_PARTY,
-        env_mode: EnvMode.DEVELOPMENT,
+        usage_type: UsageType.FIRST_PARTY,
+        env_mode: EnvMode.STANDALONE,
         active_renderer_id: 'lit',
         catalog_id: 'basic-catalog',
         page_path: '/chat',
@@ -398,13 +398,12 @@ describe('Ga4UsageTrackingService', () => {
   });
 
   it('tracks api key update event', () => {
-    service.trackApiKeyUpdate({action: ApiKeyAction.SELECT, keyId: 'key-1'});
+    service.trackApiKeyUpdate({action: ApiKeyAction.SELECT});
     expect(mockWindow.gtag).toHaveBeenCalledWith(
       'event',
       'api_key_update',
       expect.objectContaining({
         action: ApiKeyAction.SELECT,
-        key_id: 'key-1',
       }),
     );
   });

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
@@ -1,0 +1,272 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {Injectable, inject} from '@angular/core';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {trustedResourceUrl} from 'safevalues';
+import {setScriptSrc} from 'safevalues/dom';
+import {
+  AppConfigProvider,
+  ThemePreference,
+} from '../settings/app-config-provider/app-config-provider';
+import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
+import {StartupResolution} from '../shell/startup-resolution/startup-resolution';
+import {CatalogManagement} from '../storage/catalog-management/catalog-management';
+import {
+  ApiKeyAction,
+  PromptTurnType,
+  ShareTrackingStatus,
+  TrafficType,
+  USAGE_TRACKING_CONFIG,
+  UsageTrackingService,
+} from './usage-tracking.service';
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * Google Analytics 4 implementation of UsageTrackingService with safe script injection
+ * and baseline dimensions enrichment.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class Ga4UsageTrackingService extends UsageTrackingService {
+  private readonly config = inject(USAGE_TRACKING_CONFIG);
+  private readonly startupResolution = inject(StartupResolution);
+  private readonly appConfigProvider = inject(AppConfigProvider);
+  private readonly catalogManagement = inject(CatalogManagement);
+  private readonly document = inject(DOCUMENT);
+
+  private _composerSessionId: string = crypto.randomUUID();
+
+  get composerSessionId(): string {
+    return this._composerSessionId;
+  }
+
+  resetSession(): void {
+    this._composerSessionId = crypto.randomUUID();
+  }
+
+  initialize(): void {
+    if (!this.config.enabled || !this.config.measurementId) {
+      return;
+    }
+
+    const windowObj = this.document.defaultView;
+    if (!windowObj) {
+      return;
+    }
+
+    windowObj.dataLayer = windowObj.dataLayer || [];
+    if (!windowObj.gtag) {
+      windowObj.gtag = function (...args: unknown[]) {
+        windowObj.dataLayer?.push(args);
+      };
+    }
+
+    windowObj.gtag('js', new Date());
+    windowObj.gtag('config', this.config.measurementId, {send_page_view: false});
+
+    const existingScript = this.document.querySelector(
+      `script[src*="${this.config.measurementId}"]`,
+    );
+    if (!existingScript && this.document.head) {
+      const script = this.document.createElement('script');
+      script.async = true;
+      const safeUrl = trustedResourceUrl`https://www.googletagmanager.com/gtag/js?id=${this.config.measurementId}`;
+      setScriptSrc(script, safeUrl);
+      this.document.head.appendChild(script);
+    }
+  }
+
+  private getBaselineDimensions(): Record<string, unknown> {
+    const is3P = this.startupResolution.isThirdPartyEnvironment();
+    const activeRendererId = this.startupResolution.selectedRendererId() || 'default';
+    const catalogObj = this.catalogManagement.activeCatalog();
+    const catalogId = catalogObj ? catalogObj.catalogId || catalogObj.$id || '' : '';
+    return {
+      composer_session_id: this._composerSessionId,
+      traffic_type: is3P ? TrafficType.THIRD_PARTY : TrafficType.FIRST_PARTY,
+      env_mode: this.appConfigProvider.envMode(),
+      active_renderer_id: activeRendererId,
+      catalog_id: catalogId,
+    };
+  }
+
+  private dispatchGtagEvent(name: string, params?: Record<string, unknown>): void {
+    if (!this.config.enabled || !this.config.measurementId) {
+      return;
+    }
+
+    const windowObj = this.document.defaultView;
+    if (!windowObj || !windowObj.gtag) {
+      return;
+    }
+
+    const payload = {
+      ...this.getBaselineDimensions(),
+      ...(params || {}),
+    };
+
+    windowObj.gtag('event', name, payload);
+  }
+
+  trackPageView(params: {pagePath: string}): void {
+    this.dispatchGtagEvent('page_view', {
+      page_path: params.pagePath,
+    });
+  }
+
+  trackShareDesign(params: {status: ShareTrackingStatus; compressedLengthChars: number}): void {
+    this.dispatchGtagEvent('share_design', {
+      status: params.status,
+      compressed_length_chars: params.compressedLengthChars,
+    });
+  }
+
+  trackSessionReset(params: {totalPromptTurns: number}): void {
+    this.dispatchGtagEvent('session_reset', {
+      total_prompt_turns: params.totalPromptTurns,
+    });
+  }
+
+  trackThemeToggle(params: {theme: ThemePreference}): void {
+    this.dispatchGtagEvent('theme_toggle', {
+      theme: params.theme,
+    });
+  }
+
+  trackChatPrompt(params: {
+    promptId: string;
+    catalogId: string;
+    turnType: PromptTurnType;
+    turnIndex: number;
+    attemptNumber: number;
+    hasScreenshot: boolean;
+    attachmentCount: number;
+  }): void {
+    this.dispatchGtagEvent('chat_prompt', {
+      prompt_id: params.promptId,
+      catalog_id: params.catalogId,
+      turn_type: params.turnType,
+      turn_index: params.turnIndex,
+      attempt_number: params.attemptNumber,
+      has_screenshot: params.hasScreenshot,
+      attachment_count: params.attachmentCount,
+    });
+  }
+
+  trackChatRetry(params: {
+    promptId: string;
+    catalogId: string;
+    turnIndex: number;
+    attemptNumber: number;
+  }): void {
+    this.dispatchGtagEvent('chat_prompt_retry', {
+      prompt_id: params.promptId,
+      catalog_id: params.catalogId,
+      turn_index: params.turnIndex,
+      attempt_number: params.attemptNumber,
+    });
+  }
+
+  trackChatCancel(params: {promptId: string; turnIndex: number; pipelineStatus: string}): void {
+    this.dispatchGtagEvent('chat_prompt_cancel', {
+      prompt_id: params.promptId,
+      turn_index: params.turnIndex,
+      pipeline_status_at_cancel: params.pipelineStatus,
+    });
+  }
+
+  trackDebugTabView(params: {panelId: ComposerPanelId}): void {
+    this.dispatchGtagEvent('debug_tab_view', {
+      tab_id: params.panelId,
+    });
+  }
+
+  trackRawMessageExpanded(params: {messageType: PreviewBridgeMessageType | string}): void {
+    this.dispatchGtagEvent('raw_message_expanded', {
+      message_type: params.messageType,
+    });
+  }
+
+  trackDataModelEdit(params: {isValidJson: boolean}): void {
+    this.dispatchGtagEvent('data_model_edit', {
+      is_valid_json: params.isValidJson,
+    });
+  }
+
+  trackJsonEditorEdit(params: {isValidJson: boolean}): void {
+    this.dispatchGtagEvent('json_editor_edit', {
+      is_valid_json: params.isValidJson,
+    });
+  }
+
+  trackGalleryView(): void {
+    this.dispatchGtagEvent('gallery_view');
+  }
+
+  trackGalleryComponentSelect(params: {componentKey: string; category: string}): void {
+    this.dispatchGtagEvent('gallery_component_select', {
+      component_key: params.componentKey,
+      category: params.category,
+    });
+  }
+
+  trackGalleryCopyUsage(params: {componentKey: string}): void {
+    this.dispatchGtagEvent('gallery_copy_usage', {
+      component_key: params.componentKey,
+    });
+  }
+
+  trackRendererSwitch(params: {fromRendererId: string | null; toRendererId: string}): void {
+    this.dispatchGtagEvent('renderer_switch', {
+      from_renderer_id: params.fromRendererId,
+      to_renderer_id: params.toRendererId,
+    });
+  }
+
+  trackRendererAdd(params: {rendererId: string}): void {
+    this.dispatchGtagEvent('renderer_add', {
+      renderer_id: params.rendererId,
+    });
+  }
+
+  trackRendererEdit(params: {rendererId: string}): void {
+    this.dispatchGtagEvent('renderer_edit', {
+      renderer_id: params.rendererId,
+    });
+  }
+
+  trackRendererDelete(params: {rendererId: string}): void {
+    this.dispatchGtagEvent('renderer_delete', {
+      renderer_id: params.rendererId,
+    });
+  }
+
+  trackApiKeyUpdate(params: {action: ApiKeyAction; keyId: string}): void {
+    this.dispatchGtagEvent('api_key_update', {
+      action: params.action,
+      key_id: params.keyId,
+    });
+  }
+}

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
@@ -34,6 +34,7 @@ import {
   USAGE_TRACKING_CONFIG,
   UsageTrackingService,
 } from './usage-tracking.service';
+import {generateUuid} from '../utils/uuid';
 
 declare global {
   interface Window {
@@ -56,14 +57,14 @@ export class Ga4UsageTrackingService extends UsageTrackingService {
   private readonly catalogManagement = inject(CatalogManagement);
   private readonly document = inject(DOCUMENT);
 
-  private _composerSessionId: string = crypto.randomUUID();
+  private _composerSessionId: string = generateUuid();
 
   get composerSessionId(): string {
     return this._composerSessionId;
   }
 
   resetSession(): void {
-    this._composerSessionId = crypto.randomUUID();
+    this._composerSessionId = generateUuid();
   }
 
   initialize(): void {
@@ -156,16 +157,17 @@ export class Ga4UsageTrackingService extends UsageTrackingService {
   }
 
   trackChatPrompt(params: {
-    promptId: string;
+    promptId?: string;
     catalogId: string;
     turnType: PromptTurnType;
     turnIndex: number;
     attemptNumber: number;
     hasScreenshot: boolean;
     attachmentCount: number;
-  }): void {
+  }): string {
+    const promptId = params.promptId || generateUuid();
     this.dispatchGtagEvent('chat_prompt', {
-      prompt_id: params.promptId,
+      prompt_id: promptId,
       catalog_id: params.catalogId,
       turn_type: params.turnType,
       turn_index: params.turnIndex,
@@ -173,20 +175,25 @@ export class Ga4UsageTrackingService extends UsageTrackingService {
       has_screenshot: params.hasScreenshot,
       attachment_count: params.attachmentCount,
     });
+    return promptId;
   }
 
   trackChatRetry(params: {
-    promptId: string;
+    promptId?: string;
     catalogId: string;
     turnIndex: number;
     attemptNumber: number;
-  }): void {
+    retryOfPromptId?: string;
+  }): string {
+    const promptId = params.promptId || generateUuid();
     this.dispatchGtagEvent('chat_prompt_retry', {
-      prompt_id: params.promptId,
+      prompt_id: promptId,
       catalog_id: params.catalogId,
       turn_index: params.turnIndex,
       attempt_number: params.attemptNumber,
+      ...(params.retryOfPromptId ? {retry_of_prompt_id: params.retryOfPromptId} : {}),
     });
+    return promptId;
   }
 
   trackChatCancel(params: {promptId: string; turnIndex: number; pipelineStatus: string}): void {

--- a/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/ga4-usage-tracking.service.ts
@@ -30,7 +30,7 @@ import {
   ApiKeyAction,
   PromptTurnType,
   ShareTrackingStatus,
-  TrafficType,
+  UsageType,
   USAGE_TRACKING_CONFIG,
   UsageTrackingService,
 } from './usage-tracking.service';
@@ -106,7 +106,7 @@ export class Ga4UsageTrackingService extends UsageTrackingService {
     const catalogId = catalogObj ? catalogObj.catalogId || catalogObj.$id || '' : '';
     return {
       composer_session_id: this._composerSessionId,
-      traffic_type: is3P ? TrafficType.THIRD_PARTY : TrafficType.FIRST_PARTY,
+      usage_type: is3P ? UsageType.THIRD_PARTY : UsageType.FIRST_PARTY,
       env_mode: this.appConfigProvider.envMode(),
       active_renderer_id: activeRendererId,
       catalog_id: catalogId,
@@ -270,10 +270,9 @@ export class Ga4UsageTrackingService extends UsageTrackingService {
     });
   }
 
-  trackApiKeyUpdate(params: {action: ApiKeyAction; keyId: string}): void {
+  trackApiKeyUpdate(params: {action: ApiKeyAction}): void {
     this.dispatchGtagEvent('api_key_update', {
       action: params.action,
-      key_id: params.keyId,
     });
   }
 }

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {ThemePreference} from '../settings/app-config-provider/app-config-provider';
+import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
+import {NoopUsageTrackingService} from './noop-usage-tracking.service';
+import {ApiKeyAction, PromptTurnType, ShareTrackingStatus} from './usage-tracking.service';
+
+describe('NoopUsageTrackingService', () => {
+  let service: NoopUsageTrackingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NoopUsageTrackingService],
+    });
+    service = TestBed.inject(NoopUsageTrackingService);
+  });
+
+  it('exposes a noop composerSessionId', () => {
+    expect(service.composerSessionId).toBe('noop-session');
+  });
+
+  it('executes all tracking methods cleanly without side effects or errors', () => {
+    expect(() => {
+      service.initialize();
+      service.resetSession();
+      service.trackPageView({pagePath: '/test'});
+      service.trackShareDesign({
+        status: ShareTrackingStatus.SUCCESS,
+        compressedLengthChars: 100,
+      });
+      service.trackSessionReset({totalPromptTurns: 3});
+      service.trackThemeToggle({theme: ThemePreference.DARK});
+      service.trackChatPrompt({
+        promptId: 'p1',
+        catalogId: 'cat1',
+        turnType: PromptTurnType.INITIAL,
+        turnIndex: 0,
+        attemptNumber: 1,
+        hasScreenshot: false,
+        attachmentCount: 0,
+      });
+      service.trackChatRetry({
+        promptId: 'p1',
+        catalogId: 'cat1',
+        turnIndex: 0,
+        attemptNumber: 2,
+      });
+      service.trackChatCancel({
+        promptId: 'p1',
+        turnIndex: 0,
+        pipelineStatus: 'streaming',
+      });
+      service.trackDebugTabView({panelId: ComposerPanelId.RawMessages});
+      service.trackRawMessageExpanded({
+        messageType: PreviewBridgeMessageType.CONSOLE_LOG,
+      });
+      service.trackDataModelEdit({isValidJson: true});
+      service.trackJsonEditorEdit({isValidJson: true});
+      service.trackGalleryView();
+      service.trackGalleryComponentSelect({
+        componentKey: 'button',
+        category: 'basics',
+      });
+      service.trackGalleryCopyUsage({componentKey: 'button'});
+      service.trackRendererSwitch({
+        fromRendererId: 'lit',
+        toRendererId: 'angular',
+      });
+      service.trackRendererAdd({rendererId: 'custom-1'});
+      service.trackRendererEdit({rendererId: 'custom-1'});
+      service.trackRendererDelete({rendererId: 'custom-1'});
+      service.trackApiKeyUpdate({action: ApiKeyAction.SELECT, keyId: 'k1'});
+    }).not.toThrow();
+  });
+});

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
@@ -47,7 +47,7 @@ describe('NoopUsageTrackingService', () => {
       });
       service.trackSessionReset({totalPromptTurns: 3});
       service.trackThemeToggle({theme: ThemePreference.DARK});
-      service.trackChatPrompt({
+      const promptId = service.trackChatPrompt({
         promptId: 'p1',
         catalogId: 'cat1',
         turnType: PromptTurnType.INITIAL,
@@ -56,12 +56,14 @@ describe('NoopUsageTrackingService', () => {
         hasScreenshot: false,
         attachmentCount: 0,
       });
-      service.trackChatRetry({
+      expect(promptId).toBe('p1');
+      const retryId = service.trackChatRetry({
         promptId: 'p1',
         catalogId: 'cat1',
         turnIndex: 0,
         attemptNumber: 2,
       });
+      expect(retryId).toBe('p1');
       service.trackChatCancel({
         promptId: 'p1',
         turnIndex: 0,

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.spec.ts
@@ -88,7 +88,7 @@ describe('NoopUsageTrackingService', () => {
       service.trackRendererAdd({rendererId: 'custom-1'});
       service.trackRendererEdit({rendererId: 'custom-1'});
       service.trackRendererDelete({rendererId: 'custom-1'});
-      service.trackApiKeyUpdate({action: ApiKeyAction.SELECT, keyId: 'k1'});
+      service.trackApiKeyUpdate({action: ApiKeyAction.SELECT});
     }).not.toThrow();
   });
 });

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Injectable} from '@angular/core';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {ThemePreference} from '../settings/app-config-provider/app-config-provider';
+import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
+import {
+  ApiKeyAction,
+  PromptTurnType,
+  ShareTrackingStatus,
+  UsageTrackingService,
+} from './usage-tracking.service';
+
+/**
+ * No-op implementation of UsageTrackingService used when tracking is disabled or in unit tests.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class NoopUsageTrackingService extends UsageTrackingService {
+  readonly composerSessionId = 'noop-session';
+
+  initialize(): void {}
+
+  resetSession(): void {}
+
+  trackPageView(_params: {pagePath: string}): void {}
+
+  trackShareDesign(_params: {status: ShareTrackingStatus; compressedLengthChars: number}): void {}
+
+  trackSessionReset(_params: {totalPromptTurns: number}): void {}
+
+  trackThemeToggle(_params: {theme: ThemePreference}): void {}
+
+  trackChatPrompt(_params: {
+    promptId: string;
+    catalogId: string;
+    turnType: PromptTurnType;
+    turnIndex: number;
+    attemptNumber: number;
+    hasScreenshot: boolean;
+    attachmentCount: number;
+  }): void {}
+
+  trackChatRetry(_params: {
+    promptId: string;
+    catalogId: string;
+    turnIndex: number;
+    attemptNumber: number;
+  }): void {}
+
+  trackChatCancel(_params: {promptId: string; turnIndex: number; pipelineStatus: string}): void {}
+
+  trackDebugTabView(_params: {panelId: ComposerPanelId}): void {}
+
+  trackRawMessageExpanded(_params: {messageType: PreviewBridgeMessageType | string}): void {}
+
+  trackDataModelEdit(_params: {isValidJson: boolean}): void {}
+
+  trackJsonEditorEdit(_params: {isValidJson: boolean}): void {}
+
+  trackGalleryView(): void {}
+
+  trackGalleryComponentSelect(_params: {componentKey: string; category: string}): void {}
+
+  trackGalleryCopyUsage(_params: {componentKey: string}): void {}
+
+  trackRendererSwitch(_params: {fromRendererId: string | null; toRendererId: string}): void {}
+
+  trackRendererAdd(_params: {rendererId: string}): void {}
+
+  trackRendererEdit(_params: {rendererId: string}): void {}
+
+  trackRendererDelete(_params: {rendererId: string}): void {}
+
+  trackApiKeyUpdate(_params: {action: ApiKeyAction; keyId: string}): void {}
+}

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
@@ -24,6 +24,7 @@ import {
   ShareTrackingStatus,
   UsageTrackingService,
 } from './usage-tracking.service';
+import {generateUuid} from '../utils/uuid';
 
 /**
  * No-op implementation of UsageTrackingService used when tracking is disabled or in unit tests.
@@ -46,22 +47,27 @@ export class NoopUsageTrackingService extends UsageTrackingService {
 
   trackThemeToggle(_params: {theme: ThemePreference}): void {}
 
-  trackChatPrompt(_params: {
-    promptId: string;
+  trackChatPrompt(params: {
+    promptId?: string;
     catalogId: string;
     turnType: PromptTurnType;
     turnIndex: number;
     attemptNumber: number;
     hasScreenshot: boolean;
     attachmentCount: number;
-  }): void {}
+  }): string {
+    return params.promptId || generateUuid();
+  }
 
-  trackChatRetry(_params: {
-    promptId: string;
+  trackChatRetry(params: {
+    promptId?: string;
     catalogId: string;
     turnIndex: number;
     attemptNumber: number;
-  }): void {}
+    retryOfPromptId?: string;
+  }): string {
+    return params.promptId || generateUuid();
+  }
 
   trackChatCancel(_params: {promptId: string; turnIndex: number; pipelineStatus: string}): void {}
 

--- a/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/noop-usage-tracking.service.ts
@@ -93,5 +93,5 @@ export class NoopUsageTrackingService extends UsageTrackingService {
 
   trackRendererDelete(_params: {rendererId: string}): void {}
 
-  trackApiKeyUpdate(_params: {action: ApiKeyAction; keyId: string}): void {}
+  trackApiKeyUpdate(_params: {action: ApiKeyAction}): void {}
 }

--- a/shell/src/app/usage-tracking/usage-tracking.service.spec.ts
+++ b/shell/src/app/usage-tracking/usage-tracking.service.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {describe, expect, it} from 'vitest';
+import {
+  DEFAULT_USAGE_TRACKING_CONFIG,
+  USAGE_TRACKING_CONFIG,
+  UsageTrackingConfig,
+} from './usage-tracking.service';
+
+describe('USAGE_TRACKING_CONFIG', () => {
+  it('provides default configuration with telemetry disabled', () => {
+    const config = TestBed.inject(USAGE_TRACKING_CONFIG);
+    expect(config).toEqual(DEFAULT_USAGE_TRACKING_CONFIG);
+    expect(config.enabled).toBe(false);
+    expect(config.measurementId).toBe('');
+  });
+
+  it('allows overriding configuration via dependency injection provider', () => {
+    const customConfig: UsageTrackingConfig = {
+      enabled: true,
+      measurementId: 'G-TEST123456',
+    };
+
+    TestBed.configureTestingModule({
+      providers: [{provide: USAGE_TRACKING_CONFIG, useValue: customConfig}],
+    });
+
+    const config = TestBed.inject(USAGE_TRACKING_CONFIG);
+    expect(config).toEqual(customConfig);
+    expect(config.enabled).toBe(true);
+    expect(config.measurementId).toBe('G-TEST123456');
+  });
+});

--- a/shell/src/app/usage-tracking/usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/usage-tracking.service.ts
@@ -20,9 +20,9 @@ import {ThemePreference} from '../settings/app-config-provider/app-config-provid
 import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
 
 /**
- * Traffic classification tag separating Google-internal usage from 3P open-source users.
+ * Classification tag separating Google-internal usage from 3P open-source users.
  */
-export enum TrafficType {
+export enum UsageType {
   FIRST_PARTY = '1P',
   THIRD_PARTY = '3P',
 }
@@ -214,5 +214,5 @@ export abstract class UsageTrackingService {
   /**
    * Tracks API key selection or management actions without logging secret key tokens.
    */
-  abstract trackApiKeyUpdate(params: {action: ApiKeyAction; keyId: string}): void;
+  abstract trackApiKeyUpdate(params: {action: ApiKeyAction}): void;
 }

--- a/shell/src/app/usage-tracking/usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/usage-tracking.service.ts
@@ -127,24 +127,25 @@ export abstract class UsageTrackingService {
    * Tracks user prompt dispatches to the LLM assistant.
    */
   abstract trackChatPrompt(params: {
-    promptId: string;
+    promptId?: string;
     catalogId: string;
     turnType: PromptTurnType;
     turnIndex: number;
     attemptNumber: number;
     hasScreenshot: boolean;
     attachmentCount: number;
-  }): void;
+  }): string;
 
   /**
    * Tracks prompt retries after failed turns.
    */
   abstract trackChatRetry(params: {
-    promptId: string;
+    promptId?: string;
     catalogId: string;
     turnIndex: number;
     attemptNumber: number;
-  }): void;
+    retryOfPromptId?: string;
+  }): string;
 
   /**
    * Tracks cancellation of in-flight LLM streams.

--- a/shell/src/app/usage-tracking/usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/usage-tracking.service.ts
@@ -50,6 +50,7 @@ export enum ApiKeyAction {
 export enum ShareTrackingStatus {
   SUCCESS = 'success',
   FAILURE = 'failure',
+  INVALID_JSON = 'invalid-json',
   CLIPBOARD_UNAVAILABLE = 'clipboard_unavailable',
 }
 

--- a/shell/src/app/usage-tracking/usage-tracking.service.ts
+++ b/shell/src/app/usage-tracking/usage-tracking.service.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {InjectionToken} from '@angular/core';
+import {PreviewBridgeMessageType} from 'a2ui-bridge';
+import {ThemePreference} from '../settings/app-config-provider/app-config-provider';
+import {ComposerPanelId} from '../shell/composer-workspace/composer-panel-id';
+
+/**
+ * Traffic classification tag separating Google-internal usage from 3P open-source users.
+ */
+export enum TrafficType {
+  FIRST_PARTY = '1P',
+  THIRD_PARTY = '3P',
+}
+
+/**
+ * Chat prompt turn type differentiating initial prompts from multi-turn follow-ups.
+ */
+export enum PromptTurnType {
+  INITIAL = 'initial',
+  FOLLOWUP = 'followup',
+}
+
+/**
+ * Actions performed on API keys in settings.
+ */
+export enum ApiKeyAction {
+  SELECT = 'select',
+  ADD = 'add',
+  DELETE = 'delete',
+}
+
+/**
+ * Status of the share design action.
+ */
+export enum ShareTrackingStatus {
+  SUCCESS = 'success',
+  FAILURE = 'failure',
+  CLIPBOARD_UNAVAILABLE = 'clipboard_unavailable',
+}
+
+/**
+ * Static or injected configuration for usage tracking.
+ */
+export interface UsageTrackingConfig {
+  readonly enabled: boolean;
+  readonly measurementId: string;
+}
+
+/**
+ * Default usage tracking configuration disabling telemetry out-of-the-box.
+ */
+export const DEFAULT_USAGE_TRACKING_CONFIG: UsageTrackingConfig = {
+  enabled: false,
+  measurementId: '',
+};
+
+/**
+ * Injection token for usage tracking configuration.
+ */
+export const USAGE_TRACKING_CONFIG = new InjectionToken<UsageTrackingConfig>(
+  'USAGE_TRACKING_CONFIG',
+  {
+    providedIn: 'root',
+    factory: () => DEFAULT_USAGE_TRACKING_CONFIG,
+  },
+);
+
+/**
+ * Abstract usage tracking service defining the contract for telemetry collection.
+ */
+export abstract class UsageTrackingService {
+  /**
+   * Initializes analytics scripts and global data layer bindings.
+   */
+  abstract initialize(): Promise<void> | void;
+
+  /**
+   * The current ephemeral session UUID.
+   */
+  abstract readonly composerSessionId: string;
+
+  /**
+   * Resets the ephemeral session identifier to break turn correlation.
+   */
+  abstract resetSession(): void;
+
+  /**
+   * Tracks virtual page views across Angular routes.
+   */
+  abstract trackPageView(params: {pagePath: string}): void;
+
+  /**
+   * Tracks share design URL generation attempts.
+   */
+  abstract trackShareDesign(params: {
+    status: ShareTrackingStatus;
+    compressedLengthChars: number;
+  }): void;
+
+  /**
+   * Tracks session reset button clicks.
+   */
+  abstract trackSessionReset(params: {totalPromptTurns: number}): void;
+
+  /**
+   * Tracks light/dark theme toggles.
+   */
+  abstract trackThemeToggle(params: {theme: ThemePreference}): void;
+
+  /**
+   * Tracks user prompt dispatches to the LLM assistant.
+   */
+  abstract trackChatPrompt(params: {
+    promptId: string;
+    catalogId: string;
+    turnType: PromptTurnType;
+    turnIndex: number;
+    attemptNumber: number;
+    hasScreenshot: boolean;
+    attachmentCount: number;
+  }): void;
+
+  /**
+   * Tracks prompt retries after failed turns.
+   */
+  abstract trackChatRetry(params: {
+    promptId: string;
+    catalogId: string;
+    turnIndex: number;
+    attemptNumber: number;
+  }): void;
+
+  /**
+   * Tracks cancellation of in-flight LLM streams.
+   */
+  abstract trackChatCancel(params: {
+    promptId: string;
+    turnIndex: number;
+    pipelineStatus: string;
+  }): void;
+
+  /**
+   * Tracks navigation and tab switches in the Dockview debug drawer.
+   */
+  abstract trackDebugTabView(params: {panelId: ComposerPanelId}): void;
+
+  /**
+   * Tracks raw message accordions expanded in raw messages panel.
+   */
+  abstract trackRawMessageExpanded(params: {messageType: PreviewBridgeMessageType | string}): void;
+
+  /**
+   * Tracks debounced manual edits in the Data Model panel.
+   */
+  abstract trackDataModelEdit(params: {isValidJson: boolean}): void;
+
+  /**
+   * Tracks debounced manual edits in the Monaco raw JSON editor.
+   */
+  abstract trackJsonEditorEdit(params: {isValidJson: boolean}): void;
+
+  /**
+   * Tracks navigating to the components gallery view.
+   */
+  abstract trackGalleryView(): void;
+
+  /**
+   * Tracks selecting a component card within the gallery.
+   */
+  abstract trackGalleryComponentSelect(params: {componentKey: string; category: string}): void;
+
+  /**
+   * Tracks copying component usage code from the gallery.
+   */
+  abstract trackGalleryCopyUsage(params: {componentKey: string}): void;
+
+  /**
+   * Tracks switching active renderer profiles in settings.
+   */
+  abstract trackRendererSwitch(params: {fromRendererId: string | null; toRendererId: string}): void;
+
+  /**
+   * Tracks registering a new custom renderer endpoint.
+   */
+  abstract trackRendererAdd(params: {rendererId: string}): void;
+
+  /**
+   * Tracks editing an existing renderer configuration.
+   */
+  abstract trackRendererEdit(params: {rendererId: string}): void;
+
+  /**
+   * Tracks deleting a custom renderer endpoint.
+   */
+  abstract trackRendererDelete(params: {rendererId: string}): void;
+
+  /**
+   * Tracks API key selection or management actions without logging secret key tokens.
+   */
+  abstract trackApiKeyUpdate(params: {action: ApiKeyAction; keyId: string}): void;
+}

--- a/shell/src/app/utils/uuid.spec.ts
+++ b/shell/src/app/utils/uuid.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {generateUuid} from './uuid';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('generateUuid', () => {
+  const originalCrypto = globalThis.crypto;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: originalCrypto,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('generates valid RFC4122 v4 UUID using crypto.randomUUID when available', () => {
+    const uuid = generateUuid();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('produces unique UUIDs across consecutive invocations', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateUuid());
+    }
+    expect(ids.size).toBe(100);
+  });
+
+  it('falls back to crypto.getRandomValues when crypto.randomUUID is undefined', () => {
+    const mockGetRandomValues = vi.fn((buffer: Uint8Array) => {
+      for (let i = 0; i < buffer.length; i++) {
+        buffer[i] = (i * 17 + 5) & 0xff;
+      }
+      return buffer;
+    });
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        getRandomValues: mockGetRandomValues,
+        randomUUID: undefined,
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    const uuid = generateUuid();
+    expect(mockGetRandomValues).toHaveBeenCalled();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it('falls back to Math.random when crypto is undefined', () => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    const uuid = generateUuid();
+    expect(uuid).toMatch(UUID_V4_REGEX);
+  });
+});

--- a/shell/src/app/utils/uuid.ts
+++ b/shell/src/app/utils/uuid.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Generates an RFC4122 version 4 compliant UUID string.
+ *
+ * Prioritizes standard `crypto.randomUUID()` available in secure browser contexts,
+ * falls back to `crypto.getRandomValues()` with RFC4122 v4 bit manipulation,
+ * and falls back to a `Math.random()` pseudo-random generator in legacy or non-secure HTTP contexts.
+ *
+ * @returns An RFC4122 v4 UUID string.
+ */
+export function generateUuid(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // RFC4122 v4 version (0100)
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // RFC4122 variant (10xx)
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
# Description

Add capabilities to track usage of the A2UI Composer based on Google Analytics.

In addition to page views, events that will be tracked:

| Category | Event Name | Parameters | Trigger / Purpose |
| :---- | :---- | :---- | :---- |
| **Shell & Header** | `share_design` | (`ShareTrackingStatus`: `SUCCESS`, `FAILURE`, `CLIPBOARD_UNAVAILABLE`), `catalog_id` (string, optional), `compressed_length_chars` (number, optional) | Clicking "Share design" button in header. |
|  | `session_reset` | `total_prompt_turns` (number) | Clicking "New Session" in header. |
|  | `theme_toggle` | `theme` (`ThemePreference`: `LIGHT` | `DARK`) | Toggling light/dark theme. |
| **Chat / Workspace** | `chat_prompt` | `prompt_id` (UUID), `catalog_id` (string), `turn_type` (`INITIAL` | `FOLLOWUP`), `turn_index` (number), `attempt_number` (1), `has_screenshot` (boolean), `attachment_count` (number) | Initial prompt dispatch. Prompt raw text/length omitted for privacy. |
|  | `chat_prompt_retry` | `prompt_id` (same UUID), `catalog_id` (string), `turn_index` (number), `attempt_number` (\>= 2\) | User clicks "Retry prompt" on failed turn. |
|  | `chat_prompt_cancel` | `prompt_id` (UUID), `turn_index` (number), `pipeline_status_at_cancel` (string) | User stops generation in-flight. |
|  | `debug_tab_view` | `tab_id` (`DebugTabId`: `DATA_MODEL`, `EVENTS`, `ERRORS`, `RAW_MESSAGES`, `MOCK_RULES`) | Activating tabs in Dockview debug pane. |
|  | `data_model_edit` | `is_valid_json` (boolean) | Debounced manual edit in Data Model panel. |
|  | `json_editor_edit` | `is_valid_json` (boolean) | Debounced edit in Monaco Raw Frame editor. |
| **Gallery** | `gallery_view` | `catalog_id` (string) | Navigating to Gallery route. |
|  | `gallery_component_select` | `component_key` (string), `category` (string, optional) | Selecting component card in Gallery. |
|  | `gallery_copy_usage` | `component_key` (string), `catalog_id` (string, optional) | Clicking "Copy" on component code usage. |
| **Settings** | `renderer_switch` | `from_renderer_id` (string), `to_renderer_id` (string), `is_custom` (boolean, optional) | Switching active renderer preview profile. |
|  | `renderer_add` | `renderer_id` (string), `is_cors_enabled` (boolean, optional) | Registering a custom renderer endpoint. |
|  | `renderer_edit` | `renderer_id` (string) | Editing a renderer configuration. |
|  | `renderer_delete` | `renderer_id` (string) | Deleting a custom renderer. |
|  | `api_key_update` | `action` (`ApiKeyAction`: `SELECT`, `ADD`, `DELETE`) | Updating API key selection/management. |
| **Navigation & Core** | `trackPageView` | `pagePath` (string), `pageTitle` (string, optional) | Angular router navigation events. |
|  | `trackEvent` | `eventName` (string), `params` (Record\<string, unknown\>, optional) | Generic fallback event tracker. |


## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
