### PR TITLE
Fix typos 'commited' and 'returns' across codebase

### DIFF
--- a/bridge/src/angular/angular-bridge.ts
+++ b/bridge/src/angular/angular-bridge.ts
@@ -131,7 +131,7 @@ export class A2uiSandboxConnection implements OnDestroy {
  *
  * @param catalogsClasses The array of catalog component provider classes (e.g. BasicCatalog) to register and manage.
  * @param options Optional configuration adapter block holding local catalogJson and markdownRendererFn hook delegates.
- * @returns Angular EnvironmentProviders ready for modern standalone bootstrapping application scopes.
+ * @return Angular EnvironmentProviders ready for modern standalone bootstrapping application scopes.
  */
 export function provideA2uiSandbox(
   catalogsClasses: Array<Type<Catalog<ComponentApi>>>,

--- a/bridge/src/instrumentation-overrides.ts
+++ b/bridge/src/instrumentation-overrides.ts
@@ -50,7 +50,7 @@ let rejectionHandler: ((event: PromiseRejectionEvent) => void) | null;
  *
  * @param obj The value or object to safely clone.
  * @param ancestors A set of ancestor object references used to track and prevent circular references during recursion.
- * @returns A safe, deep-cloned representation of the input value.
+ * @return A safe, deep-cloned representation of the input value.
  */
 function deepCloneSafe(obj: unknown, ancestors: Set<unknown> = new Set<unknown>()): unknown {
   if (obj instanceof Error) {

--- a/bridge/src/lit/lit-bridge.ts
+++ b/bridge/src/lit/lit-bridge.ts
@@ -177,7 +177,7 @@ export class A2uiSandboxRoot extends LitElement {
  *
  * @param catalogs The array of component catalogs defining local layouts.
  * @param options Optional configuration options block holding the HTML tag name and preloaded catalog JSON data.
- * @returns The A2uiSandboxRoot custom element constructor value ready for nominal references.
+ * @return The A2uiSandboxRoot custom element constructor value ready for nominal references.
  */
 export function bootstrapLitSandbox<T extends ComponentApi>(
   catalogs: Catalog<T>[],

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -211,7 +211,7 @@ export class PreviewBridge {
    *
    * @param processor The framework-specific message processor.
    * @param config The configuration object containing the surface group and lifecycle callbacks.
-   * @returns A subscription handle to detach the renderer and clean up surface connections.
+   * @return A subscription handle to detach the renderer and clean up surface connections.
    */
   attachRenderer(processor: RendererProcessor, config: RendererConfig): SurfaceStateSubscription {
     if (!config) {
@@ -583,7 +583,7 @@ export class PreviewBridge {
    * duplicate listeners and memory leaks during tab switching or hot-reloading.
    *
    * @param surfaceGroup The surface group or catalog renderer service model to connect.
-   * @returns A unified teardown handle exposing a single unsubscribe method to cleanly reclaim all child observers.
+   * @return A unified teardown handle exposing a single unsubscribe method to cleanly reclaim all child observers.
    */
   private connectSurfaceGroup(surfaceGroup: SurfaceGroupLike): {unsubscribe(): void} {
     const subscriptions = new Map<string, {unsubscribe(): void}>();

--- a/bridge/src/react/react-bridge.ts
+++ b/bridge/src/react/react-bridge.ts
@@ -45,7 +45,7 @@ export interface ReactSandboxOptions {
  *
  * @param catalogs The array of component catalogs matching A2UI specifications.
  * @param options Optional configuration payloads.
- * @returns A reactive state object containing the active surface drawing model.
+ * @return A reactive state object containing the active surface drawing model.
  */
 export function useA2uiSandbox<C extends ComponentApi = ComponentApi>(
   catalogs: Catalog<C>[],

--- a/bridge/src/render-config.ts
+++ b/bridge/src/render-config.ts
@@ -25,7 +25,7 @@ export declare interface DataModelObservable {
    *
    * @param path The nested object path to observe (empty string for the root model).
    * @param cb The callback executed with the updated data model value payload.
-   * @returns A subscription handle exposing an unsubscribe cleanup method.
+   * @return A subscription handle exposing an unsubscribe cleanup method.
    */
   subscribe(path: string, cb: (val: unknown) => void): {unsubscribe(): void};
 }
@@ -50,7 +50,7 @@ export declare interface SurfaceGroupLike {
      * Subscribes a callback to listen to new surface creation events.
      *
      * @param cb The callback executed with the newly created surface instance.
-     * @returns A subscription handle exposing an unsubscribe cleanup method.
+     * @return A subscription handle exposing an unsubscribe cleanup method.
      */
     subscribe(cb: (surface: SurfaceInstance) => void): {unsubscribe(): void};
   };

--- a/shell/src/app/chat/a2ui-payload-parser/a2ui-payload-parser.ts
+++ b/shell/src/app/chat/a2ui-payload-parser/a2ui-payload-parser.ts
@@ -30,7 +30,7 @@ export declare interface ParseResult {
  *
  * @param content Pre-cleaned JSON or JSON Lines string (e.g., stripped of pulse indicators,
  *                thinking tags, and markdown code fences via ChatCleaner.cleanPayload).
- * @returns ParseResult containing parsed payload blocks and whether syntax healing occurred.
+ * @return ParseResult containing parsed payload blocks and whether syntax healing occurred.
  * @throws Error if corrupted JSON Lines cannot be recovered or no valid blocks are parsed.
  */
 export function parseAndHealJsonLines(content?: string | null): ParseResult {

--- a/shell/src/app/chat/chat-coordinator/chat-coordinator.spec.ts
+++ b/shell/src/app/chat/chat-coordinator/chat-coordinator.spec.ts
@@ -301,7 +301,7 @@ describe('ChatCoordinator Pipeline & State Integration', () => {
 
     await service.submitPrompt('Create broken screen');
 
-    // Assert that the commited layout is fully healed and sanitized:
+    // Assert that the committed layout is fully healed and sanitized:
     // - Markdown stripped
     // - missing bracket appended to array
     // - trailing comma removed

--- a/shell/src/app/chat/file-ingestion/file-ingestion.service.ts
+++ b/shell/src/app/chat/file-ingestion/file-ingestion.service.ts
@@ -34,7 +34,7 @@ export class FileIngestionService {
    * Reads a given File object as an AttachedFile.
    *
    * @param file The file to read and attach.
-   * @returns A promise resolving to the AttachedFile containing the parsed contents.
+   * @return A promise resolving to the AttachedFile containing the parsed contents.
    */
   readFileAsAttachment(file: File): Promise<AttachedFile> {
     return new Promise((resolve, reject) => {

--- a/shell/src/app/chat/llm-client/llm-client.ts
+++ b/shell/src/app/chat/llm-client/llm-client.ts
@@ -144,7 +144,7 @@ export abstract class LlmClient {
    *
    * @param messages The accumulated sequence of messages representing the turn
    *   history.
-   * @returns A promise resolving to the final complete model response segment.
+   * @return A promise resolving to the final complete model response segment.
    */
   abstract chat(messages: LlmMessage[]): Promise<LlmResponse>;
 
@@ -154,7 +154,7 @@ export abstract class LlmClient {
    *
    * @param messages The accumulated sequence of messages representing the turn
    *   history.
-   * @returns A promise resolving to an active stream response boundary
+   * @return A promise resolving to an active stream response boundary
    *   interface.
    */
   abstract chatStream(messages: LlmMessage[]): Promise<LlmStreamResponse>;

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -121,7 +121,7 @@ export class Standalone3pLlmClient extends LlmClient {
    * configurations.
    *
    * @param messages The sequence of messages representing the turn history.
-   * @returns A promise resolving to the completed response content envelope.
+   * @return A promise resolving to the completed response content envelope.
    */
   override async chat(messages: LlmMessage[]): Promise<LlmResponse> {
     const stream = await this.chatStream(messages);

--- a/shell/src/app/gallery/schema/catalog-schema-resolver.ts
+++ b/shell/src/app/gallery/schema/catalog-schema-resolver.ts
@@ -50,7 +50,7 @@ export class CatalogSchemaResolver {
    * Resolves and parses all properties for the specified component from the catalog schema.
    *
    * @param componentName The name of the component to resolve.
-   * @returns An array of parsed property definitions.
+   * @return An array of parsed property definitions.
    */
   resolveComponentProperties(componentName: string): ParsedProperty[] {
     if (this.schema == null || typeof this.schema !== 'object') {
@@ -103,7 +103,7 @@ export class CatalogSchemaResolver {
    * Resolves and returns the fully resolved schemas for all properties of the specified component.
    *
    * @param componentName The name of the component.
-   * @returns A dictionary of property name to resolved schema.
+   * @return A dictionary of property name to resolved schema.
    */
   resolveComponentPropertiesSchema(componentName: string): Record<string, CatalogComponentSchema> {
     if (this.schema == null || typeof this.schema !== 'object') {
@@ -243,7 +243,7 @@ export class CatalogSchemaResolver {
    * @param propSchema The schema definition of the property to resolve.
    * @param rootSchema The root catalog schema containing definitions for references.
    * @param visitedRefs Set of references visited in the current path to detect and prevent circular resolution loops.
-   * @returns A fully resolved component schema with references inline and sub-schemas normalized.
+   * @return A fully resolved component schema with references inline and sub-schemas normalized.
    */
   private resolvePropertySchema(
     propSchema: CatalogComponentSchema | null | undefined,

--- a/shell/src/app/gallery/services/gallery-catalog.ts
+++ b/shell/src/app/gallery/services/gallery-catalog.ts
@@ -129,7 +129,7 @@ const CATEGORIES_ORDER = ['Layout', 'Content', 'Input', 'Feedback', 'Other'];
  * Resolves the visual category for a component using rule-based keyword mapping.
  *
  * @param key The component key.
- * @returns The category string (e.g. 'Layout', 'Content', 'Input', 'Feedback', 'Other').
+ * @return The category string (e.g. 'Layout', 'Content', 'Input', 'Feedback', 'Other').
  */
 function getCategoryForComponent(key: string): string {
   const lowerKey = key.toLowerCase();

--- a/shell/src/app/preview/raw/raw-frame.ts
+++ b/shell/src/app/preview/raw/raw-frame.ts
@@ -186,7 +186,7 @@ export class RawFrame {
    * If parsing fails, it throws a SyntaxError (which callers are expected to catch).
    *
    * @param value The raw layout string to parse.
-   * @returns An array of parsed JSON objects (or empty array if input is empty).
+   * @return An array of parsed JSON objects (or empty array if input is empty).
    */
   private parseLayoutString(value: string): unknown[] | null {
     const trimmed = value.trim();

--- a/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
+++ b/shell/src/app/settings/local-storage-config-provider/local-storage-config.provider.ts
@@ -284,7 +284,7 @@ export class LocalStorageAppConfigProvider extends AppConfigProvider {
   /**
    * Resolves the initial authentication mode override from storage.
    *
-   * @returns The initial authentication mode.
+   * @return The initial authentication mode.
    */
   private getInitialForcedAuth(): AuthType {
     if (!this.is1PAuthEnabled) {

--- a/shell/src/app/shared/monaco-editor/monaco-editor.ts
+++ b/shell/src/app/shared/monaco-editor/monaco-editor.ts
@@ -234,7 +234,7 @@ export class MonacoEditor {
    *
    * @param layoutSchema The dynamically generated schema representing the full A2UI layout
    *        structure, including the active catalog's components.
-   * @returns An array of schemas configured with URIs that match `$ref` references
+   * @return An array of schemas configured with URIs that match `$ref` references
    *          within the component schemas. We map local constants (like COMMON_TYPES_SCHEMA)
    *          to both `file:///` and HTTP URIs so the Monaco JSON worker can resolve them
    *          synchronously without needing an external schema request service.

--- a/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
+++ b/shell/src/app/shell/cross-frame-validator/cross-frame-validator.ts
@@ -38,7 +38,7 @@ export class CrossFrameValidator {
    *
    * @param message The outgoing message object to validate.
    * @param errors An optional array to collect validation error messages.
-   * @returns `true` if the message is valid, `false` otherwise.
+   * @return `true` if the message is valid, `false` otherwise.
    */
   static validateOutgoingMessage(message: unknown, errors?: string[]): boolean {
     if (!message || typeof message !== 'object' || Array.isArray(message)) {

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -85,7 +85,7 @@ export class HostCommunication implements OnDestroy {
 
   /**
    * Retrieves a snapshot copy of the recent message history buffer.
-   * @returns Array of stored message envelopes
+   * @return Array of stored message envelopes
    */
   getHistoryBuffer(): MessageEnvelope[] {
     return [...this.messageHistoryBuffer];
@@ -93,7 +93,7 @@ export class HostCommunication implements OnDestroy {
 
   /**
    * Retrieves the most recent catalog message envelope received from the preview frame.
-   * @returns Latest catalog envelope or null if none received
+   * @return Latest catalog envelope or null if none received
    */
   getLatestCatalog(): MessageEnvelope | null {
     return this.latestCatalogEnvelope;
@@ -292,7 +292,7 @@ export class HostCommunication implements OnDestroy {
 
   /**
    * Retrieves the currently registered iframe element, if any.
-   * @returns HTMLIFrameElement or null
+   * @return HTMLIFrameElement or null
    */
   getIframeElement(): HTMLIFrameElement | null {
     return this.iframeElement;

--- a/shell/src/app/shell/screenshot/screenshot-capture.service.ts
+++ b/shell/src/app/shell/screenshot/screenshot-capture.service.ts
@@ -34,7 +34,7 @@ export class ScreenshotCaptureService {
   /**
    * Captures a screenshot of the current tab, optionally restricted to a target element.
    * @param targetElement Optional DOM element to restrict the screenshot to.
-   * @returns A base64-encoded PNG image string.
+   * @return A base64-encoded PNG image string.
    */
   async captureScreenshot(targetElement: Element | null | undefined): Promise<string> {
     if (!targetElement || !targetElement.isConnected) {

--- a/shell/src/app/storage/local-storage-interactions/local-storage-interactions.ts
+++ b/shell/src/app/storage/local-storage-interactions/local-storage-interactions.ts
@@ -49,7 +49,7 @@ export class LocalStorageInteractions {
    * Retrieves an item from browser local storage securely.
    *
    * @param key The strongly-typed local storage key enum.
-   * @returns The associated string value, or null if storage is unavailable.
+   * @return The associated string value, or null if storage is unavailable.
    */
   getItem(key: LocalStorageKey): string | null {
     if (!this._isStorageAvailable) {

--- a/shell/src/app/storage/session-storage-interactions/session-storage-interactions.ts
+++ b/shell/src/app/storage/session-storage-interactions/session-storage-interactions.ts
@@ -39,7 +39,7 @@ export class SessionStorageInteractions {
   /**
    * Retrieves an item from the underlying sessionStorage.
    * @param key Stored item identifier
-   * @returns Stored string value or null if non-existent or inaccessible
+   * @return Stored string value or null if non-existent or inaccessible
    */
   getItem(key: string): string | null {
     if (!this.storage) return null;

--- a/shell/src/app/utils/date.utils.ts
+++ b/shell/src/app/utils/date.utils.ts
@@ -18,7 +18,7 @@
  * Formats an epoch timestamp (in milliseconds) into localized "HH:mm:ss.SSS" format.
  *
  * @param epoch The timestamp in milliseconds.
- * @returns Formatted localized timezone-safe time string.
+ * @return Formatted localized timezone-safe time string.
  */
 export function formatTimestamp(epoch: number): string {
   const date = new Date(epoch);

--- a/shell/src/app/utils/json.ts
+++ b/shell/src/app/utils/json.ts
@@ -19,7 +19,7 @@
  * Returns the parsed array if successful, or null if the string is not a valid JSON array.
  *
  * @param content The string content to parse.
- * @returns The parsed array, or null if parsing fails or the content is not an array.
+ * @return The parsed array, or null if parsing fails or the content is not an array.
  */
 export function tryParseJsonArray(content?: string | null): unknown[] | null {
   if (content == null) {
@@ -88,7 +88,7 @@ export function tryParseJsonArray(content?: string | null): unknown[] | null {
  * Formats the given value as a JSON string with 2-space indentation.
  *
  * @param value The value to format.
- * @returns The formatted JSON string.
+ * @return The formatted JSON string.
  */
 export function formatJson(value: unknown): string {
   return JSON.stringify(value, null, 2);

--- a/shell/src/app/utils/uuid.ts
+++ b/shell/src/app/utils/uuid.ts
@@ -21,7 +21,7 @@
  * falls back to `crypto.getRandomValues()` with RFC4122 v4 bit manipulation,
  * and falls back to a `Math.random()` pseudo-random generator in legacy or non-secure HTTP contexts.
  *
- * @returns An RFC4122 v4 UUID string.
+ * @return An RFC4122 v4 UUID string.
  */
 export function generateUuid(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') {


### PR DESCRIPTION
# Description

Replaces occurrences of 'commited' with 'committed' and '@returns' with '@return' to resolve identified typo and JSDoc issues.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

