### PR TITLE
Preserve object property names in gallery A2UI payloads

### DIFF
--- a/bridge/src/bridge-message.ts
+++ b/bridge/src/bridge-message.ts
@@ -46,7 +46,7 @@ export declare interface SetThemePayload {
 /**
  * Represents a message structure transmitted across the Preview Bridge iframe boundary.
  *
- * NOTE: Declared as a `declare interface` so `tsickle` generates compiler `@externs`
+ * NOTE: Declared as a `declare interface` so `tsickle` generates compiler externs
  * definitions for JSCompiler (Closure Compiler), preventing property renaming across frame boundaries.
  */
 export declare interface BridgeMessage {
@@ -127,7 +127,7 @@ export type DeleteSurfaceDetails = BaseSurfaceDetails;
 /**
  * Represents a single layout command item inside the RENDER_A2UI array.
  *
- * NOTE: Declared with `declare interface` so `tsickle` generates compiler `@externs` for
+ * NOTE: Declared with `declare interface` so `tsickle` generates compiler externs for
  * JSCompiler (Closure Compiler), preserving explicitly declared property names without requiring
  * quoted property keys.
  */
@@ -151,7 +151,7 @@ export declare interface CatalogDetails {
 /**
  * Represents a component instance definition in the A2UI layout tree.
  *
- * NOTE: Declared with `declare interface` so `tsickle` generates compiler `@externs`.
+ * NOTE: Declared with `declare interface` so `tsickle` generates compiler externs.
  * Explicitly declared properties (`component`, `id`) are preserved without quoting, while
  * dynamic/custom component schema properties not declared here must use quoted keys
  * to prevent property renaming during JS optimization.

--- a/bridge/src/bridge-message.ts
+++ b/bridge/src/bridge-message.ts
@@ -124,7 +124,13 @@ export declare interface UpdateComponentsDetails extends BaseSurfaceDetails {
 /** Inner details for deleteSurface command in RENDER_A2UI payload. */
 export type DeleteSurfaceDetails = BaseSurfaceDetails;
 
-/** Represents a single layout command item inside the RENDER_A2UI array. */
+/**
+ * Represents a single layout command item inside the RENDER_A2UI array.
+ *
+ * NOTE: Declared with `declare interface` so `tsickle` generates compiler `@externs` for
+ * JSCompiler (Closure Compiler), preserving explicitly declared property names without requiring
+ * quoted property keys.
+ */
 export declare interface RenderA2uiItem {
   version: string;
   createSurface?: CreateSurfaceDetails;
@@ -142,7 +148,14 @@ export declare interface CatalogDetails {
   [key: string]: unknown;
 }
 
-/** Represents a component instance definition in the A2UI layout tree. */
+/**
+ * Represents a component instance definition in the A2UI layout tree.
+ *
+ * NOTE: Declared with `declare interface` so `tsickle` generates compiler `@externs`.
+ * Explicitly declared properties (`component`, `id`) are preserved without quoting, while
+ * dynamic/custom component schema properties not declared here must use quoted keys
+ * to prevent property renaming during JS optimization.
+ */
 export declare interface A2uiComponentInstance {
   component: string;
   id?: string;

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -87,17 +87,17 @@ export class Gallery implements OnInit, OnDestroy {
   private buildA2UIPayload(preset: ComponentUsage, catalogId: string): RenderA2uiItem[] {
     const payload: RenderA2uiItem[] = [
       {
-        version: 'v0.9',
-        createSurface: {
-          surfaceId: 'gallery-preview',
-          catalogId: catalogId,
+        ['version']: 'v0.9',
+        ['createSurface']: {
+          ['surfaceId']: 'gallery-preview',
+          ['catalogId']: catalogId,
         },
       },
       {
-        version: 'v0.9',
-        updateComponents: {
-          surfaceId: 'gallery-preview',
-          components: this.getComponentsPayload(preset.usage),
+        ['version']: 'v0.9',
+        ['updateComponents']: {
+          ['surfaceId']: 'gallery-preview',
+          ['components']: this.getComponentsPayload(preset.usage),
         },
       },
     ];
@@ -105,10 +105,10 @@ export class Gallery implements OnInit, OnDestroy {
     const dataObj = preset.data;
     if (dataObj !== undefined) {
       const cmd3: RenderA2uiItem = {
-        version: 'v0.9',
-        updateDataModel: {
-          surfaceId: 'gallery-preview',
-          value: dataObj,
+        ['version']: 'v0.9',
+        ['updateDataModel']: {
+          ['surfaceId']: 'gallery-preview',
+          ['value']: dataObj,
         },
       };
       payload.push(cmd3);
@@ -220,7 +220,7 @@ export class Gallery implements OnInit, OnDestroy {
         if (comp && typeof comp === 'object') {
           const obj = comp as Record<string, unknown>;
           if (obj['id'] === 'root' || obj['id'] === 'target') {
-            return {...obj, id: 'target'};
+            return {...obj, ['id']: 'target'};
           }
         }
         return comp;
@@ -228,11 +228,11 @@ export class Gallery implements OnInit, OnDestroy {
 
       return [
         {
-          id: 'root',
-          component: columnKey,
-          align: 'center',
-          justify: 'center',
-          children: ['target'],
+          ['id']: 'root',
+          ['component']: columnKey,
+          ['align']: 'center',
+          ['justify']: 'center',
+          ['children']: ['target'],
         },
         ...normalizedComponents,
       ];
@@ -242,7 +242,7 @@ export class Gallery implements OnInit, OnDestroy {
       if (comp && typeof comp === 'object') {
         const obj = comp as Record<string, unknown>;
         if (obj['id'] === 'target') {
-          return {...obj, id: 'root'};
+          return {...obj, ['id']: 'root'};
         }
       }
       return comp;

--- a/shell/src/app/gallery/gallery.ts
+++ b/shell/src/app/gallery/gallery.ts
@@ -84,20 +84,27 @@ export class Gallery implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * Constructs the A2UI layout and data model command payload.
+   *
+   * Note: Properties explicitly declared in `declare interface` definitions (like `RenderA2uiItem`,
+   * `CreateSurfaceDetails`, `UpdateComponentsDetails`, `UpdateDataModelDetails`) are emitted in externs
+   * by tsickle, so JSCompiler (Closure Compiler) preserves their names without needing bracket notation.
+   */
   private buildA2UIPayload(preset: ComponentUsage, catalogId: string): RenderA2uiItem[] {
     const payload: RenderA2uiItem[] = [
       {
-        ['version']: 'v0.9',
-        ['createSurface']: {
-          ['surfaceId']: 'gallery-preview',
-          ['catalogId']: catalogId,
+        version: 'v0.9',
+        createSurface: {
+          surfaceId: 'gallery-preview',
+          catalogId: catalogId,
         },
       },
       {
-        ['version']: 'v0.9',
-        ['updateComponents']: {
-          ['surfaceId']: 'gallery-preview',
-          ['components']: this.getComponentsPayload(preset.usage),
+        version: 'v0.9',
+        updateComponents: {
+          surfaceId: 'gallery-preview',
+          components: this.getComponentsPayload(preset.usage),
         },
       },
     ];
@@ -105,10 +112,10 @@ export class Gallery implements OnInit, OnDestroy {
     const dataObj = preset.data;
     if (dataObj !== undefined) {
       const cmd3: RenderA2uiItem = {
-        ['version']: 'v0.9',
-        ['updateDataModel']: {
-          ['surfaceId']: 'gallery-preview',
-          ['value']: dataObj,
+        version: 'v0.9',
+        updateDataModel: {
+          surfaceId: 'gallery-preview',
+          value: dataObj,
         },
       };
       payload.push(cmd3);
@@ -220,7 +227,7 @@ export class Gallery implements OnInit, OnDestroy {
         if (comp && typeof comp === 'object') {
           const obj = comp as Record<string, unknown>;
           if (obj['id'] === 'root' || obj['id'] === 'target') {
-            return {...obj, ['id']: 'target'};
+            return {...obj, id: 'target'};
           }
         }
         return comp;
@@ -228,8 +235,11 @@ export class Gallery implements OnInit, OnDestroy {
 
       return [
         {
-          ['id']: 'root',
-          ['component']: columnKey,
+          id: 'root',
+          component: columnKey,
+          // Custom/dynamic component schema properties not declared on externed interfaces
+          // (such as A2uiComponentInstance) must use quoted keys to prevent Closure Compiler
+          // from renaming them during optimization.
           ['align']: 'center',
           ['justify']: 'center',
           ['children']: ['target'],
@@ -242,7 +252,7 @@ export class Gallery implements OnInit, OnDestroy {
       if (comp && typeof comp === 'object') {
         const obj = comp as Record<string, unknown>;
         if (obj['id'] === 'target') {
-          return {...obj, ['id']: 'root'};
+          return {...obj, id: 'root'};
         }
       }
       return comp;


### PR DESCRIPTION
Use computed property syntax in Gallery component payloads to prevent property renaming during JS optimization.

# Description

_Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots._