### PR TITLE
fix(gallery): resolve canonical full URL references in catalog schema

### DIFF
--- a/shell/src/app/gallery/schema/catalog-schema-resolver.spec.ts
+++ b/shell/src/app/gallery/schema/catalog-schema-resolver.spec.ts
@@ -1204,4 +1204,35 @@ describe('CatalogSchemaResolver', () => {
     );
     consoleWarnSpy.mockRestore();
   });
+
+  it('resolves canonical full URL references to common_types.json', () => {
+    const mockSchema = {
+      components: {
+        Card: {
+          properties: {
+            child: {
+              $ref: 'https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId',
+            },
+            action: {
+              $ref: 'https://a2ui.org/specification/v0_9/common_types.json#/$defs/Action',
+            },
+          },
+        },
+      },
+    };
+    const resolver = new CatalogSchemaResolver(mockSchema);
+    const properties = resolver.resolveComponentProperties('Card');
+    expect(properties).toContainEqual({
+      name: 'child',
+      description: '',
+      type: 'string',
+      required: false,
+    });
+    expect(properties).toContainEqual({
+      name: 'action',
+      description: '',
+      type: 'object',
+      required: false,
+    });
+  });
 });

--- a/shell/src/app/gallery/schema/catalog-schema-resolver.ts
+++ b/shell/src/app/gallery/schema/catalog-schema-resolver.ts
@@ -492,7 +492,9 @@ export class CatalogSchemaResolver {
     }
 
     const isCommonTypes =
-      pointer === 'common_types.json' || pointer.startsWith('common_types.json#');
+      pointer === 'common_types.json' ||
+      pointer.startsWith('common_types.json#') ||
+      pointer.includes('/common_types.json#');
     if (isCommonTypes) {
       const localResolved = this.resolveJsonPointerBase(schema, relativePointer);
       if (localResolved !== undefined) {
@@ -501,7 +503,10 @@ export class CatalogSchemaResolver {
       return this.resolveJsonPointerBase(COMMON_TYPES_SCHEMA, relativePointer);
     }
 
-    const isCatalog = pointer === 'catalog.json' || pointer.startsWith('catalog.json#');
+    const isCatalog =
+      pointer === 'catalog.json' ||
+      pointer.startsWith('catalog.json#') ||
+      pointer.includes('/catalog.json#');
     if (isCatalog) {
       const localResolved = this.resolveJsonPointerBase(schema, relativePointer);
       if (localResolved !== undefined) {


### PR DESCRIPTION
## Summary

This PR addresses an issue where schema references (`$ref`) pointing to canonical full URLs (e.g., `https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId` or `https://a2ui.org/specification/v0_9/catalog.json#/$defs/...`) failed to resolve in `CatalogSchemaResolver.resolveJsonPointer`, causing property types in the Gallery to fall back to `'unknown'`.

### Root Cause
1. The `Type` column in the Gallery properties table is computed dynamically by `CatalogSchemaResolver` from the component JSON schema (the `properties` list in `basic_catalog_components_data.ts` only provides metadata like `name`, `description`, `required`, and `defaultValue`, without a `type` field).
2. Properties such as `Card.child`, `Button.action`, `Modal.trigger`/`content`, and `ChoicePicker.label` reference canonical common types using full URLs (e.g., `https://a2ui.org/specification/v0_9/common_types.json#/$defs/ComponentId`).
3. In `CatalogSchemaResolver.resolveJsonPointer`, `isCommonTypes` and `isCatalog` previously only checked local relative paths (`pointer === 'common_types.json' || pointer.startsWith('common_types.json#')`). Consequently, references using canonical full URLs starting with `https://...` failed to match, causing `getPropertyType()` to fall back to `'unknown'`.

### Fix
- Updated `resolveJsonPointer` in `CatalogSchemaResolver` to also match canonical full URLs containing `/common_types.json#` and `/catalog.json#`.
- Added unit tests in `catalog-schema-resolver.spec.ts` verifying that canonical full URL references to `common_types.json` resolve correctly to their respective types (`string`, `object`).

### Verification
- `corepack yarn --cwd shell vitest run src/app/gallery/schema/catalog-schema-resolver.spec.ts` (46/46 passed)
- `corepack yarn prettier:check`
- `corepack yarn tsc`