### PR TITLE
[HostCommunication] Implement short-term renderer readiness handshake

### DIFF
--- a/shell/src/app/debug/data-model/data-model.spec.ts
+++ b/shell/src/app/debug/data-model/data-model.spec.ts
@@ -17,7 +17,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
-import {signal, WritableSignal} from '@angular/core';
+import {Subject} from 'rxjs';
 import {describe, it, expect, beforeEach, vi, afterEach} from 'vitest';
 import {DataModel} from './data-model';
 import {DataModelHarness} from './test/data-model.harness';
@@ -35,7 +35,7 @@ describe('DataModel', () => {
   let component: DataModel;
   let harness: DataModelHarness;
   let mockHostComm: {
-    messageStream: WritableSignal<MessageEnvelope | null>;
+    messageStream$: Subject<MessageEnvelope>;
     sendMessage: ReturnType<typeof vi.fn>;
   };
 
@@ -43,7 +43,7 @@ describe('DataModel', () => {
     vi.useFakeTimers();
 
     mockHostComm = {
-      messageStream: signal<MessageEnvelope | null>(null),
+      messageStream$: new Subject<MessageEnvelope>(),
       sendMessage: vi.fn(),
     };
 
@@ -78,7 +78,7 @@ describe('DataModel', () => {
         value: {foo: 'bar'},
       },
     };
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       payload,
       origin: 'http://localhost',
@@ -129,7 +129,7 @@ describe('DataModel', () => {
 
   it('does not dispatch redundant message when local JSON matches incoming data model', async () => {
     const incomingData = {foo: 'bar', count: 42};
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       payload: {
         updateDataModel: {
@@ -167,7 +167,7 @@ describe('DataModel', () => {
     TestBed.tick();
     fixture.detectChanges();
 
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: 'IRRELEVANT_MESSAGE_TYPE',
       payload: {foo: 'bar'},
       origin: 'http://localhost',
@@ -182,7 +182,7 @@ describe('DataModel', () => {
   });
 
   it('resets the editor text to empty when remote state resets to null', async () => {
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       payload: {
         updateDataModel: {
@@ -222,7 +222,7 @@ describe('DataModel', () => {
   });
 
   it('retains last known surfaceId and clears path when updateDataModel message is missing them', async () => {
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       payload: {
         updateDataModel: {
@@ -237,7 +237,7 @@ describe('DataModel', () => {
     TestBed.tick();
     fixture.detectChanges();
 
-    mockHostComm.messageStream.set({
+    mockHostComm.messageStream$.next({
       type: PreviewBridgeMessageType.DATA_MODEL_CHANGE,
       payload: {
         updateDataModel: {

--- a/shell/src/app/debug/data-model/data-model.ts
+++ b/shell/src/app/debug/data-model/data-model.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Component, computed, effect, inject, linkedSignal, signal, untracked} from '@angular/core';
+import {Component, computed, inject, linkedSignal, signal} from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {FormsModule} from '@angular/forms';
 import {MatFormFieldModule} from '@angular/material/form-field';
@@ -65,8 +65,7 @@ export class DataModel {
   });
 
   constructor() {
-    effect(() => {
-      const streamValue = this.hostComm.messageStream();
+    this.hostComm.messageStream$.pipe(takeUntilDestroyed()).subscribe(streamValue => {
       if (streamValue?.type === PreviewBridgeMessageType.DATA_MODEL_CHANGE) {
         const payload = streamValue?.payload as DataModelChangePayload | undefined;
         const updateObj = payload?.['updateDataModel'];
@@ -81,7 +80,7 @@ export class DataModel {
           }
 
           const cleanValue = updateObj['value'];
-          untracked(() => this.latestModelValue.set(cleanValue));
+          this.latestModelValue.set(cleanValue);
         }
       }
     });

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -704,15 +704,86 @@ describe('HostCommunication', () => {
       );
     });
 
-    it('suppresses outbound messages in sendMessage when renderer is not ready', () => {
+    it('queues outbound messages when renderer is not ready', () => {
       const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
       service.registerIframe(mockIframeWindow);
       expect(service.isRendererReady()).toBe(false);
 
       service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
       expect(mockIframeWindow.postMessage).not.toHaveBeenCalled();
+
+      // Checking that outboundMessageBuffer buffered the message.
+      // We can assert via internal state if possible, but the best way is to send RENDERER_READY and check if it's flushed.
+      // But wait, the flush spec will cover flushing. To prove queueing, we can check mock postMessage count before and after RENDERER_READY.
     });
 
+    it('flushes queued outbound messages in order when RENDERER_READY is received', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      service.sendMessage({type: PreviewBridgeMessageType.CONSOLE_LOG});
+      expect(mockIframeWindow.postMessage).not.toHaveBeenCalled();
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {type: PreviewBridgeMessageType.RENDERER_READY},
+        }),
+      );
+
+      // It should have sent SET_THEME plus the 2 queued messages
+      expect(mockIframeWindow.postMessage).toHaveBeenNthCalledWith(
+        1,
+        {
+          type: PreviewBridgeMessageType.SET_THEME,
+          payload: {theme: ThemePreference.LIGHT},
+        },
+        'http://localhost:3000',
+      );
+      expect(mockIframeWindow.postMessage).toHaveBeenNthCalledWith(
+        2,
+        {type: PreviewBridgeMessageType.GET_CATALOG},
+        'http://localhost:3000',
+      );
+      expect(mockIframeWindow.postMessage).toHaveBeenNthCalledWith(
+        3,
+        {type: PreviewBridgeMessageType.CONSOLE_LOG},
+        'http://localhost:3000',
+      );
+      expect(mockIframeWindow.postMessage).toHaveBeenCalledTimes(3);
+    });
+
+    it('clears the outbound buffer on registerTarget, unregisterTarget, and ngOnDestroy', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+
+      // Seed buffer
+      service.registerIframe(mockIframeWindow);
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      expect(service['outboundMessageBuffer'].length).toBe(1);
+
+      // Clears on unregisterTarget (registerIframe(null))
+      service.registerIframe(null);
+      expect(service['outboundMessageBuffer'].length).toBe(0);
+
+      // Seed buffer again
+      service.registerIframe(mockIframeWindow);
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      expect(service['outboundMessageBuffer'].length).toBe(1);
+
+      // Clears on registerTarget (registerIframe with target)
+      service.registerIframe(mockIframeWindow);
+      expect(service['outboundMessageBuffer'].length).toBe(0);
+
+      // Seed buffer again
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      expect(service['outboundMessageBuffer'].length).toBe(1);
+
+      // Clears on ngOnDestroy
+      service.ngOnDestroy();
+      expect(service['outboundMessageBuffer'].length).toBe(0);
+    });
     it('allows outbound messages in sendMessage when renderer is ready', () => {
       const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
       service.registerIframe(mockIframeWindow);

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -138,6 +138,13 @@ describe('HostCommunication', () => {
       postMessage: vi.fn(),
     } as unknown as Window;
     service.registerIframe(mockIframeWindow);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      }),
+    );
 
     service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
 
@@ -184,6 +191,13 @@ describe('HostCommunication', () => {
   it('successfully invokes postMessage when sendRenderA2UI is called with a valid payload', () => {
     const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
     service.registerIframe(mockIframeWindow);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      }),
+    );
 
     const validPayload = [{version: 'v0.9', updateDataModel: {surfaceId: 's-1'}}];
     service.sendRenderA2UI(validPayload);
@@ -219,6 +233,13 @@ describe('HostCommunication', () => {
     const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
     const mockIFrameElement = {contentWindow: mockIframeWindow} as unknown as HTMLIFrameElement;
     service.registerIframe(mockIFrameElement);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      }),
+    );
 
     service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
 
@@ -542,6 +563,13 @@ describe('HostCommunication', () => {
   it('dispatches SET_THEME message via sendTheme', () => {
     const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
     service.registerIframe(mockIframeWindow);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      }),
+    );
 
     service.sendTheme(ThemePreference.DARK);
 
@@ -576,19 +604,13 @@ describe('HostCommunication', () => {
     );
   });
 
-  it('automatically dispatches current themePreference upon iframe registration', () => {
+  it('suppresses automatic dispatch of current themePreference upon iframe registration', () => {
     const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
     themePreferenceSignal.set(ThemePreference.DARK);
 
     service.registerIframe(mockIframeWindow);
 
-    expect(mockIframeWindow.postMessage).toHaveBeenCalledWith(
-      {
-        type: PreviewBridgeMessageType.SET_THEME,
-        payload: {theme: ThemePreference.DARK},
-      },
-      'http://localhost:3000',
-    );
+    expect(mockIframeWindow.postMessage).not.toHaveBeenCalled();
   });
 
   it('preserves early message buffer when registering an unattached iframe element with null contentWindow', () => {
@@ -629,6 +651,124 @@ describe('HostCommunication', () => {
 
       service.registerIframe(null);
       expect(service.getIframeElement()).toBeNull();
+    });
+  });
+
+  describe('Renderer Readiness', () => {
+    it('initializes renderer readiness signal to false', () => {
+      expect(service.isRendererReady()).toBe(false);
+    });
+
+    it('resets renderer readiness to false when iframe target is re-registered or nulled', () => {
+      // Simulate ready
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {type: PreviewBridgeMessageType.RENDERER_READY},
+        }),
+      );
+      expect(service.isRendererReady()).toBe(true);
+
+      // Null it out
+      service.registerIframe(null);
+      expect(service.isRendererReady()).toBe(false);
+
+      // Register again
+      service.registerIframe(mockIframeWindow);
+      expect(service.isRendererReady()).toBe(false);
+    });
+
+    it('transitions renderer readiness to true upon receiving RENDERER_READY message and triggers sendTheme', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+      expect(service.isRendererReady()).toBe(false);
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {type: PreviewBridgeMessageType.RENDERER_READY},
+        }),
+      );
+
+      expect(service.isRendererReady()).toBe(true);
+      expect(mockIframeWindow.postMessage).toHaveBeenCalledWith(
+        {
+          type: PreviewBridgeMessageType.SET_THEME,
+          payload: {theme: ThemePreference.LIGHT},
+        },
+        'http://localhost:3000',
+      );
+    });
+
+    it('suppresses outbound messages in sendMessage when renderer is not ready', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+      expect(service.isRendererReady()).toBe(false);
+
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      expect(mockIframeWindow.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('allows outbound messages in sendMessage when renderer is ready', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {type: PreviewBridgeMessageType.RENDERER_READY},
+        }),
+      );
+
+      expect(service.isRendererReady()).toBe(true);
+
+      service.sendMessage({type: PreviewBridgeMessageType.GET_CATALOG});
+      expect(mockIframeWindow.postMessage).toHaveBeenCalledWith(
+        {type: PreviewBridgeMessageType.GET_CATALOG},
+        'http://localhost:3000',
+      );
+    });
+
+    it('resets renderer readiness to false upon destruction (ngOnDestroy)', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {type: PreviewBridgeMessageType.RENDERER_READY},
+        }),
+      );
+      expect(service.isRendererReady()).toBe(true);
+
+      service.ngOnDestroy();
+      expect(service.isRendererReady()).toBe(false);
+    });
+
+    it('preserves readiness on repeated RENDERER_READY messages', () => {
+      const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+      service.registerIframe(mockIframeWindow);
+
+      const readyEvent = new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      });
+
+      window.dispatchEvent(readyEvent);
+      expect(service.isRendererReady()).toBe(true);
+      expect(mockIframeWindow.postMessage).toHaveBeenCalledTimes(1);
+
+      // Send another one
+      window.dispatchEvent(readyEvent);
+      expect(service.isRendererReady()).toBe(true);
+      // It should send SET_THEME again on each RENDERER_READY per standard behavior
+      expect(mockIframeWindow.postMessage).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -77,6 +77,10 @@ export class HostCommunication implements OnDestroy {
 
   private readonly messageHistoryBuffer: MessageEnvelope[] = [];
   private readonly earlyMessageBuffer: MessageEvent[] = [];
+  private readonly outboundMessageBuffer: Array<{
+    type: PreviewBridgeMessageType;
+    payload?: unknown;
+  }> = [];
   private latestCatalogEnvelope: MessageEnvelope | null = null;
 
   /**
@@ -166,6 +170,11 @@ export class HostCommunication implements OnDestroy {
       if (type === PreviewBridgeMessageType.RENDERER_READY) {
         this.isRendererReadySignal.set(true);
         this.sendTheme(this.configProvider.themePreference());
+        const pending = [...this.outboundMessageBuffer];
+        this.outboundMessageBuffer.length = 0;
+        for (const msg of pending) {
+          this.sendMessage(msg);
+        }
       }
       if (type !== PreviewBridgeMessageType.CONSOLE_LOG) {
         this.messageHistoryBuffer.push(envelope);
@@ -202,6 +211,7 @@ export class HostCommunication implements OnDestroy {
    * @param target Target iframe element, window reference, or null to unregister
    */
   registerIframe(target: HTMLIFrameElement | Window | null): void {
+    this.outboundMessageBuffer.length = 0;
     if (!target) {
       this.iframeElement = null;
       this.iframeWindow = null;
@@ -237,7 +247,8 @@ export class HostCommunication implements OnDestroy {
     }
 
     if (!this.isRendererReady()) {
-      console.debug('Dropping outbound message; renderer is not yet ready.', message);
+      console.debug('Queueing outbound message; renderer is not yet ready.', message);
+      this.outboundMessageBuffer.push(message);
       return;
     }
 
@@ -288,6 +299,7 @@ export class HostCommunication implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.outboundMessageBuffer.length = 0;
     this.isRendererReadySignal.set(false);
     this.earlyMessageBuffer.length = 0;
     this.messageStreamSubject.complete();

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -59,9 +59,13 @@ export class HostCommunication implements OnDestroy {
   private iframeWindow: Window | null = null;
   private iframeElement: HTMLIFrameElement | null = null;
   private readonly latestEnvelopeSignal = signal<MessageEnvelope | null>(null);
+  private readonly isRendererReadySignal = signal<boolean>(false);
 
   /** Readonly signal tracking the most recent message envelope */
   readonly latestEnvelope: Signal<MessageEnvelope | null> = this.latestEnvelopeSignal.asReadonly();
+
+  /** Readonly signal tracking if the guest renderer is ready */
+  readonly isRendererReady = this.isRendererReadySignal.asReadonly();
 
   private readonly messageStreamSubject = new ReplaySubject<MessageEnvelope>(1);
   /** Uncoalesced hot event stream broadcasting all incoming message envelopes */
@@ -160,6 +164,7 @@ export class HostCommunication implements OnDestroy {
         this.latestCatalogEnvelope = envelope;
       }
       if (type === PreviewBridgeMessageType.RENDERER_READY) {
+        this.isRendererReadySignal.set(true);
         this.sendTheme(this.configProvider.themePreference());
       }
       if (type !== PreviewBridgeMessageType.CONSOLE_LOG) {
@@ -201,6 +206,7 @@ export class HostCommunication implements OnDestroy {
       this.iframeElement = null;
       this.iframeWindow = null;
       this.earlyMessageBuffer.length = 0;
+      this.isRendererReadySignal.set(false);
       return;
     }
 
@@ -214,9 +220,9 @@ export class HostCommunication implements OnDestroy {
     }
 
     this.iframeWindow = windowTarget;
+    this.isRendererReadySignal.set(false);
     if (windowTarget) {
       this.flushEarlyMessages();
-      this.sendTheme(this.configProvider.themePreference());
     }
   }
 
@@ -227,6 +233,11 @@ export class HostCommunication implements OnDestroy {
   sendMessage(message: {type: PreviewBridgeMessageType; payload?: unknown}): void {
     if (!CrossFrameValidator.validateOutgoingMessage(message)) {
       console.error('Blocked dispatch of malformed message type...', message);
+      return;
+    }
+
+    if (!this.isRendererReady()) {
+      console.debug('Dropping outbound message; renderer is not yet ready.', message);
       return;
     }
 
@@ -277,7 +288,9 @@ export class HostCommunication implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.isRendererReadySignal.set(false);
     this.earlyMessageBuffer.length = 0;
+    this.messageStreamSubject.complete();
     if (typeof window !== 'undefined') {
       window.removeEventListener('message', this.messageListener);
       delete window.a2uiHostCommunication;


### PR DESCRIPTION
# Description

Introduce isRendererReady signal to track iframe preview readiness. Defer theme transmission and guard outbound messages until the RENDERER_READY signal is received from the preview bridge.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].
