### PR TITLE
Move reusable code to LlmClient.

### DIFF
--- a/shell/src/app/chat/llm-client/llm-client.ts
+++ b/shell/src/app/chat/llm-client/llm-client.ts
@@ -208,6 +208,26 @@ export abstract class LlmClient {
   abstract chatStream(messages: LlmMessage[]): Promise<LlmStreamResponse>;
 
   /**
+   * Extracts and removes XML-like thought tags (`<thought>`, `<thinking>`,
+   * `<reasoning>`) from raw streaming text.
+   *
+   * @param accumulatedRawText The raw stream string containing potential thought
+   *     tags.
+   * @return An object containing the sanitized clean text and extracted thoughts.
+   */
+  protected extractXmlThoughts(accumulatedRawText: string): ExtractedXmlThoughts {
+    let totalExtractedThinking = '';
+    const cleanText = accumulatedRawText.replace(
+      /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi,
+      (_, _tag, innerText) => {
+        totalExtractedThinking += innerText;
+        return '';
+      },
+    );
+    return {cleanText, totalExtractedThinking};
+  }
+
+  /**
    * Creates an asynchronous iterable stream from a buffered queue of responses.
    *
    * Resolves new chunks as they are pushed to the buffer, yields them in order,
@@ -221,7 +241,7 @@ export abstract class LlmClient {
    * updates occur.
    * @return An asynchronous iterable stream yielding `LlmResponse` objects.
    */
-  createContentStream(
+  protected createContentStream(
     buffer: LlmResponse[],
     state: StreamProcessingState,
     listeners: Array<() => void>,
@@ -264,24 +284,4 @@ export abstract class LlmClient {
       },
     };
   }
-}
-
-/**
- * Extracts and removes XML-like thought tags (`<thought>`, `<thinking>`,
- * `<reasoning>`) from raw streaming text.
- *
- * @param accumulatedRawText The raw stream string containing potential thought
- *     tags.
- * @return An object containing the sanitized clean text and extracted thoughts.
- */
-export function extractXmlThoughts(accumulatedRawText: string): ExtractedXmlThoughts {
-  let totalExtractedThinking = '';
-  const cleanText = accumulatedRawText.replace(
-    /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi,
-    (_, _tag, innerText) => {
-      totalExtractedThinking += innerText;
-      return '';
-    },
-  );
-  return {cleanText, totalExtractedThinking};
 }

--- a/shell/src/app/chat/llm-client/llm-client.ts
+++ b/shell/src/app/chat/llm-client/llm-client.ts
@@ -131,6 +131,44 @@ export interface LlmStreamResponse {
 }
 
 /**
+ * Default token budget allocated for model reasoning and thought process
+ * generation.
+ */
+export const THINKING_BUDGET = 1024;
+
+/**
+ * Tracks mutable accumulation state and lifecycle status during response stream
+ * processing.
+ */
+export interface StreamProcessingState {
+  /** Filtered text content accumulated so far, excluding XML thought tags. */
+  accumulatedText: string;
+  /**
+   * Full raw text stream received from the backend, including embedded tags.
+   */
+  accumulatedRawText: string;
+  /** Character length of content already yielded downstream. */
+  emittedContentLength: number;
+  /** Character length of thinking text already yielded downstream. */
+  emittedThinkingLength: number;
+  /** Indicates whether the underlying stream completed successfully. */
+  isDone: boolean;
+  /** Holds any error encountered during stream transmission. */
+  streamError: unknown;
+}
+
+/**
+ * Holds extracted model thinking alongside the cleaned conversational text
+ * payload.
+ */
+export interface ExtractedXmlThoughts {
+  /** The sanitized text content with XML thought tags removed. */
+  readonly cleanText: string;
+  /** The accumulated reasoning text extracted from within thought tags. */
+  readonly totalExtractedThinking: string;
+}
+
+/**
  * Facade contract token representing boundary client capability endpoints.
  * Serves as the dynamic Angular DI injection boundary token mapping
  * conversational facades. Decouples the visual shell package from physical
@@ -146,7 +184,17 @@ export abstract class LlmClient {
    *   history.
    * @return A promise resolving to the final complete model response segment.
    */
-  abstract chat(messages: LlmMessage[]): Promise<LlmResponse>;
+  async chat(messages: LlmMessage[]): Promise<LlmResponse> {
+    const stream = await this.chatStream(messages);
+    const content = await stream.complete;
+    // We don't get the combined thinking easily back from stream.complete
+    // unless we change complete type, but chat is rarely used directly for full
+    // text. We can just return content.
+    return {
+      content,
+      isComplete: true,
+    };
+  }
 
   /**
    * Dispatches conversational turns in-stream, providing chunked generative
@@ -158,4 +206,82 @@ export abstract class LlmClient {
    *   interface.
    */
   abstract chatStream(messages: LlmMessage[]): Promise<LlmStreamResponse>;
