### PR TITLE
Fix sharing

### DIFF
--- a/shell/e2e/renderer-integration-and-telemetry.e2e.ts
+++ b/shell/e2e/renderer-integration-and-telemetry.e2e.ts
@@ -49,8 +49,10 @@ const CONFIGS: IntegrationConfig[] = [
     pickupLocationLocator: iframe => iframe.locator('label:has-text("Pick-up Location") + input'),
     fillDate: async (locator, value) => {
       await locator.evaluate((el: HTMLInputElement, val) => {
-        const prototype = Object.getPrototypeOf(el);
-        const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          'value',
+        )?.set;
         if (setter) {
           setter.call(el, val);
           el.dispatchEvent(new Event('input', {bubbles: true}));

--- a/shell/src/app/chat/chat-coordinator/chat-coordinator.ts
+++ b/shell/src/app/chat/chat-coordinator/chat-coordinator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {DestroyRef, inject, Injectable, signal} from '@angular/core';
+import {inject, Injectable, signal} from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {skip} from 'rxjs/operators';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
@@ -62,7 +62,6 @@ export class ChatCoordinator {
   private readonly usageTrackingService = inject(UsageTrackingService);
   private readonly promptFactory = inject(ChatPromptFactoryService);
   private readonly errorPresenter = inject(ChatErrorFormatterService);
-  private readonly destroyRef = inject(DestroyRef);
 
   /** Reactively mapped rendering pipeline execution milestones. */
   readonly pipelineStatus = this.chatState.pipelineStatus;
@@ -83,7 +82,7 @@ export class ChatCoordinator {
     // resets
     toObservable(this.configProvider.rendererUrl)
       // skip(1) prevents wiping the cache on the initial startup signal emission
-      .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+      .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         queueMicrotask(() => this.wipeEnvironmentCache());
       });

--- a/shell/src/app/chat/file-ingestion/file-ingestion.service.spec.ts
+++ b/shell/src/app/chat/file-ingestion/file-ingestion.service.spec.ts
@@ -26,7 +26,7 @@ describe('FileIngestionService', () => {
     service = TestBed.inject(FileIngestionService);
   });
 
-  it('should read file as attachment', async () => {
+  it('reads file as attachment', async () => {
     const file = new File(['hello world'], 'test.txt', {type: 'text/plain'});
     const result = await service.readFileAsAttachment(file);
 
@@ -36,7 +36,7 @@ describe('FileIngestionService', () => {
     expect(result.previewUrl).toBeUndefined();
   });
 
-  it('should read image and return preview url', async () => {
+  it('reads image and returns preview url', async () => {
     const file = new File(['blobdata'], 'test.png', {type: 'image/png'});
     const result = await service.readFileAsAttachment(file);
 

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -557,7 +557,6 @@ describe('Settings', () => {
     });
 
     it('returns undefined for selectedRendererOption when selectedRendererId is null or Custom', async () => {
-
       const {component} = await setupComponent();
 
       component.selectedRendererId.set(null);

--- a/shell/src/app/settings/settings-view/settings.spec.ts
+++ b/shell/src/app/settings/settings-view/settings.spec.ts
@@ -549,7 +549,15 @@ describe('Settings', () => {
       expect(component.selectedRendererId()).toBe('preset-1');
     });
 
+    it('defaults selectedRendererId to default when SettingsService returns null', async () => {
+      mockSelectedRendererId.set(null);
+      const {component} = await setupComponent();
+
+      expect(component.selectedRendererId()).toBe('default');
+    });
+
     it('returns undefined for selectedRendererOption when selectedRendererId is null or Custom', async () => {
+
       const {component} = await setupComponent();
 
       component.selectedRendererId.set(null);

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -130,7 +130,6 @@ export class Settings implements OnInit {
     const currentRendererId = this.settingsService.selectedRendererId() || 'default';
     this.selectedRendererId.set(currentRendererId);
 
-
     void this.settingsService.getEffectiveApiKey();
 
     const is3P = this.startupResolution.isThirdPartyEnvironment();

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
-import {Component, computed, inject, OnInit, signal, Signal, WritableSignal} from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  OnInit,
+  signal,
+  Signal,
+  untracked,
+  WritableSignal,
+} from '@angular/core';
 import {NonNullableFormBuilder, ReactiveFormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
@@ -107,11 +117,19 @@ export class Settings implements OnInit {
 
   readonly settingsForm = this.fb.group({});
 
-  constructor() {}
+  constructor() {
+    effect(() => {
+      const activeId = this.settingsService.selectedRendererId$() || 'default';
+      untracked(() => {
+        this.selectedRendererId$.set(activeId);
+      });
+    });
+  }
 
   ngOnInit(): void {
-    const currentRendererId = this.settingsService.selectedRendererId() || 'Custom';
+    const currentRendererId = this.settingsService.selectedRendererId() || 'default';
     this.selectedRendererId.set(currentRendererId);
+
 
     void this.settingsService.getEffectiveApiKey();
 
@@ -122,10 +140,10 @@ export class Settings implements OnInit {
   }
 
   async onRendererSelected(rendererId: string): Promise<void> {
-    const targetId = rendererId === 'Custom' ? null : rendererId;
     const previousId = this.selectedRendererId();
     this.selectedRendererId.set(rendererId);
-    const success = await this.settingsService.selectRenderer(targetId);
+    const success = await this.settingsService.selectRenderer(rendererId);
+
     if (!success) {
       this.selectedRendererId.set(previousId);
     }

--- a/shell/src/app/settings/settings-view/settings.ts
+++ b/shell/src/app/settings/settings-view/settings.ts
@@ -119,9 +119,9 @@ export class Settings implements OnInit {
 
   constructor() {
     effect(() => {
-      const activeId = this.settingsService.selectedRendererId$() || 'default';
+      const activeId = this.settingsService.selectedRendererId() || 'default';
       untracked(() => {
-        this.selectedRendererId$.set(activeId);
+        this.selectedRendererId.set(activeId);
       });
     });
   }

--- a/shell/src/app/shared/security/safe-url-validator.service.spec.ts
+++ b/shell/src/app/shared/security/safe-url-validator.service.spec.ts
@@ -26,7 +26,7 @@ describe('SafeUrlValidatorService', () => {
     service = TestBed.inject(SafeUrlValidatorService);
   });
 
-  it('should be created', () => {
+  it('is created', () => {
     expect(service).toBeTruthy();
   });
 

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -58,6 +58,7 @@ describe('ComposerShell Layout', () => {
   };
   let startupConfigStateMock: {
     resolvedUrl: WritableSignal<string | null>;
+    selectedRendererId: WritableSignal<string | null>;
     sharedA2uiError: WritableSignal<string | null>;
   };
   let stateSyncMock: {
@@ -94,6 +95,7 @@ describe('ComposerShell Layout', () => {
 
     startupConfigStateMock = {
       resolvedUrl: signal<string | null>(null),
+      selectedRendererId: signal<string | null>(null),
       sharedA2uiError: signal<string | null>(null),
     };
 

--- a/shell/src/app/shell/composer-shell/composer-shell.spec.ts
+++ b/shell/src/app/shell/composer-shell/composer-shell.spec.ts
@@ -132,11 +132,11 @@ describe('ComposerShell Layout', () => {
           provide: AppConfigProvider,
           useValue: configProviderMock,
         },
-        {provide: StartupResolution, useValue: {}},
         {
           provide: StartupConfigStateService,
           useValue: startupConfigStateMock,
         },
+        {provide: StartupResolution, useValue: {}},
         {
           provide: StateSync,
           useValue: stateSyncMock,

--- a/shell/src/app/shell/share/share.service.spec.ts
+++ b/shell/src/app/shell/share/share.service.spec.ts
@@ -19,12 +19,11 @@ import {DOCUMENT} from '@angular/common';
 import {TestBed} from '@angular/core/testing';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {StateSync} from '../../chat/state-sync/state-sync';
-import {StartupResolution} from '../startup-resolution/startup-resolution';
+import {StartupConfigStateService} from '../startup-resolution/state/startup-config-state.service';
 import {
   UsageTrackingService,
   ShareTrackingStatus,
 } from '../../usage-tracking/usage-tracking.service';
-
 import {ShareService} from './share.service';
 import {signal} from '@angular/core';
 
@@ -32,7 +31,7 @@ describe('ShareService', () => {
   let service: ShareService;
   let mockSnackBar: {open: ReturnType<typeof vi.fn>};
   let mockStateSync: unknown;
-  let mockStartupResolution: unknown;
+  let mockStartupConfigState: unknown;
   let mockDocument: {defaultView: {location: {href: string}}};
   let mockUsageTracking: {trackShareDesign: ReturnType<typeof vi.fn>};
 
@@ -44,7 +43,10 @@ describe('ShareService', () => {
     });
     mockSnackBar = {open: vi.fn()};
     mockStateSync = {activeDraft: signal('{"a":1}')};
-    mockStartupResolution = {resolvedUrl: signal('http://renderer')};
+    mockStartupConfigState = {
+      resolvedUrl: signal('http://renderer'),
+      selectedRendererId: signal('default'),
+    };
     mockDocument = {defaultView: {location: {href: 'http://localhost/'}}};
     mockUsageTracking = {trackShareDesign: vi.fn()};
 
@@ -52,7 +54,7 @@ describe('ShareService', () => {
       providers: [
         {provide: MatSnackBar, useValue: mockSnackBar},
         {provide: StateSync, useValue: mockStateSync},
-        {provide: StartupResolution, useValue: mockStartupResolution},
+        {provide: StartupConfigStateService, useValue: mockStartupConfigState},
         {provide: DOCUMENT, useValue: mockDocument},
         {provide: UsageTrackingService, useValue: mockUsageTracking},
       ],
@@ -108,9 +110,9 @@ describe('ShareService', () => {
     );
   });
 
-  it('includes rendererId in share URL hash when selectedRendererId$ is present', async () => {
+  it('includes rendererId in share URL hash when selectedRendererId is present', async () => {
     mockClipboard.copy.mockReturnValue(true);
-    (mockStartupResolution as {selectedRendererId$: unknown}).selectedRendererId$ =
+    (mockStartupConfigState as {selectedRendererId: unknown}).selectedRendererId =
       signal('angular-dev');
     await service.shareDesign();
     expect(mockClipboard.copy).toHaveBeenCalledWith(

--- a/shell/src/app/shell/share/share.service.spec.ts
+++ b/shell/src/app/shell/share/share.service.spec.ts
@@ -107,4 +107,14 @@ describe('ShareService', () => {
       expect.any(Object),
     );
   });
+
+  it('includes rendererId in share URL hash when selectedRendererId$ is present', async () => {
+    mockClipboard.copy.mockReturnValue(true);
+    (mockStartupResolution as {selectedRendererId$: unknown}).selectedRendererId$ =
+      signal('angular-dev');
+    await service.shareDesign();
+    expect(mockClipboard.copy).toHaveBeenCalledWith(
+      expect.stringContaining('rendererId=angular-dev'),
+    );
+  });
 });

--- a/shell/src/app/shell/share/share.service.spec.ts
+++ b/shell/src/app/shell/share/share.service.spec.ts
@@ -111,11 +111,12 @@ describe('ShareService', () => {
   });
 
   it('includes rendererId in share URL hash when selectedRendererId is present', async () => {
-    mockClipboard.copy.mockReturnValue(true);
-    (mockStartupConfigState as {selectedRendererId: unknown}).selectedRendererId =
-      signal('angular-dev');
+    vi.mocked(navigator.clipboard.writeText).mockResolvedValue(undefined);
+    (
+      mockStartupConfigState as {selectedRendererId: ReturnType<typeof signal>}
+    ).selectedRendererId.set('angular-dev');
     await service.shareDesign();
-    expect(mockClipboard.copy).toHaveBeenCalledWith(
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('rendererId=angular-dev'),
     );
   });

--- a/shell/src/app/shell/share/share.service.ts
+++ b/shell/src/app/shell/share/share.service.ts
@@ -64,11 +64,15 @@ export class ShareService {
     let compressedLengthChars = 0;
     try {
       const rendererUrl = this.startupResolution.resolvedUrl() || '';
+      const selectedId = this.startupResolution.selectedRendererId$?.() ?? null;
       const compressed = await QueryParser.encodeSharedPayload(activeDraft);
       const shareUrl = new URL(href);
       const hashParams = new URLSearchParams();
       if (rendererUrl) {
         hashParams.set('renderer', rendererUrl);
+      }
+      if (selectedId) {
+        hashParams.set('rendererId', selectedId);
       }
       hashParams.set('a2ui', compressed);
       shareUrl.hash = hashParams.toString();

--- a/shell/src/app/shell/share/share.service.ts
+++ b/shell/src/app/shell/share/share.service.ts
@@ -19,7 +19,7 @@ import {Injectable, inject} from '@angular/core';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {StateSync} from '../../chat/state-sync/state-sync';
 import {QueryParser} from '../query-parser/query-parser';
-import {StartupResolution} from '../startup-resolution/startup-resolution';
+import {StartupConfigStateService} from '../startup-resolution/state/startup-config-state.service';
 import {
   ShareTrackingStatus,
   UsageTrackingService,
@@ -35,7 +35,7 @@ export class ShareService {
   private readonly document = inject(DOCUMENT);
   private readonly snackBar = inject(MatSnackBar);
   private readonly stateSync = inject(StateSync);
-  private readonly startupResolution = inject(StartupResolution);
+  private readonly startupConfigState = inject(StartupConfigStateService);
   private readonly usageTrackingService = inject(UsageTrackingService);
 
   /**
@@ -63,8 +63,8 @@ export class ShareService {
 
     let compressedLengthChars = 0;
     try {
-      const rendererUrl = this.startupResolution.resolvedUrl() || '';
-      const selectedId = this.startupResolution.selectedRendererId$?.() ?? null;
+      const rendererUrl = this.startupConfigState.resolvedUrl() || '';
+      const selectedId = this.startupConfigState.selectedRendererId() ?? null;
       const compressed = await QueryParser.encodeSharedPayload(activeDraft);
       const shareUrl = new URL(href);
       const hashParams = new URLSearchParams();

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -27,6 +27,7 @@ import {QueryParser} from '../query-parser/query-parser';
 import {OriginConfirmationDialog} from './origin-confirmation-dialog/origin-confirmation-dialog';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
+import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {CONFIG_URL, IS_1P_AUTH_ENABLED} from '../environment-tokens/environment-tokens';
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
@@ -69,6 +70,11 @@ class MockAppConfigProvider {
   isApiKeyProvidedByConfig = signal<boolean>(false);
   purgeGeminiApiKey = vi.fn().mockResolvedValue(undefined);
   setGeminiApiKey = vi.fn().mockResolvedValue(undefined);
+  setRendererUrl = vi.fn();
+  setRuntimeApiKey = vi.fn().mockImplementation((key: string) => {
+    this.isApiKeyProvidedByConfig.set(false);
+    this.geminiApiKey.set(key);
+  });
   setApiKeyFromConfig = vi.fn().mockImplementation((key: string) => {
     this.isApiKeyProvidedByConfig.set(true);
     this.geminiApiKey.set(key);
@@ -243,17 +249,22 @@ describe('StartupResolution', () => {
       expect(cleanSpy).toHaveBeenCalled();
     });
 
-    it('cleans a2ui parameter from window hash via history.replaceState', () => {
+    it('cleans shared parameters from window hash via history.replaceState', () => {
       const replaceStateSpy = vi.spyOn(globalThis.history, 'replaceState');
-      globalThis.location.hash = '#renderer=http%3A%2F%2Frenderer.com&a2ui=d1.abc';
+      globalThis.location.hash = '#renderer=http%3A%2F%2Frenderer.com&rendererId=dev&a2ui=d1.abc';
       try {
         service.cleanSharedA2uiUrl();
+        expect(replaceStateSpy).toHaveBeenCalledWith({}, '', expect.not.stringContaining('a2ui='));
         expect(replaceStateSpy).toHaveBeenCalledWith(
           {},
           '',
-          expect.stringContaining('#renderer=http%3A%2F%2Frenderer.com'),
+          expect.not.stringContaining('renderer='),
         );
-        expect(replaceStateSpy).toHaveBeenCalledWith({}, '', expect.not.stringContaining('a2ui='));
+        expect(replaceStateSpy).toHaveBeenCalledWith(
+          {},
+          '',
+          expect.not.stringContaining('rendererId='),
+        );
       } finally {
         globalThis.location.hash = '';
       }
@@ -267,6 +278,39 @@ describe('StartupResolution', () => {
 
       await service.processSharedA2uiUrl();
       expect(service.sharedA2uiPayload()).toBe(expectedFormattedJson);
+    });
+
+    it('switches active renderer and updates selectedRendererId$ when hash contains renderer and rendererId', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'http://default-renderer:3000'},
+          'angular-dev': {rendererUrl: 'http://localhost:4200/samples/ng-basic-catalog/'},
+          'react-dev': {rendererUrl: 'http://localhost:4200/samples/react-basic-catalog/'},
+        },
+      });
+
+      service.startupConfigState.setSelectedRendererId('angular-dev');
+      service.startupConfigState.setResolvedUrl('http://localhost:4200/samples/ng-basic-catalog/');
+      localStorage.setItem(LocalStorageKey.SELECTED_RENDERER, 'angular-dev');
+
+      const rawJson = '[{"version":"v0.9","createSurface":{"surfaceId":"react-card"}}]';
+      const expectedFormattedJson = JSON.stringify(JSON.parse(rawJson), null, 2);
+      const compressed = await QueryParser.encodeSharedPayload(rawJson);
+
+      vi.spyOn(service, 'getWindowHash').mockReturnValue(
+        `#renderer=http%3A%2F%2Flocalhost%3A4200%2Fsamples%2Freact-basic-catalog%2F&rendererId=react-dev&a2ui=${compressed}`,
+      );
+      vi.spyOn(service, 'isOriginAllowed').mockResolvedValue(true);
+
+      await service.processSharedA2uiUrl();
+
+      expect(service.sharedA2uiPayload()).toBe(expectedFormattedJson);
+      expect(service.selectedRendererId$()).toBe('react-dev');
+      expect(service.resolvedUrl()).toBe('http://localhost:4200/samples/react-basic-catalog/');
+      expect(localStorage.getItem(LocalStorageKey.SELECTED_RENDERER)).toBe('react-dev');
+      expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith(
+        'http://localhost:4200/samples/react-basic-catalog/',
+      );
     });
   });
 
@@ -1060,6 +1104,29 @@ describe('StartupResolution', () => {
       expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
       expect(mockConfigProvider.setGeminiApiKey).not.toHaveBeenCalled();
     });
+
+    it('restores custom API key from SecureCredentialsStorage when renderer has no static API key', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'http://base:3000'},
+          'react-dev': {rendererUrl: 'http://localhost:4200/samples/react-basic-catalog/'},
+        },
+      });
+
+      localStorage.setItem(LocalStorageKey.SELECTED_API_KEY, 'my-custom-key-id');
+      const storage = TestBed.inject(SecureCredentialsStorage);
+      vi.spyOn(storage, 'getCustomApiKey').mockResolvedValue({
+        id: 'my-custom-key-id',
+        name: 'My Gemini Key',
+        key: 'custom-secret-key-123',
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue('?rendererId=react-dev');
+
+      await service.resolveStartupConfiguration();
+      expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith('');
+      expect(mockConfigProvider.setRuntimeApiKey).toHaveBeenCalledWith('custom-secret-key-123');
+    });
   });
 
   describe('with custom CONFIG_URL provider', () => {
@@ -1172,6 +1239,91 @@ describe('StartupResolution', () => {
       expect(mockConfigProvider.setApiKeyFromConfig).toHaveBeenCalledWith(
         'default-api-key-from-map',
       );
+    });
+
+    it('1c. matches static renderer ID when query or hash contains matching renderer URL without explicit rendererId', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'https://default.example.com'},
+          'angular-dev': {rendererUrl: 'http://localhost:4200/samples/ng-basic-catalog/'},
+        },
+      });
+
+      vi.spyOn(service, 'getWindowHash').mockReturnValue(
+        '#renderer=http://localhost:4200/samples/ng-basic-catalog/',
+      );
+      vi.spyOn(service, 'isOriginAllowed').mockResolvedValue(true);
+
+      const url = await service.resolveRenderer();
+      expect(url).toBe('http://localhost:4200/samples/ng-basic-catalog/');
+      expect(service.selectedRendererId$()).toBe('angular-dev');
+    });
+
+    it('1d. matches custom renderer ID when query contains matching custom renderer URL', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'https://default.example.com'},
+        },
+      });
+      localStorage.setItem(
+        LocalStorageKey.CUSTOM_RENDERERS,
+        JSON.stringify([
+          {id: 'my-custom-1', name: 'My Custom', rendererUrl: 'http://localhost:5000/renderer'},
+        ]),
+      );
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?renderer=http://localhost:5000/renderer',
+      );
+      vi.spyOn(service, 'isOriginAllowed').mockResolvedValue(true);
+
+      const url = await service.resolveRenderer();
+      expect(url).toBe('http://localhost:5000/renderer');
+      expect(service.selectedRendererId$()).toBe('my-custom-1');
+    });
+
+    it('1e. registers unknown allowed URL as custom renderer in LocalStorage and selects it', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'https://default.example.com'},
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?renderer=http://localhost:9999/preview',
+      );
+      vi.spyOn(service, 'isOriginAllowed').mockResolvedValue(true);
+
+      const url = await service.resolveRenderer();
+      expect(url).toBe('http://localhost:9999/preview');
+      expect(service.selectedRendererId$()).toMatch(/^custom-\d+$/);
+
+      const customList = JSON.parse(localStorage.getItem(LocalStorageKey.CUSTOM_RENDERERS) || '[]');
+      expect(customList).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            rendererUrl: 'http://localhost:9999/preview',
+            name: expect.stringContaining('Custom (localhost:9999)'),
+          }),
+        ]),
+      );
+    });
+
+    it('1f. registers new custom renderer when ?renderer= is provided with an unrecognized ?rendererId=', async () => {
+      mockFetchConfig({
+        renderers: {
+          default: {rendererUrl: 'https://default.example.com'},
+        },
+      });
+
+      vi.spyOn(service, 'getWindowSearch').mockReturnValue(
+        '?renderer=http://localhost:8888/preview&rendererId=sender-custom-id',
+      );
+      vi.spyOn(service, 'isOriginAllowed').mockResolvedValue(true);
+
+      const url = await service.resolveRenderer();
+      expect(url).toBe('http://localhost:8888/preview');
+      expect(service.selectedRendererId$()).toMatch(/^custom-\d+$/);
     });
 
     it('2a. auto-allows localhost, 127.0.0.1, and [::1] origins in ?renderer= without prompting confirmation', async () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -280,7 +280,7 @@ describe('StartupResolution', () => {
       expect(service.sharedA2uiPayload()).toBe(expectedFormattedJson);
     });
 
-    it('switches active renderer and updates selectedRendererId$ when hash contains renderer and rendererId', async () => {
+    it('switches active renderer and updates selectedRendererId when hash contains renderer and rendererId', async () => {
       mockFetchConfig({
         renderers: {
           default: {rendererUrl: 'http://default-renderer:3000'},
@@ -305,7 +305,7 @@ describe('StartupResolution', () => {
       await service.processSharedA2uiUrl();
 
       expect(service.sharedA2uiPayload()).toBe(expectedFormattedJson);
-      expect(service.selectedRendererId$()).toBe('react-dev');
+      expect(stateService.selectedRendererId()).toBe('react-dev');
       expect(service.resolvedUrl()).toBe('http://localhost:4200/samples/react-basic-catalog/');
       expect(localStorage.getItem(LocalStorageKey.SELECTED_RENDERER)).toBe('react-dev');
       expect(mockConfigProvider.setRendererUrl).toHaveBeenCalledWith(
@@ -1256,7 +1256,7 @@ describe('StartupResolution', () => {
 
       const url = await service.resolveRenderer();
       expect(url).toBe('http://localhost:4200/samples/ng-basic-catalog/');
-      expect(service.selectedRendererId$()).toBe('angular-dev');
+      expect(stateService.selectedRendererId()).toBe('angular-dev');
     });
 
     it('1d. matches custom renderer ID when query contains matching custom renderer URL', async () => {
@@ -1279,7 +1279,7 @@ describe('StartupResolution', () => {
 
       const url = await service.resolveRenderer();
       expect(url).toBe('http://localhost:5000/renderer');
-      expect(service.selectedRendererId$()).toBe('my-custom-1');
+      expect(stateService.selectedRendererId()).toBe('my-custom-1');
     });
 
     it('1e. registers unknown allowed URL as custom renderer in LocalStorage and selects it', async () => {
@@ -1296,7 +1296,7 @@ describe('StartupResolution', () => {
 
       const url = await service.resolveRenderer();
       expect(url).toBe('http://localhost:9999/preview');
-      expect(service.selectedRendererId$()).toMatch(/^custom-\d+$/);
+      expect(stateService.selectedRendererId()).toMatch(/^custom-\d+$/);
 
       const customList = JSON.parse(localStorage.getItem(LocalStorageKey.CUSTOM_RENDERERS) || '[]');
       expect(customList).toEqual(
@@ -1323,7 +1323,7 @@ describe('StartupResolution', () => {
 
       const url = await service.resolveRenderer();
       expect(url).toBe('http://localhost:8888/preview');
-      expect(service.selectedRendererId$()).toMatch(/^custom-\d+$/);
+      expect(stateService.selectedRendererId()).toMatch(/^custom-\d+$/);
     });
 
     it('2a. auto-allows localhost, 127.0.0.1, and [::1] origins in ?renderer= without prompting confirmation', async () => {

--- a/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.spec.ts
@@ -1550,6 +1550,13 @@ describe('StartupResolution', () => {
         expect.any(Error),
       );
     });
+
+    it('returns empty string safely from normalizeUrl when passed null or undefined without throwing TypeError', () => {
+      const callNormalize = (val?: string | null) =>
+        (service as unknown as {normalizeUrl(urlStr?: string | null): string}).normalizeUrl(val);
+      expect(callNormalize(null)).toBe('');
+      expect(callNormalize(undefined)).toBe('');
+    });
   });
 });
 

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -422,7 +422,11 @@ export class StartupResolution {
     return null;
   }
 
-  private normalizeUrl(urlStr: string): string {
+  private normalizeUrl(urlStr?: string | null): string {
+    if (!urlStr) {
+      return '';
+    }
+
     try {
       const baseOrigin = this.environmentContext.getBaseOrigin();
       const u = urlStr.startsWith('/') ? new URL(urlStr, baseOrigin) : new URL(urlStr);

--- a/shell/src/app/shell/startup-resolution/startup-resolution.ts
+++ b/shell/src/app/shell/startup-resolution/startup-resolution.ts
@@ -117,15 +117,21 @@ export class StartupResolution {
     if (!rawParam) {
       return;
     }
+    const queryRendererUrl = QueryParser.parseRendererUrl(rawParam);
+    const queryRendererId = QueryParser.parseRendererId(rawParam);
+    if (queryRendererUrl || queryRendererId) {
+      await this.resolveRenderer();
+    }
     const {payload, error} = await QueryParser.parseSharedA2ui(rawParam);
     if (payload) {
       console.log('Using shared A2UI payload from URL.');
       this.startupConfigState.setSharedA2uiPayload(payload);
       this.cleanSharedA2uiUrl();
-    }
-    if (error) {
+    } else if (error) {
       console.warn('Shared A2UI payload error:', error);
       this.startupConfigState.setSharedA2uiError(error);
+      this.cleanSharedA2uiUrl();
+    } else if (queryRendererUrl || queryRendererId) {
       this.cleanSharedA2uiUrl();
     }
   }
@@ -173,9 +179,42 @@ export class StartupResolution {
         this.configProvider.setApiKeyFromConfig(apiKey);
       } else {
         this.configProvider.setApiKeyFromConfig('');
+        await this.syncStoredCredentialsToConfigProvider(staticConfig);
       }
     } catch (err) {
       console.warn('Failed to apply config-provided API key to AppConfigProvider:', err);
+    }
+  }
+
+  private async syncStoredCredentialsToConfigProvider(staticConfig?: AppConfig): Promise<void> {
+    try {
+      const selectedId = this.localStorageInteractions.getItem(LocalStorageKey.SELECTED_API_KEY);
+      if (selectedId) {
+        const staticApiKeys = staticConfig?.apiKeys || this.startupConfigState.apiKeys() || {};
+        const entry = staticApiKeys[selectedId];
+        const keyVal = entry?.apiKey?.trim() || '';
+        if (keyVal) {
+          this.configProvider.setApiKeyFromConfig(keyVal);
+          return;
+        }
+        if (this.secureCredentialsStorage) {
+          const custom = await this.secureCredentialsStorage.getCustomApiKey(selectedId);
+          if (custom?.key) {
+            this.configProvider.setRuntimeApiKey(custom.key.trim());
+            return;
+          }
+        }
+      }
+      if (this.secureCredentialsStorage) {
+        const customKeys = await this.secureCredentialsStorage.getCustomApiKeys();
+        const defaultCustom = customKeys.find(k => k.id === 'default') || customKeys[0];
+        if (defaultCustom?.key) {
+          this.configProvider.setRuntimeApiKey(defaultCustom.key.trim());
+          return;
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to restore stored credentials in StartupResolution:', err);
     }
   }
 
@@ -262,11 +301,59 @@ export class StartupResolution {
         const requestedId =
           QueryParser.parseRendererId(this.getWindowHash()) ||
           QueryParser.parseRendererId(this.getWindowSearch());
-        if (requestedId) {
-          this.startupConfigState.setSelectedRendererId(requestedId);
+        const existingRenderer = requestedId
+          ? this.getRendererById(requestedId, staticRenderers)
+          : null;
+        let targetId = existingRenderer ? requestedId : null;
+        if (!targetId) {
+          const staticMatch = Object.entries(staticRenderers).find(
+            ([_, r]) =>
+              r?.rendererUrl &&
+              this.normalizeUrl(r.rendererUrl) === this.normalizeUrl(queryRendererUrl),
+          );
+          if (staticMatch) {
+            targetId = staticMatch[0];
+          } else {
+            const customMatch = this.getCustomRenderers().find(
+              r =>
+                r?.rendererUrl &&
+                this.normalizeUrl(r.rendererUrl) === this.normalizeUrl(queryRendererUrl),
+            );
+            if (customMatch) {
+              targetId = customMatch.id ?? null;
+            } else {
+              try {
+                const urlObj = new URL(queryRendererUrl, this.environmentContext.getBaseOrigin());
+                const hostname = urlObj.hostname || 'custom';
+                const port = urlObj.port ? `:${urlObj.port}` : '';
+                const newId = `custom-${Date.now()}`;
+                const customEntry: RendererConfig = {
+                  id: newId,
+                  name: `Custom (${hostname}${port})`,
+                  rendererUrl: queryRendererUrl,
+                };
+                const customList = this.getCustomRenderers();
+                customList.push(customEntry);
+                this.localStorageInteractions.setItem(
+                  LocalStorageKey.CUSTOM_RENDERERS,
+                  JSON.stringify(customList),
+                );
+                targetId = newId;
+              } catch {
+                // Ignore parse errors
+              }
+            }
+          }
         }
-        await this.applyApiKeyFromConfig(config || {}, requestedId || 'default');
+        if (targetId) {
+          this.startupConfigState.setSelectedRendererId(targetId);
+          this.localStorageInteractions.setItem(LocalStorageKey.SELECTED_RENDERER, targetId);
+        }
+        const effectiveApiKeyId =
+          requestedId ?? (targetId && config?.apiKeys?.[targetId] ? targetId : 'default');
+        await this.applyApiKeyFromConfig(config || {}, effectiveApiKeyId);
         this.startupConfigState.setResolvedUrl(queryRendererUrl);
+        this.configProvider?.setRendererUrl?.(queryRendererUrl);
         return queryRendererUrl;
       } else {
         console.warn('Renderer parameter origin not allowed by user.');
@@ -282,11 +369,13 @@ export class StartupResolution {
       if (candidate) {
         console.log(`Using renderer ID '${requestedId}' from query param.`);
         this.startupConfigState.setSelectedRendererId(requestedId);
+        this.localStorageInteractions.setItem(LocalStorageKey.SELECTED_RENDERER, requestedId);
         if (config) {
           await this.applyApiKeyFromConfig(config, requestedId);
         }
         if (candidate.rendererUrl) {
           this.startupConfigState.setResolvedUrl(candidate.rendererUrl);
+          this.configProvider?.setRendererUrl?.(candidate.rendererUrl);
           return candidate.rendererUrl;
         }
       } else {
@@ -331,6 +420,16 @@ export class StartupResolution {
     this.startupConfigState.setResolvedUrl(null);
     this.startupConfigState.setSelectedRendererId(null);
     return null;
+  }
+
+  private normalizeUrl(urlStr: string): string {
+    try {
+      const baseOrigin = this.environmentContext.getBaseOrigin();
+      const u = urlStr.startsWith('/') ? new URL(urlStr, baseOrigin) : new URL(urlStr);
+      return u.origin + u.pathname.replace(/\/+$/, '') + u.search;
+    } catch {
+      return urlStr.replace(/\/+$/, '');
+    }
   }
 
   async isOriginAllowed(url: string): Promise<boolean> {

--- a/shell/src/app/shell/startup-resolution/state/environment-context.service.ts
+++ b/shell/src/app/shell/startup-resolution/state/environment-context.service.ts
@@ -86,15 +86,27 @@ export class EnvironmentContextService {
         let modified = false;
         if (cleanUrl.hash) {
           const hashParams = new URLSearchParams(cleanUrl.hash.replace(/^#/, ''));
-          if (hashParams.has('a2ui')) {
+          if (
+            hashParams.has('a2ui') ||
+            hashParams.has('renderer') ||
+            hashParams.has('rendererId')
+          ) {
             hashParams.delete('a2ui');
+            hashParams.delete('renderer');
+            hashParams.delete('rendererId');
             const remaining = hashParams.toString();
             cleanUrl.hash = remaining ? `#${remaining}` : '';
             modified = true;
           }
         }
-        if (cleanUrl.searchParams.has('a2ui')) {
+        if (
+          cleanUrl.searchParams.has('a2ui') ||
+          cleanUrl.searchParams.has('renderer') ||
+          cleanUrl.searchParams.has('rendererId')
+        ) {
           cleanUrl.searchParams.delete('a2ui');
+          cleanUrl.searchParams.delete('renderer');
+          cleanUrl.searchParams.delete('rendererId');
           modified = true;
         }
         if (modified) {


### PR DESCRIPTION
# Description

**URL Parameter Sanitization & Active Renderer Persistence**

* Sanitizes the browser address bar after loading shared designs (cleanSharedA2uiUrl) using history.replaceState to strip lingering a2ui, renderer, and rendererId query and hash parameters.
* Maps queryRendererUrl directly to matching static/custom renderer configurations and persists allowed origins in LocalStorage.
* Ensures the Settings view defaults to the active renderer selection on load instead of an unselected state.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.
