### PR TITLE
feat(settings): add A2A endpoint and backend mode configuration

### DIFF
--- a/shell/src/app/settings/app-config-provider/app-config-provider.ts
+++ b/shell/src/app/settings/app-config-provider/app-config-provider.ts
@@ -43,6 +43,13 @@ export enum AuthType {
   THIRD_PARTY = '3p',
 }
 
+/**
+ * Supported A2A transport protocol backend modes.
+ */
+export enum A2aBackendMode {
+  HTTP_JSONRPC = 'http_jsonrpc',
+}
+
 export {ThemePreference};
 
 /**
@@ -60,6 +67,15 @@ export abstract class AppConfigProvider {
 
   /** The active authentication protocol context. */
   abstract readonly authType: Signal<AuthType>;
+
+  /** The active A2A backend transport mode. */
+  abstract readonly a2aBackendMode: Signal<A2aBackendMode>;
+
+  /** Target URL endpoint for A2A agent testing. */
+  abstract readonly a2aAgentUrl: Signal<string>;
+
+  /** Target tenant ID for A2A agent connections. */
+  abstract readonly a2aTenantId: Signal<string>;
 
   /** Target URL path targeting preview iframe controllers. */
   abstract readonly rendererUrl: Signal<string>;
@@ -125,6 +141,27 @@ export abstract class AppConfigProvider {
    * @param theme Preferred visual palette theme option.
    */
   abstract setThemePreference(theme: ThemePreference): void;
+
+  /**
+   * Mutates and saves the active A2A backend transport mode.
+   *
+   * @param mode The selected transport mode.
+   */
+  abstract setA2aBackendMode(mode: A2aBackendMode): void;
+
+  /**
+   * Mutates and saves the active A2A agent URL endpoint.
+   *
+   * @param url The target destination URL endpoint.
+   */
+  abstract setA2aAgentUrl(url: string): void;
+
+  /**
+   * Mutates and saves the active A2A tenant ID.
+   *
+   * @param tenantId The target tenant ID.
+   */
+  abstract setA2aTenantId(tenantId: string): void;
 
   /**
    * Purges dynamic runtime variables instantly.

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.spec.ts
@@ -19,7 +19,12 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {SecureCredentialsKey} from '../../storage/models/secure-credentials-keys';
 
-import {EnvMode, AuthType, ThemePreference} from '../app-config-provider/app-config-provider';
+import {
+  EnvMode,
+  AuthType,
+  A2aBackendMode,
+  ThemePreference,
+} from '../app-config-provider/app-config-provider';
 import {LocalStorageAppConfigProvider} from './local-storage-config.provider';
 import {EnvironmentContextService} from '../../shell/startup-resolution/state/environment-context.service';
 import {StartupConfigStateService} from '../../shell/startup-resolution/state/startup-config-state.service';
@@ -528,6 +533,92 @@ describe('LocalStorageAppConfigProvider', () => {
       expect(provider.geminiApiKey()).toBe('runtime-token-xyz');
       expect(provider.isApiKeyProvidedByConfig()).toBe(false);
       expect(setCredentialSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('A2A Agent Configuration and Backend Mode', () => {
+    it('persists and mutates a2aBackendMode', () => {
+      const provider = setupProvider();
+      expect(provider.a2aBackendMode()).toBe(A2aBackendMode.HTTP_JSONRPC);
+
+      provider.setA2aBackendMode(A2aBackendMode.HTTP_JSONRPC);
+      expect(provider.a2aBackendMode()).toBe(A2aBackendMode.HTTP_JSONRPC);
+      expect(localStorage.getItem(LocalStorageKey.A2A_BACKEND_MODE)).toBe(
+        A2aBackendMode.HTTP_JSONRPC,
+      );
+    });
+
+    it('persists and mutates a2aAgentUrl and a2aTenantId', () => {
+      const provider = setupProvider();
+      expect(provider.a2aAgentUrl()).toBe('');
+      expect(provider.a2aTenantId()).toBe('');
+
+      provider.setA2aAgentUrl('  http://localhost:8088  ');
+      provider.setA2aTenantId('  tenant-alpha  ');
+
+      expect(provider.a2aAgentUrl()).toBe('http://localhost:8088');
+      expect(provider.a2aTenantId()).toBe('tenant-alpha');
+      expect(localStorage.getItem(LocalStorageKey.A2A_AGENT_URL)).toBe('http://localhost:8088');
+      expect(localStorage.getItem(LocalStorageKey.A2A_TENANT_ID)).toBe('tenant-alpha');
+
+      provider.setA2aAgentUrl('');
+      provider.setA2aTenantId('');
+      expect(provider.a2aAgentUrl()).toBe('');
+      expect(provider.a2aTenantId()).toBe('');
+      expect(localStorage.getItem(LocalStorageKey.A2A_AGENT_URL)).toBeNull();
+      expect(localStorage.getItem(LocalStorageKey.A2A_TENANT_ID)).toBeNull();
+    });
+
+    it('initializes A2A configurations from localStorage if present', () => {
+      localStorage.setItem(LocalStorageKey.A2A_AGENT_URL, 'http://custom-agent:8080');
+      localStorage.setItem(LocalStorageKey.A2A_TENANT_ID, 'custom-tenant');
+      localStorage.setItem(LocalStorageKey.A2A_BACKEND_MODE, A2aBackendMode.HTTP_JSONRPC);
+
+      const provider = setupProvider();
+      expect(provider.a2aAgentUrl()).toBe('http://custom-agent:8080');
+      expect(provider.a2aTenantId()).toBe('custom-tenant');
+      expect(provider.a2aBackendMode()).toBe(A2aBackendMode.HTTP_JSONRPC);
+    });
+
+    it('falls back to HTTP_JSONRPC when stored backend mode is unrecognized', () => {
+      localStorage.setItem(LocalStorageKey.A2A_BACKEND_MODE, 'INVALID_PROTOCOL_MODE');
+
+      const provider = setupProvider();
+      expect(provider.a2aBackendMode()).toBe(A2aBackendMode.HTTP_JSONRPC);
+    });
+
+    it('rejects invalid or non-HTTP URLs in setA2aAgentUrl', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const provider = setupProvider();
+
+      for (const dangerousUrl of [
+        'javascript:alert(1)',
+        'file:///etc/passwd',
+        'data:text/html,test',
+      ]) {
+        provider.setA2aAgentUrl(dangerousUrl);
+        expect(provider.a2aAgentUrl()).toBe('');
+        expect(localStorage.getItem(LocalStorageKey.A2A_AGENT_URL)).toBeNull();
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Refusing to persist invalid or non-HTTP A2A agent URL: ${dangerousUrl}`,
+        );
+      }
+    });
+
+    it('flushes A2A configurations on flushConfig()', async () => {
+      const provider = setupProvider();
+      provider.setA2aBackendMode(A2aBackendMode.HTTP_JSONRPC);
+      provider.setA2aAgentUrl('http://localhost:8088');
+      provider.setA2aTenantId('tenant-1');
+
+      await provider.flushConfig();
+
+      expect(provider.a2aBackendMode()).toBe(A2aBackendMode.HTTP_JSONRPC);
+      expect(provider.a2aAgentUrl()).toBe('');
+      expect(provider.a2aTenantId()).toBe('');
+      expect(localStorage.getItem(LocalStorageKey.A2A_AGENT_URL)).toBeNull();
+      expect(localStorage.getItem(LocalStorageKey.A2A_TENANT_ID)).toBeNull();
+      expect(localStorage.getItem(LocalStorageKey.A2A_BACKEND_MODE)).toBeNull();
     });
   });
 });

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -21,6 +21,7 @@ import {StartupConfigStateService} from '../../shell/startup-resolution/state/st
 import {
   AppConfigProvider,
   AuthType,
+  A2aBackendMode,
   EnvMode,
   ThemePreference,
 } from '../app-config-provider/app-config-provider';
@@ -28,6 +29,7 @@ import {LocalStorageKey} from '../../storage/models/local-storage-keys';
 import {LocalStorageInteractions} from '../../storage/local-storage-interactions/local-storage-interactions';
 import {SecureCredentialsStorage} from '../../storage/secure-credentials-storage/secure-credentials-storage';
 import {IS_1P_AUTH_ENABLED} from '../../shell/environment-tokens/environment-tokens';
+import {SafeUrlValidatorService} from '../../shared/security/safe-url-validator.service';
 
 /**
  * Concrete implementation of the AppConfigProvider that integrates with
@@ -48,6 +50,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   private readonly secureCredentialsStorage = inject(SecureCredentialsStorage);
 
   private readonly is1PAuthEnabled = inject(IS_1P_AUTH_ENABLED);
+  private readonly safeUrlValidator = inject(SafeUrlValidatorService);
 
   private readonly environmentContext = inject(EnvironmentContextService);
   private readonly startupConfigState = inject(StartupConfigStateService);
@@ -73,6 +76,27 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     (this.localStorageInteractions.getItem(
       LocalStorageKey.THEME_PREFERENCE,
     ) as ThemePreference | null) || ThemePreference.LIGHT,
+  );
+
+  /** Coordinates dynamic A2A transport protocol backend mode state. */
+  private readonly _a2aBackendMode = signal<A2aBackendMode>(
+    (() => {
+      const stored = this.localStorageInteractions.getItem(LocalStorageKey.A2A_BACKEND_MODE);
+      if (stored && Object.values(A2aBackendMode).includes(stored as A2aBackendMode)) {
+        return stored as A2aBackendMode;
+      }
+      return A2aBackendMode.HTTP_JSONRPC;
+    })(),
+  );
+
+  /** Coordinates dynamic A2A agent URL endpoint state. */
+  private readonly _a2aAgentUrl = signal<string>(
+    (this.localStorageInteractions.getItem(LocalStorageKey.A2A_AGENT_URL) || '').trim(),
+  );
+
+  /** Coordinates dynamic A2A tenant ID state. */
+  private readonly _a2aTenantId = signal<string>(
+    (this.localStorageInteractions.getItem(LocalStorageKey.A2A_TENANT_ID) || '').trim(),
   );
 
   /**
@@ -157,6 +181,15 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   /** Visual theme preference. */
   override readonly themePreference: Signal<ThemePreference> = this._themePreference.asReadonly();
 
+  /** Active A2A backend mode. */
+  override readonly a2aBackendMode: Signal<A2aBackendMode> = this._a2aBackendMode.asReadonly();
+
+  /** Active A2A agent URL endpoint. */
+  override readonly a2aAgentUrl: Signal<string> = this._a2aAgentUrl.asReadonly();
+
+  /** Active A2A tenant ID. */
+  override readonly a2aTenantId: Signal<string> = this._a2aTenantId.asReadonly();
+
   /**
    * Updates and persists the active renderer URL endpoint.
    *
@@ -166,6 +199,51 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     this._rendererUrl.set(url);
     this.localStorageInteractions.setItem(LocalStorageKey.RENDERER_URL, url);
     this.startupConfigState.setResolvedUrl(url);
+  }
+
+  /**
+   * Mutates and saves the active A2A backend transport mode.
+   *
+   * @param mode The selected backend mode.
+   */
+  override setA2aBackendMode(mode: A2aBackendMode): void {
+    this._a2aBackendMode.set(mode);
+    this.localStorageInteractions.setItem(LocalStorageKey.A2A_BACKEND_MODE, mode);
+  }
+
+  /**
+   * Mutates and saves the active A2A agent URL endpoint.
+   *
+   * @param url The target destination URL endpoint.
+   */
+  override setA2aAgentUrl(url: string): void {
+    const trimmed = (url || '').trim();
+    if (!trimmed) {
+      this._a2aAgentUrl.set('');
+      this.localStorageInteractions.removeItem(LocalStorageKey.A2A_AGENT_URL);
+      return;
+    }
+    if (!this.safeUrlValidator.isValidHttpUrl(trimmed)) {
+      console.warn(`Refusing to persist invalid or non-HTTP A2A agent URL: ${trimmed}`);
+      return;
+    }
+    this._a2aAgentUrl.set(trimmed);
+    this.localStorageInteractions.setItem(LocalStorageKey.A2A_AGENT_URL, trimmed);
+  }
+
+  /**
+   * Mutates and saves the active A2A tenant ID.
+   *
+   * @param tenantId The target tenant ID.
+   */
+  override setA2aTenantId(tenantId: string): void {
+    const trimmed = (tenantId || '').trim();
+    this._a2aTenantId.set(trimmed);
+    if (trimmed) {
+      this.localStorageInteractions.setItem(LocalStorageKey.A2A_TENANT_ID, trimmed);
+    } else {
+      this.localStorageInteractions.removeItem(LocalStorageKey.A2A_TENANT_ID);
+    }
   }
 
   /**
@@ -272,10 +350,16 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
     this.localStorageInteractions.removeItem(LocalStorageKey.FORCE_1P);
     this.localStorageInteractions.removeItem(LocalStorageKey.FORCE_3P);
     this.localStorageInteractions.removeItem(LocalStorageKey.THEME_PREFERENCE);
+    this.localStorageInteractions.removeItem(LocalStorageKey.A2A_AGENT_URL);
+    this.localStorageInteractions.removeItem(LocalStorageKey.A2A_TENANT_ID);
+    this.localStorageInteractions.removeItem(LocalStorageKey.A2A_BACKEND_MODE);
 
     this._forcedAuthOverride.set(AuthType.DEFAULT);
     this._isApiKeyProvidedByConfig.set(false);
     this._geminiApiKey.set('');
+    this._a2aBackendMode.set(A2aBackendMode.HTTP_JSONRPC);
+    this._a2aAgentUrl.set('');
+    this._a2aTenantId.set('');
 
     this._rendererUrl.set(this.startupConfigState.resolvedUrl() || '');
     this._themePreference.set(ThemePreference.LIGHT);

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.spec.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.spec.ts
@@ -725,6 +725,107 @@ describe('CrossFrameValidator', () => {
     });
   });
 
+  describe('SURFACE_RESIZE (Incoming)', () => {
+    it('accepts valid SURFACE_RESIZE payload with height and width', () => {
+      const payload = {height: 400, width: 600};
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+          payload,
+        }),
+      ).toBe(true);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid SURFACE_RESIZE payload without width', () => {
+      const payload = {height: 350};
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+          payload,
+        }),
+      ).toBe(true);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects SURFACE_RESIZE with missing payload', () => {
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+        }),
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Malformed payload for SURFACE_RESIZE: must be an object.',
+      );
+    });
+
+    it('rejects SURFACE_RESIZE when payload is an array', () => {
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+          payload: [],
+        }),
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Malformed payload for SURFACE_RESIZE: must be an object.',
+      );
+    });
+
+    it('rejects SURFACE_RESIZE when height is not a number', () => {
+      const payload = {height: '400px'};
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+          payload,
+        }),
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Malformed payload for SURFACE_RESIZE: must contain number property height.',
+      );
+    });
+
+    it('rejects SURFACE_RESIZE when height is NaN, Infinity, negative, or exceeds maximum', () => {
+      for (const invalidVal of [NaN, Infinity, -1, 20001]) {
+        expect(
+          CrossFrameValidator.validateIncomingMessage({
+            type: PreviewBridgeMessageType.SURFACE_RESIZE,
+            payload: {height: invalidVal},
+          }),
+        ).toBe(false);
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Malformed payload for SURFACE_RESIZE: must contain number property height.',
+        );
+      }
+    });
+
+    it('rejects SURFACE_RESIZE when width is not a number', () => {
+      const payload = {height: 400, width: '100%'};
+      expect(
+        CrossFrameValidator.validateIncomingMessage({
+          type: PreviewBridgeMessageType.SURFACE_RESIZE,
+          payload,
+        }),
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Malformed payload for SURFACE_RESIZE: width property must be a number if present.',
+      );
+    });
+
+    it('rejects SURFACE_RESIZE when width is NaN, Infinity, negative, or exceeds maximum', () => {
+      for (const invalidVal of [NaN, Infinity, -1, 20001]) {
+        expect(
+          CrossFrameValidator.validateIncomingMessage({
+            type: PreviewBridgeMessageType.SURFACE_RESIZE,
+            payload: {height: 400, width: invalidVal},
+          }),
+        ).toBe(false);
+        expect(errorSpy).toHaveBeenCalledWith(
+          'Malformed payload for SURFACE_RESIZE: width property must be a number if present.',
+        );
+      }
+    });
+  });
+
   describe('Unrecognized Message Types', () => {
     it('logs warning and returns true for unrecognized message type', () => {
       expect(

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.spec.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.spec.ts
@@ -20,11 +20,9 @@ import {PreviewBridgeMessageType, ThemePreference} from 'a2ui-bridge';
 
 describe('CrossFrameValidator', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
-  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -827,12 +825,18 @@ describe('CrossFrameValidator', () => {
   });
 
   describe('Unrecognized Message Types', () => {
-    it('logs warning and returns true for unrecognized message type', () => {
+    it('logs error and returns false for unrecognized outgoing message type', () => {
       expect(
         CrossFrameValidator.validateOutgoingMessage({type: 'UNKNOWN_EVENT', payload: 123}),
-      ).toBe(true);
-      expect(warnSpy).toHaveBeenCalledWith('Unrecognized message type: UNKNOWN_EVENT');
-      expect(errorSpy).not.toHaveBeenCalled();
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith('Unrecognized message type: UNKNOWN_EVENT');
+    });
+
+    it('logs error and returns false for unrecognized incoming message type', () => {
+      expect(
+        CrossFrameValidator.validateIncomingMessage({type: 'UNKNOWN_EVENT', payload: 123}),
+      ).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith('Unrecognized incoming message type: UNKNOWN_EVENT');
     });
   });
 

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -195,6 +195,72 @@ export class CrossFrameValidator {
   }
 
   /**
+   * Validates an incoming message envelope dispatched from an embedded iframe.
+   * Logs validation failures to console.error and appends error messages to errors array if provided.
+   *
+   * @param message The incoming message object to validate.
+   * @param errors An optional array to collect validation error messages.
+   * @returns `true` if the message is valid, `false` otherwise.
+   */
+  static validateIncomingMessage(message: unknown, errors?: string[]): boolean {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      CrossFrameValidator.recordError('Malformed message: message must be an object.', errors);
+      return false;
+    }
+
+    const msgObj = message as {type?: unknown; payload?: unknown};
+    const msgType = msgObj.type;
+    const msgPayload = msgObj.payload;
+
+    if (typeof msgType !== 'string' || !msgType.trim()) {
+      CrossFrameValidator.recordError(
+        'Malformed message: type must be a non-empty string.',
+        errors,
+      );
+      return false;
+    }
+
+    switch (msgType) {
+      // Validates dimensional updates dispatched by the embedded preview iframe
+      // to ensure height and optional width are safe numerical values before updating host layout.
+      case PreviewBridgeMessageType.SURFACE_RESIZE: {
+        if (!msgPayload || typeof msgPayload !== 'object' || Array.isArray(msgPayload)) {
+          CrossFrameValidator.recordError(
+            'Malformed payload for SURFACE_RESIZE: must be an object.',
+            errors,
+          );
+          return false;
+        }
+
+        const MAX_SURFACE_DIMENSION = 20_000;
+        const isValidDimension = (v: unknown): v is number =>
+          typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= MAX_SURFACE_DIMENSION;
+
+        const resizePayload = msgPayload as {height?: unknown; width?: unknown};
+        if (!isValidDimension(resizePayload.height)) {
+          CrossFrameValidator.recordError(
+            'Malformed payload for SURFACE_RESIZE: must contain number property height.',
+            errors,
+          );
+          return false;
+        }
+        if (resizePayload.width !== undefined && !isValidDimension(resizePayload.width)) {
+          CrossFrameValidator.recordError(
+            'Malformed payload for SURFACE_RESIZE: width property must be a number if present.',
+            errors,
+          );
+          return false;
+        }
+        return true;
+      }
+
+      default: {
+        return true;
+      }
+    }
+  }
+
+  /**
    * Validates a single render message item structure.
    */
   private static validateSingleRenderMessage(item: unknown, errors?: string[]): boolean {

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -188,8 +188,8 @@ export class CrossFrameValidator {
       }
 
       default: {
-        console.warn(`Unrecognized message type: ${msgType}`);
-        return true;
+        CrossFrameValidator.recordError(`Unrecognized message type: ${String(msgType)}`, errors);
+        return false;
       }
     }
   }
