### PR TITLE
Fix Monaco JSON validation error in A2UI Composer.

### DIFF
--- a/shell/src/app/gallery/schema/common-types-schema.ts
+++ b/shell/src/app/gallery/schema/common-types-schema.ts
@@ -18,6 +18,8 @@
  * This is a copy synchronized from https://github.com/a2ui-project/a2ui/blob/main/specification/v0_9/json/common_types.json
  */
 export const COMMON_TYPES_SCHEMA: Record<string, unknown> = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://a2ui.org/specification/v0_9/common_types.json',
   $defs: {
     ComponentId: {
       type: 'string',

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -249,23 +249,23 @@ export class MonacoEditor {
       },
       {
         uri: 'file:///common_types.json',
-        schema: COMMON_TYPES_SCHEMA,
+        schema: structuredClone(COMMON_TYPES_SCHEMA),
       },
       {
         uri: 'file:///catalog.json',
-        schema: BASIC_CATALOG_SCHEMA,
+        schema: structuredClone(BASIC_CATALOG_SCHEMA),
       },
       {
         uri: 'https://a2ui.org/specification/v0_9/common_types.json',
-        schema: COMMON_TYPES_SCHEMA,
+        schema: structuredClone(COMMON_TYPES_SCHEMA),
       },
       {
         uri: 'https://a2ui.org/specification/v0_9/catalog.json',
-        schema: BASIC_CATALOG_SCHEMA,
+        schema: structuredClone(BASIC_CATALOG_SCHEMA),
       },
       {
         uri: 'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json',
-        schema: BASIC_CATALOG_SCHEMA,
+        schema: structuredClone(BASIC_CATALOG_SCHEMA),
       },
     ];
   }

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -245,7 +245,7 @@ export class MonacoEditor {
       {
         uri: 'a2ui-catalog-schema',
         fileMatch: [LAYOUT_MODEL_URI],
-        schema: layoutSchema,
+        schema: structuredClone(layoutSchema),
       },
       {
         uri: 'file:///common_types.json',


### PR DESCRIPTION
# Description

Address the Monaco (768) validation error for Draft 2020-12 schemas.

Update common-types-schema.ts to use $schema and $id correctly for
  Draft 2020-12 support.
Ensure schema objects are deep-copied using structuredClone() in
  monaco-editor.ts to prevent Monaco from unexpectedly mutating shared
  schema objects.

TAG=agy

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