+
+  /**
+   * Creates an asynchronous iterable stream from a buffered queue of responses.
+   *
+   * Resolves new chunks as they are pushed to the buffer, yields them in order,
+   * and handles termination or error conditions signaled by the shared state.
+   *
+   * @param buffer The FIFO queue of accumulated LLM responses awaiting
+   * consumption.
+   * @param state The shared state monitoring completion and error status.
+   * @param listeners An array of callback listeners notified when buffer or
+   *     state
+   * updates occur.
+   * @return An asynchronous iterable stream yielding `LlmResponse` objects.
+   */
+  createContentStream(
+    buffer: LlmResponse[],
+    state: StreamProcessingState,
+    listeners: Array<() => void>,
+  ): AsyncIterable<LlmResponse> {
+    return {
+      [Symbol.asyncIterator](): AsyncIterator<LlmResponse> {
+        let localBufferIndex = 0;
+        return {
+          async next(): Promise<IteratorResult<LlmResponse>> {
+            // Wait in-loop while buffer is exhausted and stream is
+            // active/errored
+            while (localBufferIndex >= buffer.length && !state.isDone && !state.streamError) {
+              await new Promise<void>((resolve, reject) => {
+                listeners.push(() => {
+                  if (state.streamError) {
+                    reject(state.streamError);
+                  } else {
+                    resolve();
+                  }
+                });
+              });
+            }
+
+            // Throw connection exceptions immediately upon exhausting
+            // successful yields
+            if (localBufferIndex >= buffer.length && state.streamError) {
+              throw state.streamError;
+            }
+
+            // Yield buffered chunks
+            if (localBufferIndex < buffer.length) {
+              const value = buffer[localBufferIndex];
+              localBufferIndex++;
+              return {value, done: false};
+            }
+
+            return {value: undefined, done: true};
+          },
+        };
+      },
+    };
+  }
+}
+
+/**
+ * Extracts and removes XML-like thought tags (`<thought>`, `<thinking>`,
+ * `<reasoning>`) from raw streaming text.
+ *
+ * @param accumulatedRawText The raw stream string containing potential thought
+ *     tags.
+ * @return An object containing the sanitized clean text and extracted thoughts.
+ */
+export function extractXmlThoughts(accumulatedRawText: string): ExtractedXmlThoughts {
+  let totalExtractedThinking = '';
+  const cleanText = accumulatedRawText.replace(
+    /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi,
+    (_, _tag, innerText) => {
+      totalExtractedThinking += innerText;
+      return '';
+    },
+  );
+  return {cleanText, totalExtractedThinking};
 }

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -16,12 +16,15 @@
 
 import {Injectable, inject} from '@angular/core';
 import {
+  extractXmlThoughts,
   LlmClient,
   LlmMessage,
   LlmResponse,
   LlmStreamResponse,
   MessageRole,
   CANCEL_ERROR_NAME,
+  StreamProcessingState,
+  THINKING_BUDGET,
 } from './llm-client';
 import {AppConfigProvider} from '../../settings/app-config-provider/app-config-provider';
 import {
@@ -32,17 +35,6 @@ import {
   GenerateContentConfig,
   GenerateContentResponse,
 } from '@google/genai';
-
-const TAG_REGEX = /<(thought|thinking|reasoning)>([\s\S]*?)(?:<\/\1>|$)/gi;
-
-interface StreamProcessingState {
-  accumulatedText: string;
-  accumulatedRawText: string;
-  emittedContentLength: number;
-  emittedThinkingLength: number;
-  isDone: boolean;
-  streamError: unknown;
-}
 
 /**
  * Standard public endpoint authentication client utilizing user developer keys.
@@ -113,25 +105,6 @@ export class Standalone3pLlmClient extends LlmClient {
     }
 
     return {systemInstruction, contents};
-  }
-
-  /**
-   * Generates a static conversational response for the provided chat history.
-   * Dynamically constructs the GoogleGenAI network target matching active
-   * configurations.
-   *
-   * @param messages The sequence of messages representing the turn history.
-   * @return A promise resolving to the completed response content envelope.
-   */
-  override async chat(messages: LlmMessage[]): Promise<LlmResponse> {
-    const stream = await this.chatStream(messages);
-    const content = await stream.complete;
-    // We don't get the combined thinking easily back from stream.complete unless we change complete type,
-    // but chat is rarely used directly for full text. We can just return content.
-    return {
-      content,
-      isComplete: true,
-    };
   }
 
   /**
@@ -211,7 +184,7 @@ export class Standalone3pLlmClient extends LlmClient {
     }
     config.thinkingConfig = {
       includeThoughts: true,
-      thinkingBudget: 1024,
+      thinkingBudget: THINKING_BUDGET,
     };
     return config;
   }
@@ -254,19 +227,6 @@ export class Standalone3pLlmClient extends LlmClient {
     return {chunkContent, nativeThoughtVal};
   }
 
-  private extractXmlThoughts(accumulatedRawText: string): {
-    cleanText: string;
-    totalExtractedThinking: string;
-  } {
-    let totalExtractedThinking = '';
-    TAG_REGEX.lastIndex = 0;
-    const cleanText = accumulatedRawText.replace(TAG_REGEX, (_, _tag, innerText) => {
-      totalExtractedThinking += innerText;
-      return '';
-    });
-    return {cleanText, totalExtractedThinking};
-  }
-
   private async consumeStream(
     responseStream: AsyncIterable<GenerateContentResponse>,
     state: StreamProcessingState,
@@ -281,9 +241,7 @@ export class Standalone3pLlmClient extends LlmClient {
 
         state.accumulatedRawText += chunkContent;
 
-        const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(
-          state.accumulatedRawText,
-        );
+        const {cleanText, totalExtractedThinking} = extractXmlThoughts(state.accumulatedRawText);
 
         const contentVal = cleanText.slice(state.emittedContentLength);
         const tagThought = totalExtractedThinking.slice(state.emittedThinkingLength);
@@ -322,47 +280,5 @@ export class Standalone3pLlmClient extends LlmClient {
       rejectComplete(finalErr);
       notify();
     }
-  }
-
-  private createContentStream(
-    buffer: LlmResponse[],
-    state: StreamProcessingState,
-    listeners: (() => void)[],
-  ): AsyncIterable<LlmResponse> {
-    return {
-      [Symbol.asyncIterator]() {
-        let localBufferIndex = 0;
-        return {
-          async next(): Promise<IteratorResult<LlmResponse>> {
-            // Wait in-loop while buffer is exhausted and stream is active/errored
-            while (localBufferIndex >= buffer.length && !state.isDone && !state.streamError) {
-              await new Promise<void>((resolve, reject) => {
-                listeners.push(() => {
-                  if (state.streamError) {
-                    reject(state.streamError);
-                  } else {
-                    resolve();
-                  }
-                });
-              });
-            }
-
-            // Throw connection exceptions immediately upon exhausting successful yields
-            if (localBufferIndex >= buffer.length && state.streamError) {
-              throw state.streamError;
-            }
-
-            // Yield buffered chunks
-            if (localBufferIndex < buffer.length) {
-              const value = buffer[localBufferIndex];
-              localBufferIndex++;
-              return {value, done: false};
-            }
-
-            return {value: undefined, done: true};
-          },
-        };
-      },
-    };
   }
 }

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -240,7 +240,9 @@ export class Standalone3pLlmClient extends LlmClient {
 
         state.accumulatedRawText += chunkContent;
 
-        const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(state.accumulatedRawText);
+        const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(
+          state.accumulatedRawText,
+        );
 
         const contentVal = cleanText.slice(state.emittedContentLength);
         const tagThought = totalExtractedThinking.slice(state.emittedThinkingLength);

--- a/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
+++ b/shell/src/app/chat/llm-client/standalone-3p-llm-client.ts
@@ -16,7 +16,6 @@
 
 import {Injectable, inject} from '@angular/core';
 import {
-  extractXmlThoughts,
   LlmClient,
   LlmMessage,
   LlmResponse,
@@ -241,7 +240,7 @@ export class Standalone3pLlmClient extends LlmClient {
 
         state.accumulatedRawText += chunkContent;
 
-        const {cleanText, totalExtractedThinking} = extractXmlThoughts(state.accumulatedRawText);
+        const {cleanText, totalExtractedThinking} = this.extractXmlThoughts(state.accumulatedRawText);
 
         const contentVal = cleanText.slice(state.emittedContentLength);
         const tagThought = totalExtractedThinking.slice(state.emittedThinkingLength);


### PR DESCRIPTION
# Description

- Add default `chat` implementation that calls `chatStream`.
- Move `extractXmlThoughts` and `createContentStream` and associated interfaces.
- Add default `THINKING_BUDGET` constant.

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [x] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [x] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