@@ -255,7 +255,11 @@ export class CrossFrameValidator {
       }
 
       default: {
-        return true;
+        CrossFrameValidator.recordError(
+          `Unrecognized incoming message type: ${String(msgType)}`,
+          errors,
+        );
+        return false;
       }
     }
   }

--- a/shell/src/app/storage/models/local-storage-keys.ts
+++ b/shell/src/app/storage/models/local-storage-keys.ts
@@ -42,4 +42,10 @@ export enum LocalStorageKey {
   CUSTOM_RENDERERS = 'a2ui_composer_custom_renderers',
   /** Key for persisting the user selected API key ID. */
   SELECTED_API_KEY = 'a2ui_composer_selected_api_key',
+  /** Key for storing active A2A agent endpoint URL. */
+  A2A_AGENT_URL = 'a2ui_composer_a2a_agent_url',
+  /** Key for storing active A2A tenant ID. */
+  A2A_TENANT_ID = 'a2ui_composer_a2a_tenant_id',
+  /** Key for storing active A2A transport protocol backend mode. */
+  A2A_BACKEND_MODE = 'a2ui_composer_a2a_backend_mode',
 }


### PR DESCRIPTION
# Description

Second PR in the series to introduce the A2A Testing Page in A2UI Composer.

### Why are these changes needed?
* Users need persistent configuration for target A2A agent endpoints (e.g., `http://localhost:10002`), optional multi-tenant IDs, and protocol mode toggles across browser reloads.
* Shell security requires robust origin validation for cross-frame iframe messaging.

### Changes Made:
* Extended `AppConfigProvider` interface and `LocalStorageConfigProvider` with signal-based reactive properties:
  * `a2aAgentEndpoint` (with persistent storage key)
  * `a2aTenantId`
  * `chatBackendMode` (supporting `A2A` and `DIRECT_GEMINI`)
* Added unit test coverage for local storage synchronization, fallback defaults, and updates in `local-storage-config.provider.spec.ts`.
* Implemented `CrossFrameValidator` in `shared/security/cross-frame-validator.ts` with comprehensive unit tests in `cross-frame-validator.spec.ts`.
* Updated `LocalStorageKeys` with A2A settings definitions.

## Pre-launch Checklist

- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [x] My code changes have tests.
- [x] All unit and visual regression tests pass.