### PR TITLE
Don't clear the API key just because the renderer is changed.

### DIFF
--- a/shell/src/app/settings/settings-service/settings.service.spec.ts
+++ b/shell/src/app/settings/settings-service/settings.service.spec.ts
@@ -159,7 +159,7 @@ describe('SettingsService', () => {
   it('resets config key state and sets runtime key when selected renderer lacks apiKey', async () => {
     await service.selectRenderer('locked');
 
-    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalledWith('');
     expect(mockConfigProvider.setRuntimeApiKey).toHaveBeenCalledWith('');
   });
 
@@ -167,7 +167,7 @@ describe('SettingsService', () => {
     await service.selectRenderer(null);
 
     expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith('');
-    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalledWith('');
     expect(mockConfigProvider.setRuntimeApiKey).toHaveBeenCalledWith('');
   });
 
@@ -208,12 +208,12 @@ describe('SettingsService', () => {
     expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('padded-key');
 
     await service.selectRenderer('blankKey');
-    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalledWith('');
 
     mockConfigProvider.setApiKeyFromConfig.mockClear();
 
     await service.selectRenderer('nonStringKey');
-    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalledWith('');
   });
 
   it('handles error gracefully when secureCredentialsStorage throws in selectProfile', async () => {
@@ -222,7 +222,7 @@ describe('SettingsService', () => {
 
     await service.selectRenderer('locked');
 
-    expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+    expect(mockConfigProvider.setApiKeyFromConfig).not.toHaveBeenCalledWith('');
     expect(warnSpy).toHaveBeenCalledWith(
       'Failed to resolve effective API key during renderer selection:',
       expect.any(Error),

--- a/shell/src/app/settings/settings-service/settings.service.ts
+++ b/shell/src/app/settings/settings-service/settings.service.ts
@@ -115,7 +115,6 @@ export class SettingsService {
     if (apiKey) {
       this.configProvider.setApiKeyFromConfig(apiKey);
     } else {
-      this.configProvider.setApiKeyFromConfig('');
       try {
         await this.syncEffectiveApiKeyToConfigProvider();
       } catch (err) {


### PR DESCRIPTION
# Description

It will be updated appropriately by the call to `syncEffectiveApiKeyToConfigProvider`.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
