### PR TITLE
Fix a11y issues on settings page

### DIFF
--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -91,8 +91,8 @@
 
   <mat-card class="status-card">
     <mat-card-header>
-      <mat-card-title>Connection Status & Diagnostics</mat-card-title>
-      <mat-card-subtitle>Real-time monitoring bridge</mat-card-subtitle>
+      <h2 mat-card-title>Connection Status & Diagnostics</h2>
+      <h3 mat-card-subtitle>Real-time monitoring bridge</h3>
     </mat-card-header>
     <mat-card-content>
       <div class="status-badges">

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -125,11 +125,9 @@
             <code>[System] Active renderer updated to {{ activeRendererUrl() }}</code>
           }
           @if (catalogErrorMessage()) {
-            <code class="error-log" style="color: #f44336; font-weight: bold"
-              >[Catalog Error] {{ catalogErrorMessage() }}</code
-            >
+            <code class="error-log">[Catalog Error] {{ catalogErrorMessage() }}</code>
           } @else if (catalogStatus() === 'Connected') {
-            <code class="success-log" style="color: #188038"
+            <code class="success-log"
               >[System] Catalog handshake completed successfully. Active catalog ready.</code
             >
           } @else if (catalogStatus() === 'Indexing') {

--- a/shell/src/app/settings/settings-view/settings.ng.html
+++ b/shell/src/app/settings/settings-view/settings.ng.html
@@ -17,7 +17,7 @@
 <div class="settings-container">
   <mat-card class="settings-card">
     <mat-card-header>
-      <mat-card-title>A2UI Composer Settings</mat-card-title>
+      <h2 mat-card-title>A2UI Composer Settings</h2>
     </mat-card-header>
     <mat-card-content>
       <form [formGroup]="settingsForm">
@@ -129,7 +129,7 @@
               >[Catalog Error] {{ catalogErrorMessage() }}</code
             >
           } @else if (catalogStatus() === 'Connected') {
-            <code class="success-log" style="color: #4caf50"
+            <code class="success-log" style="color: #188038"
               >[System] Catalog handshake completed successfully. Active catalog ready.</code
             >
           } @else if (catalogStatus() === 'Indexing') {

--- a/shell/src/app/settings/settings-view/settings.scss
+++ b/shell/src/app/settings/settings-view/settings.scss
@@ -95,6 +95,15 @@ mat-form-field {
   }
 }
 
+.error-log {
+  color: var(--mat-sys-error);
+  font-weight: bold;
+}
+
+.success-log {
+  color: var(--mat-sys-tertiary);
+}
+
 ::ng-deep body .mat-mdc-slide-toggle {
   .mat-internal-form-field,
   .mdc-form-field {


### PR DESCRIPTION
# Description

- Change `mat-card-title` to `h2` so that `h2` is not skipped in the heading order.
- Darken success log color so that contrast is now 6.44:1 ([WCAG requires 4.5:1](https://www.w3.org/TR/WCAG21/#contrast-minimum))

## Pre-launch Checklist

- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [ ] My code changes (if any) have tests.
- [x] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

If you need help, consider asking for advice on the [discussion board].

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
