### PR TITLE
Handle jsonl

### DIFF
--- a/shell/src/app/chat/a2ui-payload-parser/a2ui-payload-parser.spec.ts
+++ b/shell/src/app/chat/a2ui-payload-parser/a2ui-payload-parser.spec.ts
@@ -40,9 +40,12 @@ describe('a2ui-payload-parser', () => {
       expect(attemptSyntaxHealing('unhealable {')).toBeNull();
     });
 
-    it('returns null for nullish or empty line', () => {
+    it('returns null when input is null or undefined', () => {
       expect(attemptSyntaxHealing(null)).toBeNull();
       expect(attemptSyntaxHealing(undefined)).toBeNull();
+    });
+
+    it('returns null for empty line', () => {
       expect(attemptSyntaxHealing('')).toBeNull();
       expect(attemptSyntaxHealing('   ')).toBeNull();
       expect(attemptSyntaxHealing('\t\n ')).toBeNull();
@@ -50,11 +53,14 @@ describe('a2ui-payload-parser', () => {
   });
 
   describe('parseAndHealJsonLines', () => {
-    it('returns empty blocks and wasHealed false for nullish or empty content', () => {
+    it('returns empty blocks and wasHealed false when input is null or undefined', () => {
       // @ts-expect-error - testing nullish input
       expect(parseAndHealJsonLines(null)).toEqual({blocks: [], wasHealed: false});
       // @ts-expect-error - testing undefined input
       expect(parseAndHealJsonLines(undefined)).toEqual({blocks: [], wasHealed: false});
+    });
+
+    it('returns empty blocks and wasHealed false for empty content', () => {
       expect(parseAndHealJsonLines('')).toEqual({blocks: [], wasHealed: false});
       expect(parseAndHealJsonLines('   ')).toEqual({blocks: [], wasHealed: false});
       expect(parseAndHealJsonLines('\n\t\n')).toEqual({blocks: [], wasHealed: false});

--- a/shell/src/app/chat/chat-cleaner/chat-cleaner.spec.ts
+++ b/shell/src/app/chat/chat-cleaner/chat-cleaner.spec.ts
@@ -117,6 +117,21 @@ describe('ChatCleaner', () => {
       expect(service.cleanPayload(input)).toBe('[\n  {\n    "createSurface": {"surfaceId": "s1"}');
     });
 
+    it('isolates JSON Lines layout stream without truncating prose brackets', () => {
+      const input = 'Prose [bracket] before JSONL:\n{"version": "v0.9"}\n{"createSurface": {}}';
+      expect(service.cleanPayload(input)).toBe('{"version": "v0.9"}\n{"createSurface": {}}');
+    });
+
+    it('does not isolate non-layout JSON array from prose', () => {
+      const input = 'Prose before: [{"foo": "bar"}]';
+      expect(service.cleanPayload(input)).toBe('Prose before: [{"foo": "bar"}]');
+    });
+
+    it('does not isolate non-layout JSON Lines stream from prose', () => {
+      const input = 'Prose before:\n{"foo": "bar"}\n{"baz": "qux"}';
+      expect(service.cleanPayload(input)).toBe('Prose before:\n{"foo": "bar"}\n{"baz": "qux"}');
+    });
+
     it('returns cleaned text when content is not JSON', () => {
       expect(service.cleanPayload('hello world')).toBe('hello world');
     });
@@ -145,6 +160,26 @@ describe('ChatCleaner', () => {
       expect(service.isLayoutSnapshot('[\n  {\n    "updateComponents": {"surfaceId": "s1"}')).toBe(
         true,
       );
+    });
+
+    it('returns true for JSON Lines layout stream with version string', () => {
+      expect(service.isLayoutSnapshot('{"version": "v0.9"}\n{"createSurface": {}}')).toBe(true);
+    });
+
+    it('returns true for JSON Lines layout stream without version but with layout commands', () => {
+      expect(
+        service.isLayoutSnapshot(
+          '{"createSurface": {"surfaceId": "s1"}}\n{"updateComponents": {"surfaceId": "s1"}}',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for non-layout JSON array', () => {
+      expect(service.isLayoutSnapshot('[{"foo": "bar"}]')).toBe(false);
+    });
+
+    it('returns false for non-layout JSON Lines stream', () => {
+      expect(service.isLayoutSnapshot('{"foo": "bar"}\n{"baz": "qux"}')).toBe(false);
     });
 
     it('returns false for arbitrary non-layout text', () => {

--- a/shell/src/app/chat/chat-cleaner/chat-cleaner.ts
+++ b/shell/src/app/chat/chat-cleaner/chat-cleaner.ts
@@ -21,6 +21,25 @@ const MD_FENCE_REGEX = /```(?:jsonl?|jsonlines|a2ui|html|xml)?\s*([\s\S]*?)\s*``
 const TAG_REGEX = /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi;
 const PULSE_INDICATOR_REGEX = /\s*●●●\s*$/g;
 
+function isLayoutArray(arr: unknown[]): boolean {
+  return (
+    arr.length > 0 &&
+    arr.some(item => {
+      if (item && typeof item === 'object' && !Array.isArray(item)) {
+        const keys = Object.keys(item);
+        return (
+          keys.includes('version') ||
+          keys.includes('createSurface') ||
+          keys.includes('updateComponents') ||
+          keys.includes('updateDataModel') ||
+          keys.includes('deleteSurface')
+        );
+      }
+      return false;
+    })
+  );
+}
+
 /**
  * Service for cleaning and processing raw LLM chat messages, including
  * pulse indicator handling, thinking tag stripping, markdown fence extraction,
@@ -107,9 +126,13 @@ export class ChatCleaner {
               /^\[\s*[\{\"]/.test(candidate) &&
               (candidate.includes('"version"') ||
                 candidate.includes('"createSurface"') ||
-                candidate.includes('"updateComponents"'))) ||
-            tryParseJsonArray(candidate) !== null
+                candidate.includes('"updateComponents"')))
           ) {
+            result = candidate;
+            break;
+          }
+          const parsed = tryParseJsonArray(candidate);
+          if (parsed !== null && isLayoutArray(parsed)) {
             result = candidate;
             break;
           }
@@ -128,14 +151,17 @@ export class ChatCleaner {
       return false;
     }
     const trimmed = this.cleanPayload(text);
-    return (
+    if (
       trimmed.startsWith('{"version"') ||
       (trimmed.startsWith('{') && trimmed.includes('"version"')) ||
       (trimmed.startsWith('[') &&
         (trimmed.includes('"version"') ||
           trimmed.includes('"createSurface"') ||
-          trimmed.includes('"updateComponents"'))) ||
-      tryParseJsonArray(trimmed) !== null
-    );
+          trimmed.includes('"updateComponents"')))
+    ) {
+      return true;
+    }
+    const parsedArray = tryParseJsonArray(trimmed);
+    return parsedArray !== null && isLayoutArray(parsedArray);
   }
 }

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -35,6 +35,7 @@ import {ChatState} from '../../chat/chat-state/chat-state';
 import {MonacoEditor} from '../../shared/monaco-editor/monaco-editor';
 import {PreviewBridgeMessageType} from 'a2ui-bridge';
 import {UsageTrackingService} from '../../usage-tracking/usage-tracking.service';
+import {tryParseJsonArray} from '../../utils/json';
 
 /**
  * Hosts the raw JSON view of active surface models, allowing direct source editing
@@ -192,12 +193,11 @@ export class RawFrame {
     if (!trimmed) {
       return [];
     }
-    try {
-      const parsed = JSON.parse(trimmed);
-      return Array.isArray(parsed) ? parsed : [parsed];
-    } catch (err) {
-      throw new SyntaxError('Invalid JSON');
+    const parsed = tryParseJsonArray(trimmed);
+    if (parsed !== null) {
+      return parsed;
     }
+    throw new SyntaxError('Invalid JSON');
   }
 
   private showJsonSyntaxError(): void {

--- a/shell/src/app/utils/json.spec.ts
+++ b/shell/src/app/utils/json.spec.ts
@@ -24,6 +24,11 @@ describe('JSON Array Parser Utilities', () => {
     expect(tryParseJsonArray('[]')).toEqual([]);
   });
 
+  it('returns null safely when input is null or undefined', () => {
+    expect(tryParseJsonArray(null)).toBeNull();
+    expect(tryParseJsonArray(undefined)).toBeNull();
+  });
+
   it('returns null safely for invalid JSON Lines or primitive values', () => {
     expect(tryParseJsonArray('')).toBeNull();
     expect(tryParseJsonArray('   ')).toBeNull();

--- a/shell/src/app/utils/json.spec.ts
+++ b/shell/src/app/utils/json.spec.ts
@@ -24,12 +24,29 @@ describe('JSON Array Parser Utilities', () => {
     expect(tryParseJsonArray('[]')).toEqual([]);
   });
 
-  it('returns null safely without throwing on malformed JSON or non-array primitives', () => {
+  it('returns null safely for invalid JSON Lines or primitive values', () => {
+    expect(tryParseJsonArray('')).toBeNull();
+    expect(tryParseJsonArray('   ')).toBeNull();
     expect(tryParseJsonArray('  [1, 2, ')).toBeNull();
     expect(tryParseJsonArray('invalid json')).toBeNull();
-    expect(tryParseJsonArray('{"not": "an array"}')).toBeNull();
     expect(tryParseJsonArray('"string primitive"')).toBeNull();
     expect(tryParseJsonArray('123')).toBeNull();
+    expect(tryParseJsonArray('{"a": 1}\n{"b": 2}\ninvalid\n{"c": 3}')).toBeNull();
+    expect(tryParseJsonArray('{"a": 1\n{"b": 2}')).toBeNull();
+    expect(tryParseJsonArray('{"a": 1}\n{ "syntax_error": }')).toBeNull();
+  });
+
+  it('parses a single JSON object as a single-element array', () => {
+    expect(tryParseJsonArray('{"not": "an array"}')).toEqual([{not: 'an array'}]);
+    expect(tryParseJsonArray('  {"foo": "bar"}  ')).toEqual([{foo: 'bar'}]);
+  });
+
+  it('parses multiline JSON Lines (JSONL) string into an array of objects', () => {
+    expect(tryParseJsonArray('{"a": 1}\n{"b": 2}\n{"c": 3}')).toEqual([{a: 1}, {b: 2}, {c: 3}]);
+  });
+
+  it('parses JSON Lines with leading, trailing, and intermediate blank lines', () => {
+    expect(tryParseJsonArray('\n  \n{"a": 1}\n\n  {"b": 2} \n ')).toEqual([{a: 1}, {b: 2}]);
   });
 });
 

--- a/shell/src/app/utils/json.ts
+++ b/shell/src/app/utils/json.ts
@@ -23,6 +23,10 @@
  */
 export function tryParseJsonArray(content: string): unknown[] | null {
   const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
   if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
     try {
       const parsed = JSON.parse(trimmed);
@@ -30,9 +34,50 @@ export function tryParseJsonArray(content: string): unknown[] | null {
         return parsed;
       }
     } catch (e) {
-      // Ignore and return null
+      // Ignore array parse errors
+    }
+  } else if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return [parsed];
+      }
+    } catch (e) {
+      // Ignore object parse errors
     }
   }
+
+  // Try parsing as JSON Lines
+  const lines = trimmed
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0);
+  if (lines.length > 0) {
+    const parsedLines: unknown[] = [];
+    let validJSONL = true;
+    for (const line of lines) {
+      if (!line.startsWith('{') || !line.endsWith('}')) {
+        validJSONL = false;
+        break;
+      }
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          parsedLines.push(parsed);
+        } else {
+          validJSONL = false;
+          break;
+        }
+      } catch (e) {
+        validJSONL = false;
+        break;
+      }
+    }
+    if (validJSONL) {
+      return parsedLines;
+    }
+  }
+
   return null;
 }
 

--- a/shell/src/app/utils/json.ts
+++ b/shell/src/app/utils/json.ts
@@ -21,7 +21,10 @@
  * @param content The string content to parse.
  * @returns The parsed array, or null if parsing fails or the content is not an array.
  */
-export function tryParseJsonArray(content: string): unknown[] | null {
+export function tryParseJsonArray(content?: string | null): unknown[] | null {
+  if (content == null) {
+    return null;
+  }
   const trimmed = content.trim();
   if (trimmed.length === 0) {
     return null;


### PR DESCRIPTION
# Description

**Multi-Format Layout Parser (JSON, JSONL, Single-Object)**

* Enhances tryParseJsonArray in utils/json.ts to parse standard JSON arrays ([...]), single JSON objects ({...} → [obj]), and streaming JSON Lines ({...}\n{...}).
* Updates RawFrame and ChatCleaner to use unified JSONL-tolerant parsing and layout snapshot validation.
* Adds comprehensive unit tests covering single objects, multi-line JSONL streams, and malformed edge cases.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].
