### PR TITLE
Improve A2UI chat streaming, surface recreation, and thinking UI

### DIFF
--- a/bridge/src/preview-bridge.spec.ts
+++ b/bridge/src/preview-bridge.spec.ts
@@ -1193,11 +1193,18 @@ describe('PreviewBridge Core API Runtime', () => {
       ]);
       expect(onSurfaceClearedSpy).toHaveBeenCalledTimes(1);
 
-      // Step 2: Advance timer tick to trigger deferred render payload
+      // Step 2: Advance timer tick to trigger deferred render payload. The incoming
+      // surface is pre-deleted first so a recreate cannot collide with a stale instance.
       vi.advanceTimersByTime(0);
 
-      expect(processMessagesSpy).toHaveBeenCalledTimes(2);
-      expect(processMessagesSpy).toHaveBeenNthCalledWith(2, payload as A2uiMessage[]);
+      expect(processMessagesSpy).toHaveBeenCalledTimes(3);
+      expect(processMessagesSpy).toHaveBeenNthCalledWith(2, [
+        {
+          version: 'v0.9',
+          deleteSurface: {surfaceId: 'sample-surface'},
+        } as A2uiMessage,
+      ]);
+      expect(processMessagesSpy).toHaveBeenNthCalledWith(3, payload as A2uiMessage[]);
 
       conn.unsubscribe();
       vi.useRealTimers();
@@ -1404,11 +1411,15 @@ describe('PreviewBridge Core API Runtime', () => {
 
       vi.runAllTimers();
 
-      // Ensure second payload is processed after clearing first
+      // Ensure second payload is processed after clearing first. Only the surviving
+      // payload runs, preceded by its defensive pre-delete dispatch.
       expect(processSpy).toHaveBeenLastCalledWith([
         {version: 'v0.9', createSurface: {surfaceId: 'surf-2'}},
       ]);
-      expect(processSpy).toHaveBeenCalledTimes(1);
+      expect(processSpy).toHaveBeenCalledTimes(2);
+      expect(processSpy).toHaveBeenNthCalledWith(1, [
+        {version: 'v0.9', deleteSurface: {surfaceId: 'surf-2'}} as A2uiMessage,
+      ]);
 
       conn.unsubscribe();
       vi.useRealTimers();

--- a/bridge/src/preview-bridge.ts
+++ b/bridge/src/preview-bridge.ts
@@ -542,6 +542,22 @@ export class PreviewBridge {
         }
         surfaceId = createSurface.surfaceId;
         if (surfaceId) {
+          // Proactively clear any pre-existing instance of this surface in the
+          // renderer processor to prevent "Surface <surfaceId> already exists"
+          // collisions upon recreate.
+          const deleteMessage: A2uiMessage = {
+            version: 'v0.9',
+            deleteSurface: {
+              surfaceId,
+            },
+          };
+          try {
+            this.activeRenderer.processor.processMessages([deleteMessage]);
+          } catch (err) {
+            // Surface might not exist yet; safe to proceed. Logged so genuine
+            // processor failures remain diagnosable.
+            console.debug('PreviewBridge: pre-delete of surface failed', surfaceId, err);
+          }
           // Track the surface BEFORE processing. If a subsequent command in
           // the payload has a typo and throws an error, we still want to
           // clean this surface up next time.

--- a/shell/src/app/agent-chat/a2a-chat-view.spec.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.spec.ts
@@ -672,10 +672,11 @@ describe('A2aChatView', () => {
         parts: expect.arrayContaining([
           {text: 'Action: select_demo'},
           expect.objectContaining({
-            data: expect.objectContaining({
+            // The v0.9 schema permits exactly `version` and `action`.
+            data: {
+              version: 'v0.9',
               action: actionPayload,
-              userAction: actionPayload,
-            }),
+            },
             metadata: {
               mimeType: 'application/a2ui+json',
               type: 'a2ui_action',

--- a/shell/src/app/agent-chat/a2a-chat-view.spec.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.spec.ts
@@ -677,6 +677,7 @@ describe('A2aChatView', () => {
               userAction: actionPayload,
             }),
             metadata: {
+              mimeType: 'application/a2ui+json',
               type: 'a2ui_action',
             },
           }),

--- a/shell/src/app/agent-chat/a2a-chat-view.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.ts
@@ -14,26 +14,30 @@
  * limitations under the License.
  */
 
-import {Component, DestroyRef, OnInit, effect, inject, signal, untracked} from '@angular/core';
+import {Component, DestroyRef, effect, inject, OnInit, signal, untracked} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {PreviewBridgeMessageType, RenderA2uiItem} from 'a2ui-bridge';
+
 import {A2A_TRANSPORT} from '../chat/a2a/a2a-transport.token';
 import {A2aMessage, AgentCard, TaskStatusUpdateEvent} from '../chat/a2a/a2a-types';
 import {RenderedFrame} from '../preview/rendered/rendered-frame';
-import {HostCommunication} from '../shell/host-communication/host-communication';
 import {
-  AppConfigProvider,
   A2aBackendMode,
+  AppConfigProvider,
 } from '../settings/app-config-provider/app-config-provider';
-import {generateUuid as uuid} from '../utils/uuid';
+import {HostCommunication} from '../shell/host-communication/host-communication';
 import {isValidEndpointUrl, normalizeHttpUrl} from '../utils/url';
+import {generateUuid as uuid} from '../utils/uuid';
+
 import {AgentConfigPanel, AgentConfigSaveEvent} from './agent-config-panel/agent-config-panel';
 import {A2aAgentHeader} from './agent-header/agent-header';
+import {UiAgentInfo} from './agent-header/types';
 import {A2aChatHistory} from './chat-history/chat-history';
+import {CanvasArtifact, UiMessage} from './chat-message/types';
 import {
   a2aCardToUiAgentInfo,
   createErrorEvent,
@@ -41,9 +45,7 @@ import {
   createSentMessageEvent,
   parseA2aStreamEvent,
 } from './converters/a2a-ui-converter';
-import {partitionA2uiSurfacePayload} from './converters/surface-partitioner';
-import {UiAgentInfo} from './agent-header/types';
-import {CanvasArtifact, UiMessage} from './chat-message/types';
+import {mergeA2uiItems, partitionA2uiSurfacePayload} from './converters/surface-partitioner';
 import {A2aInputArea, SendMessageEvent} from './input-area/input-area';
 import {A2aMessageInspector} from './message-inspector/message-inspector';
 import {MessageInspectorEvent} from './message-inspector/message-inspector-event';
@@ -174,8 +176,9 @@ export class A2aChatView implements OnInit {
     this.connectionError.set(null);
 
     try {
-      // Configure backend mode and tenant ID prior to fetching the agent card so
-      // that the delegating transport routes the discovery request to the selected transport.
+      // Configure backend mode and tenant ID prior to fetching the agent card
+      // so that the delegating transport routes the discovery request to the
+      // selected transport.
       if (backendMode) {
         this.configProvider.setA2aBackendMode(backendMode);
       }
@@ -225,8 +228,7 @@ export class A2aChatView implements OnInit {
 
     const userMessageId = uuid();
     const agentMessageId = uuid();
-    const contextId = this.activeContextId() || uuid();
-    this.activeContextId.set(contextId);
+    const contextId = this.activeContextId() ?? undefined;
 
     const userUiMessage: UiMessage = {
       id: userMessageId,
@@ -247,7 +249,7 @@ export class A2aChatView implements OnInit {
   private buildOutgoingA2aMessage(
     text: string,
     images: SendMessageEvent['images'],
-    contextId: string,
+    contextId?: string,
   ): A2aMessage {
     const parts: A2aMessage['parts'] = [];
     if (text) {
@@ -270,7 +272,7 @@ export class A2aChatView implements OnInit {
     return {
       role: 'user',
       parts,
-      contextId,
+      ...(contextId ? {contextId} : {}),
     };
   }
 
@@ -307,17 +309,22 @@ export class A2aChatView implements OnInit {
     let actionData: Record<string, unknown>;
     if (typeof action === 'object' && action !== null && !Array.isArray(action)) {
       const obj = action as Record<string, unknown>;
-      if ('userAction' in obj) {
-        actionData = {...obj, ['action']: obj['userAction']};
-      } else {
-        actionData = {...obj, ['userAction']: obj, ['action']: obj};
-      }
+      const innerAction = obj['action'] ?? obj['userAction'] ?? obj;
+      actionData = {
+        version: 'v0.9',
+        action: innerAction,
+        userAction: innerAction,
+        ...obj,
+      };
     } else {
-      actionData = {['userAction']: action, ['action']: action};
+      actionData = {
+        version: 'v0.9',
+        action,
+        userAction: action,
+      };
     }
 
-    const contextId = this.activeContextId() || uuid();
-    this.activeContextId.set(contextId);
+    const contextId = this.activeContextId() ?? undefined;
 
     let actionText = 'User action triggered.';
     if (typeof action === 'object' && action !== null) {
@@ -344,11 +351,12 @@ export class A2aChatView implements OnInit {
         {
           data: actionData,
           metadata: {
+            mimeType: 'application/a2ui+json',
             type: 'a2ui_action',
           },
         },
       ],
-      contextId,
+      ...(contextId ? {contextId} : {}),
     };
 
     this.recordInspectorEvent(createSentMessageEvent(a2aMsg));
@@ -520,12 +528,34 @@ export class A2aChatView implements OnInit {
           }
         }
 
-        const updatedThinking = parsed.thoughtChunk
-          ? (m.thinking || '') + parsed.thoughtChunk
-          : m.thinking;
+        let updatedThinking = m.thinking;
+        if (parsed.thoughtChunk) {
+          const chunk = parsed.thoughtChunk;
+          if (!m.thinking) {
+            updatedThinking = chunk;
+          } else if (chunk === m.thinking) {
+            updatedThinking = m.thinking;
+          } else if (chunk.startsWith(m.thinking)) {
+            updatedThinking = chunk;
+          } else {
+            const lastDoubleNewline = m.thinking.lastIndexOf('\n\n');
+            const lastStep =
+              lastDoubleNewline >= 0 ? m.thinking.substring(lastDoubleNewline + 2) : m.thinking;
+            if (lastStep && chunk.startsWith(lastStep)) {
+              const prefix = m.thinking.substring(
+                0,
+                lastDoubleNewline >= 0 ? lastDoubleNewline + 2 : 0,
+              );
+              updatedThinking = prefix + chunk;
+            } else if (!m.thinking.includes(chunk.trim())) {
+              const separator = m.thinking.endsWith('\n') ? '\n' : '\n\n';
+              updatedThinking = `${m.thinking}${separator}${chunk}`;
+            }
+          }
+        }
         const updatedPayload =
           parsed.a2uiItems.length > 0
-            ? [...(m.a2uiPayload || []), ...parsed.a2uiItems]
+            ? mergeA2uiItems(m.a2uiPayload || [], parsed.a2uiItems)
             : m.a2uiPayload;
         const updatedToolCalls =
           parsed.toolCalls && parsed.toolCalls.length > 0

--- a/shell/src/app/agent-chat/a2a-chat-view.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.ts
@@ -228,6 +228,11 @@ export class A2aChatView implements OnInit {
 
     const userMessageId = uuid();
     const agentMessageId = uuid();
+    // Context IDs are owned by the agent, not the client. The first turn is sent
+    // without one so the server can mint it; subsequent turns replay the ID
+    // adopted from the stream in handleStreamEvent. Minting one here instead
+    // would pin the conversation to an ID the agent never issued, so it would
+    // treat each turn as an unknown context and drop prior history.
     const contextId = this.activeContextId() ?? undefined;
 
     const userUiMessage: UiMessage = {

--- a/shell/src/app/agent-chat/a2a-chat-view.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.ts
@@ -45,10 +45,23 @@ import {
   createSentMessageEvent,
   parseA2aStreamEvent,
 } from './converters/a2a-ui-converter';
-import {mergeA2uiItems, partitionA2uiSurfacePayload} from './converters/surface-partitioner';
+import {
+  A2UI_MIME_TYPE,
+  A2UI_PROTOCOL_VERSION,
+  mergeA2uiItems,
+  partitionA2uiSurfacePayload,
+} from './converters/surface-partitioner';
 import {A2aInputArea, SendMessageEvent} from './input-area/input-area';
 import {A2aMessageInspector} from './message-inspector/message-inspector';
 import {MessageInspectorEvent} from './message-inspector/message-inspector-event';
+
+/**
+ * Blank line delimiting one reasoning step from the next within a message's thinking text.
+ *
+ * Agents do not tag step boundaries, so this is the only signal available for distinguishing a
+ * rewrite of the current step from the start of a new one.
+ */
+const THOUGHT_STEP_SEPARATOR = '\n\n';
 
 /**
  * Top-level view container managing end-to-end Agent-to-Agent (A2A) testing,
@@ -89,8 +102,13 @@ export class A2aChatView implements OnInit {
   protected readonly inspectorEvents = signal<MessageInspectorEvent[]>([]);
   /** Current active task ID from the agent server. */
   protected readonly activeTaskId = signal<string | null>(null);
-  /** Current active conversation context / session ID. */
-  protected readonly activeContextId = signal<string | null>(null);
+  /**
+   * Conversation context / session ID assigned by the agent.
+   *
+   * Undefined until the agent issues one on its first response, which is also the value sent on
+   * the wire to request a new context.
+   */
+  protected readonly activeContextId = signal<string | undefined>(undefined);
 
   /** Whether a connection handshake is currently in progress. */
   protected readonly isConnecting = signal<boolean>(false);
@@ -215,7 +233,7 @@ export class A2aChatView implements OnInit {
     this.messages.set([]);
     this.inspectorEvents.set([]);
     this.activeTaskId.set(null);
-    this.activeContextId.set(null);
+    this.activeContextId.set(undefined);
     this.activeCanvasPayload.set(null);
     this.isCanvasOpen.set(false);
   }
@@ -233,7 +251,7 @@ export class A2aChatView implements OnInit {
     // adopted from the stream in handleStreamEvent. Minting one here instead
     // would pin the conversation to an ID the agent never issued, so it would
     // treat each turn as an unknown context and drop prior history.
-    const contextId = this.activeContextId() ?? undefined;
+    const contextId = this.activeContextId();
 
     const userUiMessage: UiMessage = {
       id: userMessageId,
@@ -311,30 +329,20 @@ export class A2aChatView implements OnInit {
       this.cancelActiveGeneration();
     }
 
-    let actionData: Record<string, unknown>;
-    if (typeof action === 'object' && action !== null && !Array.isArray(action)) {
-      const obj = action as Record<string, unknown>;
-      const innerAction = obj['action'] ?? obj['userAction'] ?? obj;
-      actionData = {
-        version: 'v0.9',
-        action: innerAction,
-        userAction: innerAction,
-        ...obj,
-      };
-    } else {
-      actionData = {
-        version: 'v0.9',
-        action,
-        userAction: action,
-      };
-    }
+    // The v0.9 client-to-server schema accepts exactly two properties, `version` and `action`.
+    // `userAction` is the superseded v0.8 spelling and any extra key makes the payload invalid,
+    // so the action is forwarded verbatim under a minimal envelope.
+    const actionData: Record<string, unknown> = {
+      version: A2UI_PROTOCOL_VERSION,
+      action,
+    };
 
-    const contextId = this.activeContextId() ?? undefined;
+    const contextId = this.activeContextId();
 
     let actionText = 'User action triggered.';
     if (typeof action === 'object' && action !== null) {
       const obj = action as Record<string, unknown>;
-      const eventObj = (obj['event'] || obj['userAction'] || obj) as Record<string, unknown>;
+      const eventObj = (obj['event'] || obj) as Record<string, unknown>;
       if (typeof eventObj['name'] === 'string' && eventObj['name']) {
         actionText = `Action: ${eventObj['name']}`;
       } else if (typeof obj['name'] === 'string' && obj['name']) {
@@ -356,7 +364,7 @@ export class A2aChatView implements OnInit {
         {
           data: actionData,
           metadata: {
-            mimeType: 'application/a2ui+json',
+            mimeType: A2UI_MIME_TYPE,
             type: 'a2ui_action',
           },
         },
@@ -506,6 +514,56 @@ export class A2aChatView implements OnInit {
     );
   }
 
+  /**
+   * Accumulates a streamed text chunk onto the text received so far.
+   *
+   * Agents differ in what each chunk contains: some send only the delta, others resend the whole
+   * response every time. A chunk that repeats or extends what we already have therefore replaces
+   * it, and anything else is appended.
+   */
+  private appendStreamedText(existing: string | undefined, chunk: string): string {
+    if (!existing) return chunk;
+    if (chunk === existing || chunk.startsWith(existing)) return chunk;
+    return existing + chunk;
+  }
+
+  /**
+   * Accumulates a streamed thought chunk onto the reasoning received so far.
+   *
+   * Thought streams are noisier than text: agents commonly resend the current reasoning step in
+   * full on every event while occasionally emitting a brand new step. Reasoning steps are
+   * separated by a blank line, which is the only structure available to tell those two cases
+   * apart, so the last blank line marks where the in-progress step begins:
+   *
+   * - A chunk extending the whole accumulated text supersedes it (cumulative stream).
+   * - A chunk extending only the final step rewrites that step, preserving earlier ones.
+   * - Otherwise the chunk is a new step and is appended after a blank line, unless it is text we
+   *   have already recorded.
+   */
+  private appendStreamedThought(existing: string | undefined, chunk: string): string {
+    if (!existing) return chunk;
+    if (chunk === existing || chunk.startsWith(existing)) return chunk;
+
+    const lastStepStart = existing.lastIndexOf(THOUGHT_STEP_SEPARATOR);
+    const hasEarlierSteps = lastStepStart >= 0;
+    const lastStep = hasEarlierSteps
+      ? existing.substring(lastStepStart + THOUGHT_STEP_SEPARATOR.length)
+      : existing;
+
+    if (lastStep && chunk.startsWith(lastStep)) {
+      const completedSteps = hasEarlierSteps
+        ? existing.substring(0, lastStepStart + THOUGHT_STEP_SEPARATOR.length)
+        : '';
+      return completedSteps + chunk;
+    }
+
+    if (existing.includes(chunk.trim())) return existing;
+
+    // Avoid a triple newline when the accumulated text already ends in one.
+    const separator = existing.endsWith('\n') ? '\n' : THOUGHT_STEP_SEPARATOR;
+    return `${existing}${separator}${chunk}`;
+  }
+
   private handleStreamEvent(event: TaskStatusUpdateEvent, agentMessageId: string): void {
     const parsed = parseA2aStreamEvent(event);
 
@@ -520,44 +578,12 @@ export class A2aChatView implements OnInit {
       msgs.map(m => {
         if (m.id !== agentMessageId) return m;
 
-        let updatedText = m.text;
-        if (parsed.textChunk) {
-          if (!m.text) {
-            updatedText = parsed.textChunk;
-          } else if (parsed.textChunk === m.text) {
-            updatedText = m.text;
-          } else if (parsed.textChunk.startsWith(m.text)) {
-            updatedText = parsed.textChunk;
-          } else {
-            updatedText = m.text + parsed.textChunk;
-          }
-        }
-
-        let updatedThinking = m.thinking;
-        if (parsed.thoughtChunk) {
-          const chunk = parsed.thoughtChunk;
-          if (!m.thinking) {
-            updatedThinking = chunk;
-          } else if (chunk === m.thinking) {
-            updatedThinking = m.thinking;
-          } else if (chunk.startsWith(m.thinking)) {
-            updatedThinking = chunk;
-          } else {
-            const lastDoubleNewline = m.thinking.lastIndexOf('\n\n');
-            const lastStep =
-              lastDoubleNewline >= 0 ? m.thinking.substring(lastDoubleNewline + 2) : m.thinking;
-            if (lastStep && chunk.startsWith(lastStep)) {
-              const prefix = m.thinking.substring(
-                0,
-                lastDoubleNewline >= 0 ? lastDoubleNewline + 2 : 0,
-              );
-              updatedThinking = prefix + chunk;
-            } else if (!m.thinking.includes(chunk.trim())) {
-              const separator = m.thinking.endsWith('\n') ? '\n' : '\n\n';
-              updatedThinking = `${m.thinking}${separator}${chunk}`;
-            }
-          }
-        }
+        const updatedText = parsed.textChunk
+          ? this.appendStreamedText(m.text, parsed.textChunk)
+          : m.text;
+        const updatedThinking = parsed.thoughtChunk
+          ? this.appendStreamedThought(m.thinking, parsed.thoughtChunk)
+          : m.thinking;
         const updatedPayload =
           parsed.a2uiItems.length > 0
             ? mergeA2uiItems(m.a2uiPayload || [], parsed.a2uiItems)
@@ -628,7 +654,7 @@ export class A2aChatView implements OnInit {
     this.cancelActiveGeneration();
     this.messages.set([]);
     this.activeTaskId.set(null);
-    this.activeContextId.set(null);
+    this.activeContextId.set(undefined);
     this.activeCanvasPayload.set(null);
     this.isCanvasOpen.set(false);
   }

--- a/shell/src/app/agent-chat/agent-header/agent-header.spec.ts
+++ b/shell/src/app/agent-chat/agent-header/agent-header.spec.ts
@@ -60,12 +60,8 @@ describe('A2aAgentHeader', () => {
     expect(await harness.getAvatarImageSrc()).toBe('http://example.com/icon.svg');
   });
 
-  it('hides session chip when sessionId is undefined or null', async () => {
+  it('hides session chip when sessionId is undefined', async () => {
     fixture.componentRef.setInput('sessionId', undefined);
-    fixture.detectChanges();
-    expect(await harness.getSessionText()).toBeNull();
-
-    fixture.componentRef.setInput('sessionId', null);
     fixture.detectChanges();
     expect(await harness.getSessionText()).toBeNull();
   });

--- a/shell/src/app/agent-chat/agent-header/agent-header.spec.ts
+++ b/shell/src/app/agent-chat/agent-header/agent-header.spec.ts
@@ -60,6 +60,16 @@ describe('A2aAgentHeader', () => {
     expect(await harness.getAvatarImageSrc()).toBe('http://example.com/icon.svg');
   });
 
+  it('hides session chip when sessionId is undefined or null', async () => {
+    fixture.componentRef.setInput('sessionId', undefined);
+    fixture.detectChanges();
+    expect(await harness.getSessionText()).toBeNull();
+
+    fixture.componentRef.setInput('sessionId', null);
+    fixture.detectChanges();
+    expect(await harness.getSessionText()).toBeNull();
+  });
+
   it('emits event when inspector toggle button is clicked', async () => {
     const spy = vi.spyOn(fixture.componentInstance.toggleInspector, 'emit');
     await harness.clickInspector();

--- a/shell/src/app/agent-chat/agent-header/agent-header.ts
+++ b/shell/src/app/agent-chat/agent-header/agent-header.ts
@@ -42,7 +42,7 @@ export class A2aAgentHeader {
   /** Active A2A task identifier returned by the server, if any. */
   readonly activeTaskId = input<string | null>(null);
   /** Active context or session conversation identifier. */
-  readonly sessionId = input<string | null>(null);
+  readonly sessionId = input<string | null | undefined>(null);
   /** Whether the message inspector side drawer is currently open. */
   readonly isInspectorOpen = input<boolean>(false);
 

--- a/shell/src/app/agent-chat/agent-header/agent-header.ts
+++ b/shell/src/app/agent-chat/agent-header/agent-header.ts
@@ -42,7 +42,7 @@ export class A2aAgentHeader {
   /** Active A2A task identifier returned by the server, if any. */
   readonly activeTaskId = input<string | null>(null);
   /** Active context or session conversation identifier. */
-  readonly sessionId = input<string | null | undefined>(null);
+  readonly sessionId = input<string | undefined>(undefined);
   /** Whether the message inspector side drawer is currently open. */
   readonly isInspectorOpen = input<boolean>(false);
 

--- a/shell/src/app/agent-chat/chat-message/chat-message.ng.html
+++ b/shell/src/app/agent-chat/chat-message/chat-message.ng.html
@@ -34,7 +34,7 @@
     >
       <div class="agent-header-badge">
         <div class="mini-avatar">
-          <mat-icon class="mini-avatar-icon">smart_toy</mat-icon>
+          <span class="mini-avatar-letter">{{ agentInitial() }}</span>
         </div>
         <span class="agent-badge-name">{{ agentName() }}</span>
       </div>
@@ -49,27 +49,23 @@
         }
 
         @if (message().thinking) {
-          <div class="thinking-accordion">
-            <div
-              class="thinking-header"
-              role="button"
-              tabindex="0"
-              [attr.aria-expanded]="isThinkingExpanded()"
-              aria-label="Toggle thinking reasoning process"
+          <div class="thinking-container">
+            <button
+              class="toggle-show-thoughts-button"
+              type="button"
               (click)="toggleThinkingExpansion()"
-              (keydown.enter)="toggleThinkingExpansion()"
-              (keydown.space)="toggleThinkingExpansion()"
+              [attr.aria-expanded]="isThinkingExpanded()"
+              [attr.aria-label]="thinkingLabel()"
             >
-              <mat-icon class="thinking-icon">psychology</mat-icon>
-              <span class="thinking-label">
-                {{ thinkingLabel() }}
-              </span>
-              <mat-icon class="expand-arrow">
+              {{ thinkingLabel() }}
+              <mat-icon class="thinking-arrow-icon">
                 {{ thinkingExpandIcon() }}
               </mat-icon>
-            </div>
+            </button>
             @if (isThinkingExpanded()) {
-              <div class="thinking-content" [innerHTML]="formattedThinking()"></div>
+              <div class="thinking-content">
+                <div class="thinking-markdown-body" [innerHTML]="formattedThinking()"></div>
+              </div>
             }
           </div>
         }
@@ -132,6 +128,39 @@
               <span class="dot"></span>
               <span class="dot"></span>
             </div>
+          </div>
+        }
+
+        @if (showMessageActions()) {
+          <div class="message-actions-bar">
+            <button
+              mat-icon-button
+              type="button"
+              class="action-btn"
+              matTooltip="Good response"
+              aria-label="Good response"
+            >
+              <mat-icon class="action-icon">thumb_up</mat-icon>
+            </button>
+            <button
+              mat-icon-button
+              type="button"
+              class="action-btn"
+              matTooltip="Bad response"
+              aria-label="Bad response"
+            >
+              <mat-icon class="action-icon">thumb_down</mat-icon>
+            </button>
+            <button
+              mat-icon-button
+              type="button"
+              class="action-btn"
+              matTooltip="Copy text"
+              aria-label="Copy text"
+              (click)="copyMessageText()"
+            >
+              <mat-icon class="action-icon">content_copy</mat-icon>
+            </button>
           </div>
         }
       </div>

--- a/shell/src/app/agent-chat/chat-message/chat-message.scss
+++ b/shell/src/app/agent-chat/chat-message/chat-message.scss
@@ -97,13 +97,13 @@
           width: 24px;
           height: 24px;
           border-radius: 50%;
-          background: #feeed8;
-          color: #b05000;
+          background: var(--mat-sys-tertiary-container, #feeed8);
+          color: var(--mat-sys-on-tertiary-container, #b05000);
           display: flex;
           align-items: center;
           justify-content: center;
-          font-weight: 600;
-          font-size: 13px;
+          font-weight: var(--mat-sys-title-small-weight, 600);
+          font-size: var(--mat-sys-label-large-size, 0.8125rem);
           user-select: none;
 
           .mini-avatar-letter {
@@ -112,8 +112,8 @@
         }
 
         .agent-badge-name {
-          font-size: 0.92rem;
-          font-weight: 600;
+          font-size: var(--mat-sys-title-small-size, 0.92rem);
+          font-weight: var(--mat-sys-title-small-weight, 600);
           color: var(--mat-sys-on-surface, #1f1f1f);
         }
       }
@@ -212,8 +212,8 @@
             background: transparent;
             border-radius: 6px;
             color: var(--mat-sys-on-surface-variant, #444746);
-            font-size: 0.88rem;
-            font-weight: 500;
+            font-size: var(--mat-sys-label-large-size, 0.88rem);
+            font-weight: var(--mat-sys-label-large-weight, 500);
             padding: 4px 6px;
             margin-left: -6px;
             cursor: pointer;
@@ -240,9 +240,9 @@
             width: 100%;
 
             .thinking-markdown-body {
-              font-size: 0.88rem;
+              font-size: var(--mat-sys-body-medium-size, 0.88rem);
               color: var(--mat-sys-on-surface-variant, #444746);
-              line-height: 1.5;
+              line-height: var(--mat-sys-body-medium-line-height, 1.5);
 
               p {
                 margin: 0 0 6px 0;

--- a/shell/src/app/agent-chat/chat-message/chat-message.scss
+++ b/shell/src/app/agent-chat/chat-message/chat-message.scss
@@ -27,11 +27,11 @@
     justify-content: flex-end;
 
     .user-message-bubble {
-      background: var(--mat-sys-primary, #1a73e8);
-      color: var(--mat-sys-on-primary, #ffffff);
+      background: var(--mat-sys-surface-container-high, #f0f4f9);
+      color: var(--mat-sys-on-surface, #1f1f1f);
       border-radius: 20px;
       padding: 10px 18px;
-      font-size: var(--mat-sys-body-medium-size, 0.88rem);
+      font-size: var(--mat-sys-body-medium-size, 0.9rem);
       max-width: 80%;
       line-height: var(--mat-sys-body-medium-line-height, 1.4);
       word-break: break-word;
@@ -73,45 +73,48 @@
     .agent-message-container {
       display: flex;
       flex-direction: column;
-      max-width: 85%;
-      width: fit-content;
-      background: var(--mat-sys-surface-container-low, #f1f3f4);
+      max-width: 90%;
+      width: 100%;
+      background: transparent;
       border-radius: 16px;
-      padding: 16px 20px;
+      padding: 8px 4px 14px 4px;
       box-sizing: border-box;
-      gap: 8px;
+      gap: 6px;
 
       &.has-inline-surface,
       &.has-canvas-artifacts {
         width: 100%;
-        max-width: min(840px, 95%);
+        max-width: min(840px, 98%);
       }
 
       .agent-header-badge {
         display: flex;
         align-items: center;
-        gap: 6px;
+        gap: 8px;
         margin-bottom: 2px;
 
         .mini-avatar {
-          width: 18px;
-          height: 18px;
-          color: var(--mat-sys-on-surface-variant, #5f6368);
+          width: 24px;
+          height: 24px;
+          border-radius: 50%;
+          background: #feeed8;
+          color: #b05000;
           display: flex;
           align-items: center;
           justify-content: center;
+          font-weight: 600;
+          font-size: 13px;
+          user-select: none;
 
-          .mini-avatar-icon {
-            font-size: 16px;
-            width: 16px;
-            height: 16px;
+          .mini-avatar-letter {
+            line-height: 1;
           }
         }
 
         .agent-badge-name {
-          font-size: var(--mat-sys-label-small-size, 0.78rem);
-          font-weight: var(--mat-sys-label-small-weight, 500);
-          color: var(--mat-sys-on-surface-variant, #5f6368);
+          font-size: 0.92rem;
+          font-weight: 600;
+          color: var(--mat-sys-on-surface, #1f1f1f);
         }
       }
 
@@ -146,7 +149,7 @@
         }
 
         .agent-text-content {
-          font-size: var(--mat-sys-body-medium-size, 0.88rem);
+          font-size: var(--mat-sys-body-medium-size, 0.9rem);
           color: var(--mat-sys-on-surface, #1f1f1f);
           line-height: var(--mat-sys-body-medium-line-height, 1.5);
 
@@ -194,51 +197,68 @@
           }
         }
 
-        .thinking-accordion {
-          background: var(--mat-sys-surface-container-lowest, #f8f9fa);
-          border: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
-          border-radius: 8px;
-          overflow: hidden;
+        .thinking-container {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          width: 100%;
+          margin: 2px 0 4px 0;
 
-          .thinking-header {
-            display: flex;
+          .toggle-show-thoughts-button {
+            display: inline-flex;
             align-items: center;
-            gap: 8px;
-            padding: 6px 12px;
+            gap: 4px;
+            border: none;
+            background: transparent;
+            border-radius: 6px;
+            color: var(--mat-sys-on-surface-variant, #444746);
+            font-size: 0.88rem;
+            font-weight: 500;
+            padding: 4px 6px;
+            margin-left: -6px;
             cursor: pointer;
             user-select: none;
-            font-size: var(--mat-sys-label-medium-size, 0.82rem);
-            color: var(--mat-sys-on-surface-variant, #5f6368);
-            font-weight: var(--mat-sys-label-medium-weight, 500);
-            background: var(--mat-sys-surface-container, #f1f3f4);
+            transition: background-color 0.15s ease;
 
-            .thinking-icon {
-              font-size: 16px;
-              width: 16px;
-              height: 16px;
-              color: var(--mat-sys-primary, #6750a4);
+            &:hover {
+              background: var(--mat-sys-surface-container-high, rgba(0, 0, 0, 0.05));
             }
 
-            .expand-arrow {
-              margin-left: auto;
+            .thinking-arrow-icon {
               font-size: 18px;
               width: 18px;
               height: 18px;
-            }
-
-            &:hover {
-              background: var(--mat-sys-surface-container-high, #e8eaed);
+              color: var(--mat-sys-on-surface-variant, #5f6368);
             }
           }
 
           .thinking-content {
-            padding: 10px 14px;
-            font-size: var(--mat-sys-body-small-size, 0.82rem);
-            color: var(--mat-sys-on-surface-variant, #49454f);
-            line-height: var(--mat-sys-body-small-line-height, 1.4);
-            font-family: inherit;
-            background: var(--mat-sys-surface, #ffffff);
-            border-top: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            padding: 4px 0 6px 2px;
+            width: 100%;
+
+            .thinking-markdown-body {
+              font-size: 0.88rem;
+              color: var(--mat-sys-on-surface-variant, #444746);
+              line-height: 1.5;
+
+              p {
+                margin: 0 0 6px 0;
+                &:last-child {
+                  margin-bottom: 0;
+                }
+              }
+
+              code {
+                background: var(--mat-sys-surface-container-highest, #e8eaed);
+                padding: 2px 4px;
+                border-radius: 4px;
+                font-family: monospace;
+                font-size: 0.85em;
+              }
+            }
           }
         }
 
@@ -443,6 +463,37 @@
           vertical-align: middle;
           border-radius: 2px;
           animation: cursor-blink 0.8s infinite;
+        }
+
+        .message-actions-bar {
+          display: flex;
+          align-items: center;
+          gap: 2px;
+          margin-top: 4px;
+          margin-left: -6px;
+
+          .action-btn {
+            width: 32px;
+            height: 32px;
+            padding: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--mat-sys-on-surface-variant, #747775);
+            border-radius: 50%;
+            cursor: pointer;
+
+            &:hover {
+              color: var(--mat-sys-on-surface, #1f1f1f);
+              background: var(--mat-sys-surface-container-high, rgba(0, 0, 0, 0.05));
+            }
+
+            .action-icon {
+              font-size: 16px;
+              width: 16px;
+              height: 16px;
+            }
+          }
         }
       }
     }

--- a/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
@@ -76,6 +76,24 @@ describe('A2aChatMessage', () => {
     expect(await harness.getMessageContent()).toContain('Hello, user!');
   });
 
+  it('derives the avatar initial from the agent name', async () => {
+    fixture.componentRef.setInput('agentName', 'flight booker');
+    fixture.detectChanges();
+
+    expect(await harness.getAgentInitial()).toBe('F');
+  });
+
+  it('keeps non-BMP avatar initials intact and falls back for blank agent names', async () => {
+    // charAt(0) would emit a lone surrogate here rather than the whole glyph.
+    fixture.componentRef.setInput('agentName', '🤖 Agent');
+    fixture.detectChanges();
+    expect(await harness.getAgentInitial()).toBe('🤖');
+
+    fixture.componentRef.setInput('agentName', '   ');
+    fixture.detectChanges();
+    expect(await harness.getAgentInitial()).toBe('A');
+  });
+
   it('renders user message', async () => {
     fixture.componentRef.setInput('message', {
       id: 'msg-2',

--- a/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
@@ -105,6 +105,137 @@ describe('A2aChatMessage', () => {
     expect(await harness.isThinkingExpanded()).toBe(true);
   });
 
+  it('expands thinking by default while only thinking content has streamed', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3a',
+      sender: 'agent',
+      text: '',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+
+    expect(await harness.isThinkingExpanded()).toBe(true);
+  });
+
+  it('collapses thinking as soon as non-thinking content streams in', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3b',
+      sender: 'agent',
+      text: '',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+    expect(await harness.isThinkingExpanded()).toBe(true);
+
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3b',
+      sender: 'agent',
+      text: 'Here is the answer',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+
+    expect(await harness.isThinkingExpanded()).toBe(false);
+  });
+
+  it('collapses thinking when only an A2UI surface streams in', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3c',
+      sender: 'agent',
+      text: '',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+    expect(await harness.isThinkingExpanded()).toBe(true);
+
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3c',
+      sender: 'agent',
+      text: '',
+      thinking: 'Reasoning step 1...',
+      inlineA2uiPayload: [
+        {version: 'v0.9', createSurface: {surfaceId: 's1', catalogId: 'c1', component: 'Canvas'}},
+      ],
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+
+    expect(await harness.isThinkingExpanded()).toBe(false);
+  });
+
+  it('discards a manual collapse once non-thinking content streams in', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3d',
+      sender: 'agent',
+      text: '',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+    expect(await harness.isThinkingExpanded()).toBe(true);
+
+    // The user collapses it manually while only thinking content exists.
+    await harness.clickThinking();
+    expect(await harness.isThinkingExpanded()).toBe(false);
+
+    // The first real chunk arrives: the content state changed, so the manual
+    // choice no longer applies and the default (collapsed) takes over.
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3d',
+      sender: 'agent',
+      text: 'Here is the answer',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+    expect(await harness.isThinkingExpanded()).toBe(false);
+
+    // The user can still expand it explicitly afterwards.
+    await harness.clickThinking();
+    expect(await harness.isThinkingExpanded()).toBe(true);
+  });
+
+  it('keeps a manual expansion while the content state is unchanged', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3e',
+      sender: 'agent',
+      text: 'Here is the answer',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+    expect(await harness.isThinkingExpanded()).toBe(false);
+
+    await harness.clickThinking();
+    expect(await harness.isThinkingExpanded()).toBe(true);
+
+    // More text streams in; content state is still "has content", so the
+    // manual expansion survives.
+    fixture.componentRef.setInput('message', {
+      id: 'msg-3e',
+      sender: 'agent',
+      text: 'Here is the answer, continued',
+      thinking: 'Reasoning step 1...',
+      isStreaming: true,
+      timestamp: Date.now(),
+    });
+    fixture.detectChanges();
+
+    expect(await harness.isThinkingExpanded()).toBe(true);
+  });
+
   it('renders attached images', async () => {
     fixture.componentRef.setInput('message', {
       id: 'msg-4',

--- a/shell/src/app/agent-chat/chat-message/chat-message.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.ts
@@ -27,6 +27,15 @@ import {A2A_PROTOCOL_ICON_URL} from '../converters/a2a-ui-converter';
 import {CanvasArtifact, UiMessage} from './types';
 
 /**
+ * A user's explicit expand/collapse choice for the thinking accordion, tagged with the
+ * content state the choice was made under.
+ */
+interface ManualThinkingToggle {
+  readonly hadContent: boolean;
+  readonly expanded: boolean;
+}
+
+/**
  * Message bubble item rendering textual responses, markdown, thinking blocks,
  * tool calls, attachments, and embedded inline A2UI surfaces.
  */
@@ -62,7 +71,16 @@ export class A2aChatMessage {
   /** Emitted when the user clicks to open the protocol message inspector. */
   readonly openInspector = output<void>();
 
-  protected readonly isThinkingExpanded = signal<boolean>(false);
+  /**
+   * Records the user's last manual expand/collapse action along with the content state
+   * (`hadContent`) it was performed under.
+   *
+   * Storing the content state alongside the choice lets the accordion automatically revert to
+   * the default behaviour whenever the message transitions from thinking-only to having visible
+   * content (i.e. the first non-thinking chunk streams in), while still honouring the manual
+   * choice for as long as the content state is unchanged.
+   */
+  private readonly manualThinkingToggle = signal<ManualThinkingToggle | null>(null);
 
   protected readonly formattedContent = computed<string>(() => {
     const rawText = this.message().text || '';
@@ -74,6 +92,11 @@ export class A2aChatMessage {
     const raw = this.message().thinking || '';
     if (!raw.trim()) return '';
     return renderMarkdown(raw);
+  });
+
+  protected readonly agentInitial = computed<string>(() => {
+    const name = (this.agentName() || 'Agent').trim();
+    return name ? name.charAt(0).toUpperCase() : 'A';
   });
 
   protected readonly formattedTime = computed<string>(() => {
@@ -108,12 +131,48 @@ export class A2aChatMessage {
     return Boolean(this.message().images?.length);
   });
 
+  /**
+   * Whether the message has streamed any user-visible, non-thinking content yet.
+   *
+   * Covers rendered text as well as A2UI surfaces (inline or Canvas), since both represent an
+   * actual agent response rather than intermediate reasoning.
+   */
+  protected readonly hasNonThinkingContent = computed<boolean>(() => {
+    const message = this.message();
+    return Boolean(
+      message.text?.trim() ||
+      message.inlineA2uiPayload?.length ||
+      message.a2uiPayload?.length ||
+      message.canvasArtifacts?.length,
+    );
+  });
+
+  /**
+   * Whether the thinking accordion is currently expanded.
+   *
+   * Defaults to expanded while the message contains only thinking content, and automatically
+   * collapses as soon as the first non-thinking chunk streams in. A manual toggle by the user
+   * overrides this default until the content state changes again.
+   */
+  protected readonly isThinkingExpanded = computed<boolean>(() => {
+    const hasContent = this.hasNonThinkingContent();
+    const manual = this.manualThinkingToggle();
+    if (manual && manual.hadContent === hasContent) {
+      return manual.expanded;
+    }
+    return !hasContent;
+  });
+
   protected readonly thinkingLabel = computed<string>(() => {
-    return this.message().isStreaming ? 'Thinking...' : 'Reasoning Process';
+    const message = this.message();
+    if (message.isStreaming && !message.thinking) {
+      return 'Thinking...';
+    }
+    return this.isThinkingExpanded() ? 'Hide thinking' : 'Show thinking';
   });
 
   protected readonly thinkingExpandIcon = computed<string>(() => {
-    return this.isThinkingExpanded() ? 'expand_less' : 'expand_more';
+    return this.isThinkingExpanded() ? 'keyboard_arrow_up' : 'keyboard_arrow_down';
   });
 
   protected readonly isPending = computed<boolean>(() => {
@@ -144,6 +203,12 @@ export class A2aChatMessage {
     return Boolean(this.canvasArtifacts().length);
   });
 
+  /** Whether the feedback/copy action bar is shown under a finished agent turn. */
+  protected readonly showMessageActions = computed<boolean>(() => {
+    if (this.message().isStreaming) return false;
+    return Boolean(this.message().text || this.hasInlineSurface() || this.hasCanvasArtifacts());
+  });
+
   protected isArtifactActive(artifact: CanvasArtifact): boolean {
     if (!this.isCanvasOpen()) return false;
     const active = this.activeCanvasPayload();
@@ -154,7 +219,20 @@ export class A2aChatMessage {
   }
 
   protected toggleThinkingExpansion(): void {
-    this.isThinkingExpanded.update(v => !v);
+    this.manualThinkingToggle.set({
+      hadContent: this.hasNonThinkingContent(),
+      expanded: !this.isThinkingExpanded(),
+    });
+  }
+
+  protected copyMessageText(): void {
+    const text = this.message().text;
+    if (!text || typeof navigator === 'undefined' || !navigator.clipboard) {
+      return;
+    }
+    navigator.clipboard.writeText(text).catch((err: unknown) => {
+      console.warn('Failed to copy message text to clipboard', err);
+    });
   }
 
   protected openCanvasArtifact(payload: RenderA2uiItem[]): void {

--- a/shell/src/app/agent-chat/chat-message/chat-message.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.ts
@@ -96,7 +96,9 @@ export class A2aChatMessage {
 
   protected readonly agentInitial = computed<string>(() => {
     const name = (this.agentName() || 'Agent').trim();
-    return name ? name.charAt(0).toUpperCase() : 'A';
+    // Iterate by code point so a leading emoji or other non-BMP character is
+    // not split into a lone surrogate.
+    return name ? [...name][0].toUpperCase() : 'A';
   });
 
   protected readonly formattedTime = computed<string>(() => {

--- a/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
+++ b/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
@@ -21,6 +21,7 @@ export class A2aChatMessageHarness extends ComponentHarness {
   static hostSelector = 'a2ui-composer-chat-message';
 
   private getSenderName = this.locatorForOptional('.agent-badge-name');
+  private getAvatarLetter = this.locatorForOptional('.mini-avatar-letter');
   private getMessageText = this.locatorForOptional('.markdown-body, .user-message-bubble');
   private getThinkingHeader = this.locatorForOptional('.toggle-show-thoughts-button');
   private getThinkingContent = this.locatorForOptional('.thinking-content');
@@ -53,6 +54,11 @@ export class A2aChatMessageHarness extends ComponentHarness {
 
   async getSenderNameText(): Promise<string | null> {
     const el = await this.getSenderName();
+    return el ? el.text() : null;
+  }
+
+  async getAgentInitial(): Promise<string | null> {
+    const el = await this.getAvatarLetter();
     return el ? el.text() : null;
   }
 

--- a/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
+++ b/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
@@ -22,7 +22,7 @@ export class A2aChatMessageHarness extends ComponentHarness {
 
   private getSenderName = this.locatorForOptional('.agent-badge-name');
   private getMessageText = this.locatorForOptional('.markdown-body, .user-message-bubble');
-  private getThinkingHeader = this.locatorForOptional('.thinking-header');
+  private getThinkingHeader = this.locatorForOptional('.toggle-show-thoughts-button');
   private getThinkingContent = this.locatorForOptional('.thinking-content');
   private getOpenCanvasButton = this.locatorForOptional(
     MatButtonHarness.with({selector: '.view-canvas-btn'}),

--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.spec.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.spec.ts
@@ -369,7 +369,7 @@ describe('A2aStreamEventParser', () => {
     expect(parsed.a2uiItems[1].createSurface?.surfaceId).toBe('art-2');
   });
 
-  it('provides status text fallback when message is empty', () => {
+  it('routes in-progress status text to thinking and leaves empty status silent', () => {
     const statusEvent: TaskStatusUpdateEvent = {
       taskId: 'task-status-fallback',
       status: {
@@ -378,8 +378,11 @@ describe('A2aStreamEventParser', () => {
       },
     };
 
+    // Non-terminal status text belongs in the thinking panel, not the main
+    // transcript, so it is surfaced as a thought chunk.
     const parsed = parser.parse(statusEvent);
-    expect(parsed.textChunk).toBe('Working on your request...');
+    expect(parsed.textChunk).toBeUndefined();
+    expect(parsed.thoughtChunk).toBe('Working on your request...');
 
     // When status has no message but has a state, textChunk remains undefined so status transitions are not rendered in chat
     const emptyStatusEvent: TaskStatusUpdateEvent = {
@@ -429,5 +432,87 @@ describe('A2aStreamEventParser', () => {
       },
     });
     expect(rawEvent.textChunk).toContain('data:text/plain;base64,SGVsbG8gV29ybGQ=');
+  });
+
+  it('routes non-completed TASK_STATE_WORKING text to thoughtChunk without duplication', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-dup',
+      contextId: 'ctx-dup',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [{text: 'Hello, how can I help?'}],
+      },
+      status: {
+        state: 'TASK_STATE_WORKING',
+        message: {
+          role: 'ROLE_AGENT',
+          parts: [{text: 'Hello, how can I help?'}],
+        },
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.thoughtChunk).toBe('Hello, how can I help?');
+    expect(parsed.textChunk).toBeUndefined();
+  });
+
+  it('routes completed TASK_STATE_COMPLETED text to textChunk without duplication', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-comp-dup',
+      contextId: 'ctx-comp-dup',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [{text: 'Here is the final redlined contract.'}],
+      },
+      status: {
+        state: 'TASK_STATE_COMPLETED',
+        message: {
+          role: 'ROLE_AGENT',
+          parts: [{text: 'Here is the final redlined contract.'}],
+        },
+      },
+      final: true,
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toBe('Here is the final redlined contract.');
+    expect(parsed.thoughtChunk).toBeUndefined();
+    expect(parsed.isCompleted).toBe(true);
+  });
+
+  it('routes echoed user prompt in TASK_STATE_SUBMITTED to thoughtChunk so agent does not duplicate user text on main canvas', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-user-echo',
+      contextId: 'ctx-user-echo',
+      message: {
+        role: 'ROLE_USER',
+        content: [{text: 'hi'}],
+      },
+      status: {
+        state: 'TASK_STATE_SUBMITTED',
+        message: {
+          role: 'ROLE_USER',
+          content: [{text: 'hi'}],
+        },
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toBeUndefined();
+    expect(parsed.thoughtChunk).toBe('hi');
+  });
+
+  it('filters out user messages with role user outside of task submission', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-user-case',
+      message: {
+        role: 'user',
+        parts: [{text: 'show me contracts'}],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toBeUndefined();
+    expect(parsed.thoughtChunk).toBeUndefined();
   });
 });

--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
@@ -49,9 +49,9 @@ enum A2aPartKind {
 }
 
 /** Field names read off raw A2A events that are absent from {@link TaskStatusUpdateEvent}. */
-const A2A_EVENT_FIELD = {
-  KIND: 'kind',
-} as const;
+enum A2aEventField {
+  KIND = 'kind',
+}
 
 /**
  * Field names read off raw A2A parts.
@@ -59,10 +59,10 @@ const A2A_EVENT_FIELD = {
  * These are accessed through an index signature because they are absent from {@link A2aPart};
  * they only appear on payloads from agents that predate or extend the typed shape.
  */
-const A2A_PART_FIELD = {
-  KIND: 'kind',
-  THOUGHT: 'thought',
-} as const;
+enum A2aPartField {
+  KIND = 'kind',
+  THOUGHT = 'thought',
+}
 
 /**
  * Metadata keys that mark a part as model reasoning.
@@ -354,7 +354,7 @@ export class A2aStreamEventParser {
     if (typeof status === 'object' && status !== null && status['update']) {
       return status['update'];
     }
-    if (unwrapped[A2A_EVENT_FIELD.KIND] === A2aEventKind.MESSAGE) {
+    if (unwrapped[A2aEventField.KIND] === A2aEventKind.MESSAGE) {
       return unwrapped;
     }
     if (Array.isArray(unwrapped.parts)) {
@@ -486,8 +486,8 @@ export class A2aStreamEventParser {
    * protobuf `fields` map.
    */
   private isThoughtPart(part: A2aPart, partObj: Record<string, unknown>): boolean {
-    if (partObj[A2A_PART_FIELD.THOUGHT] !== undefined) return true;
-    if (partObj[A2A_PART_FIELD.KIND] === A2aPartKind.THOUGHT) return true;
+    if (partObj[A2aPartField.THOUGHT] !== undefined) return true;
+    if (partObj[A2aPartField.KIND] === A2aPartKind.THOUGHT) return true;
 
     const meta = (part.metadata || partObj['metadata']) as Record<string, unknown> | undefined;
     if (!meta) return false;

--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
@@ -16,16 +16,17 @@
 
 import {Injectable} from '@angular/core';
 import {RenderA2uiItem} from 'a2ui-bridge';
+
+import {renderBase64Data, renderMultimediaContent} from '../../chat/a2a/a2a-media';
 import {
   A2aArtifact,
-  A2aMessage,
   A2aPart,
-  TaskStatusUpdateEvent,
   isTerminalTaskState,
   normalizeTaskState,
+  TaskStatusUpdateEvent,
 } from '../../chat/a2a/a2a-types';
 import {UiToolCall} from '../chat-message/types';
-import {renderBase64Data, renderMultimediaContent} from '../../chat/a2a/a2a-media';
+
 import {isA2uiItem, normalizeA2uiItems} from './surface-partitioner';
 
 /**
@@ -216,27 +217,107 @@ export class A2aStreamEventParser {
     unwrapped: TaskStatusUpdateEvent,
     result: ParsedA2aStreamEvent,
   ): void {
-    const msg =
-      unwrapped.message ||
-      (typeof unwrapped.status === 'object' && unwrapped.status !== null
-        ? unwrapped.status.message
-        : undefined) ||
-      (Array.isArray(unwrapped.parts) ? unwrapped : undefined) ||
-      (unwrapped['kind'] === 'message' ? (unwrapped as unknown as A2aMessage) : undefined);
+    const primaryMessage = this.extractPrimaryMessage(unwrapped);
+    if (!primaryMessage) return;
 
-    if (typeof msg === 'string') {
-      result.textChunk = (result.textChunk || '') + msg;
+    const isNonCompleted = this.isNonCompletedTaskEvent(unwrapped);
+
+    if (typeof primaryMessage === 'string') {
+      if (isNonCompleted) {
+        result.thoughtChunk = (result.thoughtChunk || '') + primaryMessage;
+      } else {
+        result.textChunk = (result.textChunk || '') + primaryMessage;
+      }
       return;
     }
 
-    if (typeof msg === 'object' && msg !== null && Array.isArray(msg.parts)) {
-      for (const part of msg.parts) {
-        this.processMessagePart(part, result);
+    if (Array.isArray(primaryMessage)) {
+      for (const part of primaryMessage) {
+        if (part && typeof part === 'object') {
+          this.processMessagePart(part as A2aPart, result, isNonCompleted);
+        }
       }
+      return;
+    }
+
+    if (typeof primaryMessage !== 'object' || primaryMessage === null) {
+      return;
+    }
+
+    const msgRecord = primaryMessage as Record<string, unknown>;
+    // Outside of non-completed status, filter out user messages.
+    if (this.isUserMessage(msgRecord, unwrapped) && !isNonCompleted) {
+      return;
+    }
+
+    const parts = msgRecord['parts'] ?? msgRecord['content'];
+    if (Array.isArray(parts)) {
+      for (const part of parts) {
+        if (part && typeof part === 'object') {
+          this.processMessagePart(part as A2aPart, result, isNonCompleted);
+        }
+      }
+    } else if (typeof msgRecord['text'] === 'string' || msgRecord['data'] !== undefined) {
+      this.processMessagePart(msgRecord as A2aPart, result, isNonCompleted);
     }
   }
 
-  private processMessagePart(part: A2aPart, result: ParsedA2aStreamEvent): void {
+  private isNonCompletedTaskEvent(unwrapped: TaskStatusUpdateEvent): boolean {
+    const statusState = this.extractStatusState(unwrapped);
+    return statusState === 'submitted' || statusState === 'working';
+  }
+
+  private extractPrimaryMessage(unwrapped: TaskStatusUpdateEvent): unknown {
+    if (unwrapped.message) {
+      return unwrapped.message;
+    }
+    if (
+      typeof unwrapped.status === 'object' &&
+      unwrapped.status !== null &&
+      unwrapped.status.message
+    ) {
+      return unwrapped.status.message;
+    }
+    const {status} = unwrapped;
+    if (typeof status === 'object' && status !== null && status['update']) {
+      return status['update'];
+    }
+    if (unwrapped['kind'] === 'message') {
+      return unwrapped;
+    }
+    if (Array.isArray(unwrapped.parts)) {
+      return unwrapped;
+    }
+    if (unwrapped['content']) {
+      return unwrapped['content'];
+    }
+    return undefined;
+  }
+
+  private isUserMessage(
+    msgRecord: Record<string, unknown>,
+    unwrapped: TaskStatusUpdateEvent,
+  ): boolean {
+    const role = String(msgRecord['role'] ?? unwrapped['role'] ?? '')
+      .trim()
+      .toUpperCase();
+
+    if (role === 'ROLE_USER' || role === 'USER') {
+      return true;
+    }
+    if (role === 'ROLE_AGENT' || role === 'AGENT' || role === 'ASSISTANT') {
+      return false;
+    }
+
+    const statusState = this.extractStatusState(unwrapped);
+    return statusState === 'submitted';
+  }
+
+  private processMessagePart(
+    part: A2aPart,
+    result: ParsedA2aStreamEvent,
+    isNonCompletedStatus = false,
+  ): void {
     const partObj = part as Record<string, unknown>;
 
     // 1. Model thoughts / reasoning
@@ -255,7 +336,11 @@ export class A2aStreamEventParser {
 
     // 2. Text (v0.3 / v1.0)
     if (part.text) {
-      result.textChunk = (result.textChunk || '') + part.text;
+      if (isNonCompletedStatus) {
+        result.thoughtChunk = (result.thoughtChunk || '') + part.text;
+      } else {
+        result.textChunk = (result.textChunk || '') + part.text;
+      }
     }
 
     // 3. File attachments & media (v0.3 nested file, v1.0 url, v1.0 raw bytes)
@@ -269,7 +354,9 @@ export class A2aStreamEventParser {
     // 5. Embedded artifact parts
     if (part.artifact?.parts) {
       for (const artPart of part.artifact.parts) {
-        this.processMessagePart(artPart, result);
+        if (artPart) {
+          this.processMessagePart(artPart, result, isNonCompletedStatus);
+        }
       }
     }
   }
@@ -321,11 +408,21 @@ export class A2aStreamEventParser {
   }
 
   private isThoughtPart(part: A2aPart, partObj: Record<string, unknown>): boolean {
+    const meta = (part.metadata || partObj['metadata']) as Record<string, unknown> | undefined;
+    const metaFields =
+      meta && typeof meta['fields'] === 'object' && meta['fields'] !== null
+        ? (meta['fields'] as Record<string, unknown>)
+        : undefined;
+    const adkThoughtVal = metaFields?.['adk_thought'] as Record<string, unknown> | undefined;
+    const thoughtVal = metaFields?.['thought'] as Record<string, unknown> | undefined;
+
     return (
-      part.metadata?.['adk_thought'] === true ||
-      part.metadata?.['adk_thought'] === 'true' ||
-      part.metadata?.['thought'] === true ||
-      part.metadata?.['thought'] === 'true' ||
+      meta?.['adk_thought'] === true ||
+      meta?.['adk_thought'] === 'true' ||
+      meta?.['thought'] === true ||
+      meta?.['thought'] === 'true' ||
+      adkThoughtVal?.['boolValue'] === true ||
+      thoughtVal?.['boolValue'] === true ||
       partObj['kind'] === 'thought' ||
       partObj['thought'] !== undefined
     );
@@ -452,10 +549,16 @@ export class A2aStreamEventParser {
       artifacts.push(...unwrapped.artifacts);
     }
 
+    const seenArtifacts = new Set<unknown>();
     for (const art of artifacts) {
+      if (!art || typeof art !== 'object' || seenArtifacts.has(art)) continue;
+      seenArtifacts.add(art);
+
       if (Array.isArray(art.parts)) {
         for (const artPart of art.parts) {
-          this.processMessagePart(artPart, result);
+          if (artPart) {
+            this.processMessagePart(artPart, result);
+          }
         }
       }
     }

--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
@@ -20,14 +20,72 @@ import {RenderA2uiItem} from 'a2ui-bridge';
 import {renderBase64Data, renderMultimediaContent} from '../../chat/a2a/a2a-media';
 import {
   A2aArtifact,
+  A2aMessageRole,
   A2aPart,
+  A2aV03TaskState,
   isTerminalTaskState,
+  normalizeMessageRole,
   normalizeTaskState,
   TaskStatusUpdateEvent,
 } from '../../chat/a2a/a2a-types';
 import {UiToolCall} from '../chat-message/types';
 
 import {isA2uiItem, normalizeA2uiItems} from './surface-partitioner';
+
+/**
+ * Values of the `kind` discriminator on A2A stream events.
+ */
+enum A2aEventKind {
+  /** The event is a bare message rather than a task status update. */
+  MESSAGE = 'message',
+}
+
+/**
+ * Values of the `kind` discriminator on A2A parts.
+ */
+enum A2aPartKind {
+  /** The part holds model reasoning that belongs in the thinking panel. */
+  THOUGHT = 'thought',
+}
+
+/** Field names read off raw A2A events that are absent from {@link TaskStatusUpdateEvent}. */
+const A2A_EVENT_FIELD = {
+  KIND: 'kind',
+} as const;
+
+/**
+ * Field names read off raw A2A parts.
+ *
+ * These are accessed through an index signature because they are absent from {@link A2aPart};
+ * they only appear on payloads from agents that predate or extend the typed shape.
+ */
+const A2A_PART_FIELD = {
+  KIND: 'kind',
+  THOUGHT: 'thought',
+} as const;
+
+/**
+ * Metadata keys that mark a part as model reasoning.
+ *
+ * `adk_thought` is emitted by ADK-based agents; `thought` is the generic spelling. Either may
+ * appear at the top level of `metadata` or nested inside its protobuf `fields` map.
+ */
+const THOUGHT_METADATA_KEYS = ['adk_thought', 'thought'] as const;
+
+/**
+ * Interprets the many encodings agents use for a boolean metadata flag.
+ *
+ * Accepts a native boolean, the string `'true'`, and the protobuf Struct wrapper
+ * (`{boolValue: true}`) produced by proto3 JSON mapping.
+ */
+function isThoughtFlagSet(value: unknown): boolean {
+  if (value === true || value === 'true') return true;
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>)['boolValue'] === true
+  );
+}
 
 /**
  * Extracts a UiToolCall structure if an object represents a function or tool call invocation.
@@ -262,11 +320,25 @@ export class A2aStreamEventParser {
     }
   }
 
+  /**
+   * Whether the event reports a task that is still in flight.
+   *
+   * Text emitted while a task is `submitted` or `working` is progress narration rather than the
+   * final answer, so callers route it to the thinking panel instead of the main transcript.
+   */
   private isNonCompletedTaskEvent(unwrapped: TaskStatusUpdateEvent): boolean {
     const statusState = this.extractStatusState(unwrapped);
-    return statusState === 'submitted' || statusState === 'working';
+    return statusState === A2aV03TaskState.SUBMITTED || statusState === A2aV03TaskState.WORKING;
   }
 
+  /**
+   * Locates the message payload within an event, checking the known shapes in priority order.
+   *
+   * Depending on the agent and transport the content may sit on `message`, on `status.message`,
+   * on the legacy `status.update`, or directly on the event itself when it is a bare message.
+   *
+   * @returns The message, its parts array, or undefined when the event carries no content.
+   */
   private extractPrimaryMessage(unwrapped: TaskStatusUpdateEvent): unknown {
     if (unwrapped.message) {
       return unwrapped.message;
@@ -282,7 +354,7 @@ export class A2aStreamEventParser {
     if (typeof status === 'object' && status !== null && status['update']) {
       return status['update'];
     }
-    if (unwrapped['kind'] === 'message') {
+    if (unwrapped[A2A_EVENT_FIELD.KIND] === A2aEventKind.MESSAGE) {
       return unwrapped;
     }
     if (Array.isArray(unwrapped.parts)) {
@@ -294,23 +366,22 @@ export class A2aStreamEventParser {
     return undefined;
   }
 
+  /**
+   * Determines whether a message was authored by the user rather than the agent.
+   *
+   * Agents echo the submitted prompt back on the `submitted` status event, so those messages must
+   * be recognized and skipped to avoid duplicating the user's text in the transcript. When the
+   * payload carries no usable role, authorship is inferred from the task state.
+   */
   private isUserMessage(
     msgRecord: Record<string, unknown>,
     unwrapped: TaskStatusUpdateEvent,
   ): boolean {
-    const role = String(msgRecord['role'] ?? unwrapped['role'] ?? '')
-      .trim()
-      .toUpperCase();
-
-    if (role === 'ROLE_USER' || role === 'USER') {
-      return true;
+    const role = normalizeMessageRole(msgRecord['role'] ?? unwrapped['role']);
+    if (role) {
+      return role === A2aMessageRole.USER;
     }
-    if (role === 'ROLE_AGENT' || role === 'AGENT' || role === 'ASSISTANT') {
-      return false;
-    }
-
-    const statusState = this.extractStatusState(unwrapped);
-    return statusState === 'submitted';
+    return this.extractStatusState(unwrapped) === A2aV03TaskState.SUBMITTED;
   }
 
   private processMessagePart(
@@ -407,24 +478,26 @@ export class A2aStreamEventParser {
     }
   }
 
+  /**
+   * Whether a part carries model reasoning rather than user-visible output.
+   *
+   * Agents signal this inconsistently, so every known spelling is accepted: a `thought` payload
+   * field, a `kind` discriminator, or a metadata flag either at the top level or nested under the
+   * protobuf `fields` map.
+   */
   private isThoughtPart(part: A2aPart, partObj: Record<string, unknown>): boolean {
+    if (partObj[A2A_PART_FIELD.THOUGHT] !== undefined) return true;
+    if (partObj[A2A_PART_FIELD.KIND] === A2aPartKind.THOUGHT) return true;
+
     const meta = (part.metadata || partObj['metadata']) as Record<string, unknown> | undefined;
+    if (!meta) return false;
     const metaFields =
-      meta && typeof meta['fields'] === 'object' && meta['fields'] !== null
+      typeof meta['fields'] === 'object' && meta['fields'] !== null
         ? (meta['fields'] as Record<string, unknown>)
         : undefined;
-    const adkThoughtVal = metaFields?.['adk_thought'] as Record<string, unknown> | undefined;
-    const thoughtVal = metaFields?.['thought'] as Record<string, unknown> | undefined;
 
-    return (
-      meta?.['adk_thought'] === true ||
-      meta?.['adk_thought'] === 'true' ||
-      meta?.['thought'] === true ||
-      meta?.['thought'] === 'true' ||
-      adkThoughtVal?.['boolValue'] === true ||
-      thoughtVal?.['boolValue'] === true ||
-      partObj['kind'] === 'thought' ||
-      partObj['thought'] !== undefined
+    return THOUGHT_METADATA_KEYS.some(
+      key => isThoughtFlagSet(meta[key]) || isThoughtFlagSet(metaFields?.[key]),
     );
   }
 

--- a/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
@@ -14,15 +14,31 @@
  * limitations under the License.
  */
 
+import {RenderA2uiItem} from 'a2ui-bridge';
 import {describe, it, expect} from 'vitest';
 import {
   hasA2uiCanvasComponent,
+  isA2uiItem,
+  isA2uiMimeType,
+  mergeA2uiItems,
   normalizeA2uiItems,
   partitionA2uiSurfacePayload,
   unwrapCanvasForRenderer,
+  A2UI_MIME_TYPE,
+  LEGACY_A2UI_MIME_TYPE,
 } from './surface-partitioner';
 
 describe('SurfacePartitioner', () => {
+  describe('isA2uiMimeType and MIME type constants', () => {
+    it('validates canonical and legacy A2UI MIME types', () => {
+      expect(isA2uiMimeType(A2UI_MIME_TYPE)).toBe(true);
+      expect(isA2uiMimeType(LEGACY_A2UI_MIME_TYPE)).toBe(true);
+      expect(isA2uiMimeType('application/json')).toBe(false);
+      expect(isA2uiMimeType(undefined)).toBe(false);
+      expect(isA2uiMimeType(null)).toBe(false);
+    });
+  });
+
   describe('normalizeA2uiItems and hasA2uiCanvasComponent', () => {
     it('normalizes items ensuring version v0.9', () => {
       const raw = [{createSurface: {surfaceId: 's1', catalogId: 'c1'}}];
@@ -37,14 +53,59 @@ describe('SurfacePartitioner', () => {
       expect(normalizeA2uiItems([null, 'invalid', 123])).toEqual([]);
     });
 
-    it('filters out non-A2UI items such as tool calls', () => {
+    it('identifies server rendering commands and rejects client action echoes', () => {
+      expect(isA2uiItem({createSurface: {surfaceId: 's1'}})).toBe(true);
+      expect(isA2uiItem({updateComponents: {surfaceId: 's1', components: []}})).toBe(true);
+      expect(isA2uiItem({updateDataModel: {surfaceId: 's1', value: {}}})).toBe(true);
+      expect(isA2uiItem({deleteSurface: {surfaceId: 's1'}})).toBe(true);
+      expect(isA2uiItem({beginRendering: {surfaceId: 's1'}})).toBe(true);
+      expect(isA2uiItem({surfaceUpdate: {surfaceId: 's1'}})).toBe(true);
+      expect(isA2uiItem({dataModelUpdate: {surfaceId: 's1'}})).toBe(true);
+
+      // Rejects tool calls
+      expect(isA2uiItem({name: 'tool_fn', args: {}})).toBe(false);
+      // Rejects echoed client action messages without server update keys
+      expect(isA2uiItem({userAction: {name: 'submit'}})).toBe(false);
+      expect(isA2uiItem({action: {name: 'submit'}})).toBe(false);
+      expect(isA2uiItem({clientEvent: {name: 'click'}})).toBe(false);
+    });
+
+    it('filters out non-A2UI items such as tool calls and echoed client actions', () => {
       const mixed = [
         {createSurface: {surfaceId: 's1', catalogId: 'c1'}},
         {name: 'show_vacation_booking_form', args: {}, id: 'call_123'},
+        {userAction: {name: 'submit_clicked'}},
       ];
       const normalized = normalizeA2uiItems(mixed);
       expect(normalized.length).toBe(1);
       expect(normalized[0].createSurface).toBeDefined();
+    });
+
+    it('deduplicates redundant createSurface commands for the same surfaceId', () => {
+      const duplicateCreate = [
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {updateComponents: {surfaceId: 'surf_1', components: [{id: 'r', component: 'Text'}]}},
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {updateDataModel: {surfaceId: 'surf_1', value: {k: 'v'}}},
+      ];
+      const normalized = normalizeA2uiItems(duplicateCreate);
+      expect(normalized.length).toBe(3);
+      expect(normalized[0].createSurface?.surfaceId).toBe('surf_1');
+      expect(normalized[1].updateComponents?.surfaceId).toBe('surf_1');
+      expect(normalized[2].updateDataModel?.surfaceId).toBe('surf_1');
+    });
+
+    it('allows re-creating a surface after deleteSurface', () => {
+      const reCreate = [
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {deleteSurface: {surfaceId: 'surf_1'}},
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c2'}},
+      ];
+      const normalized = normalizeA2uiItems(reCreate);
+      expect(normalized.length).toBe(3);
+      expect(normalized[0].createSurface?.catalogId).toBe('c1');
+      expect(normalized[1].deleteSurface?.surfaceId).toBe('surf_1');
+      expect(normalized[2].createSurface?.catalogId).toBe('c2');
     });
 
     it('detects canvas components correctly', () => {
@@ -458,6 +519,43 @@ describe('SurfacePartitioner', () => {
       expect(
         partitioned.inlinePayload?.some(item => item.deleteSurface?.surfaceId === 'surf-old'),
       ).toBe(true);
+    });
+  });
+
+  describe('mergeA2uiItems', () => {
+    it('appends delta updates when new items do not recreate the surface', () => {
+      const existing = [
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {updateComponents: {surfaceId: 'surf_1', components: [{id: 'r', component: 'Card'}]}},
+      ];
+      const delta = [{updateDataModel: {surfaceId: 'surf_1', value: {count: 1}}}];
+      const merged = mergeA2uiItems(
+        existing as unknown as RenderA2uiItem[],
+        delta as unknown as RenderA2uiItem[],
+      );
+      expect(merged.length).toBe(3);
+      expect(merged[2].updateDataModel?.surfaceId).toBe('surf_1');
+    });
+
+    it('replaces prior surface items when new items re-declare the surface via createSurface', () => {
+      const existing = [
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {updateComponents: {surfaceId: 'surf_1', components: [{id: 'old', component: 'Card'}]}},
+      ];
+      const fullUpdate = [
+        {createSurface: {surfaceId: 'surf_1', catalogId: 'c1'}},
+        {updateComponents: {surfaceId: 'surf_1', components: [{id: 'new', component: 'Card'}]}},
+        {updateDataModel: {surfaceId: 'surf_1', value: {count: 2}}},
+      ];
+      const merged = mergeA2uiItems(
+        existing as unknown as RenderA2uiItem[],
+        fullUpdate as unknown as RenderA2uiItem[],
+      );
+      expect(merged.length).toBe(3);
+      expect(merged[0].createSurface?.surfaceId).toBe('surf_1');
+      const mergedComponents = merged[1].updateComponents?.components as
+        Array<{id: string}> | undefined;
+      expect(mergedComponents?.[0].id).toBe('new');
     });
   });
 });

--- a/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
@@ -58,9 +58,9 @@ describe('SurfacePartitioner', () => {
       expect(isA2uiItem({updateComponents: {surfaceId: 's1', components: []}})).toBe(true);
       expect(isA2uiItem({updateDataModel: {surfaceId: 's1', value: {}}})).toBe(true);
       expect(isA2uiItem({deleteSurface: {surfaceId: 's1'}})).toBe(true);
-      expect(isA2uiItem({beginRendering: {surfaceId: 's1'}})).toBe(true);
 
       // Rejects superseded v0.8 update spellings, which Composer does not support
+      expect(isA2uiItem({beginRendering: {surfaceId: 's1'}})).toBe(false);
       expect(isA2uiItem({surfaceUpdate: {surfaceId: 's1'}})).toBe(false);
       expect(isA2uiItem({dataModelUpdate: {surfaceId: 's1'}})).toBe(false);
 

--- a/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.spec.ts
@@ -59,8 +59,10 @@ describe('SurfacePartitioner', () => {
       expect(isA2uiItem({updateDataModel: {surfaceId: 's1', value: {}}})).toBe(true);
       expect(isA2uiItem({deleteSurface: {surfaceId: 's1'}})).toBe(true);
       expect(isA2uiItem({beginRendering: {surfaceId: 's1'}})).toBe(true);
-      expect(isA2uiItem({surfaceUpdate: {surfaceId: 's1'}})).toBe(true);
-      expect(isA2uiItem({dataModelUpdate: {surfaceId: 's1'}})).toBe(true);
+
+      // Rejects superseded v0.8 update spellings, which Composer does not support
+      expect(isA2uiItem({surfaceUpdate: {surfaceId: 's1'}})).toBe(false);
+      expect(isA2uiItem({dataModelUpdate: {surfaceId: 's1'}})).toBe(false);
 
       // Rejects tool calls
       expect(isA2uiItem({name: 'tool_fn', args: {}})).toBe(false);

--- a/shell/src/app/agent-chat/converters/surface-partitioner.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {A2UI_UPDATE_KEYS, RenderA2uiItem} from 'a2ui-bridge';
+import {RenderA2uiItem} from 'a2ui-bridge';
 import {CanvasArtifact} from '../chat-message/types';
 
 interface ExtractedCanvasInfo {
@@ -266,12 +266,40 @@ export function hasA2uiCanvasComponent(items: RenderA2uiItem[]): boolean {
 }
 
 /**
- * Checks if a candidate object is a valid A2UI v0.9 update specification item.
+ * Canonical MIME types for A2UI data parts across Google3 and A2A specs.
+ * 'application/a2ui+json' is the primary standard (see SharedWeb A2UI pipeline).
+ * 'application/json+a2ui' is supported as a backward-compatible alias.
+ */
+export const A2UI_MIME_TYPE = 'application/a2ui+json';
+export const LEGACY_A2UI_MIME_TYPE = 'application/json+a2ui';
+
+/** Returns whether the MIME type identifies an A2UI data part. */
+export function isA2uiMimeType(mimeType?: string | null): boolean {
+  return mimeType === A2UI_MIME_TYPE || mimeType === LEGACY_A2UI_MIME_TYPE;
+}
+
+/**
+ * Canonical server-to-client A2UI update keys for both v0.9 and v0.8 protocols.
+ * Follows `isA2uiServerPart` from SharedWeb A2UI pipeline
+ * (google3/java/com/google/learning/agents/ui/sharedweb/a2a/a2ui_helper.ts).
+ */
+export const A2UI_SERVER_UPDATE_KEYS = [
+  'createSurface',
+  'updateComponents',
+  'updateDataModel',
+  'deleteSurface',
+  'beginRendering',
+  'surfaceUpdate',
+  'dataModelUpdate',
+] as const;
+
+/**
+ * Checks if a candidate object is a valid A2UI server-to-client update specification item.
  *
  * An object is recognized as an A2UI item if it contains at least one of the canonical
- * update operation keys ({@link A2UI_UPDATE_KEYS}) with a defined non-null value.
+ * update operation keys ({@link A2UI_SERVER_UPDATE_KEYS}) with a defined non-null value.
  * Used during streaming ingestion to partition genuine A2UI UI payloads from
- * non-A2UI messages (such as agent tool/function calls) so they are preserved
+ * non-A2UI messages (such as agent tool/function calls or echoed client actions) so they are preserved
  * without causing canvas dispatch errors.
  *
  * @param item The candidate object or chunk to inspect.
@@ -280,24 +308,79 @@ export function hasA2uiCanvasComponent(items: RenderA2uiItem[]): boolean {
 export function isA2uiItem(item: unknown): boolean {
   if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
   const obj = item as Record<string, unknown>;
-  return A2UI_UPDATE_KEYS.some(key => key in obj && obj[key] !== undefined && obj[key] !== null);
+  return A2UI_SERVER_UPDATE_KEYS.some(
+    key => key in obj && obj[key] !== undefined && obj[key] !== null,
+  );
 }
 
 /**
  * Normalizes an array of raw layout updates into valid `RenderA2uiItem` specifications,
- * filtering out any non-A2UI objects.
+ * filtering out any non-A2UI objects and deduplicating redundant createSurface commands.
  */
-export function normalizeA2uiItems(items: unknown[]): RenderA2uiItem[] {
+export function normalizeA2uiItems(items: readonly unknown[]): RenderA2uiItem[] {
   if (!items || !Array.isArray(items)) return [];
 
-  return items.filter(isA2uiItem).map(item => {
-    const itemObj = item as Record<string, unknown>;
-    return {
+  const seenSurfaces = new Set<string>();
+  const normalized: RenderA2uiItem[] = [];
+
+  for (const raw of items) {
+    if (!isA2uiItem(raw)) continue;
+    const itemObj = raw as Record<string, unknown>;
+    const item = {
       version:
         typeof itemObj['version'] === 'string' && itemObj['version'] ? itemObj['version'] : 'v0.9',
       ...itemObj,
     } as RenderA2uiItem;
-  });
+
+    if (item.createSurface?.surfaceId) {
+      const surfaceId = item.createSurface.surfaceId;
+      if (seenSurfaces.has(surfaceId)) {
+        continue;
+      }
+      seenSurfaces.add(surfaceId);
+    } else if (item.deleteSurface?.surfaceId) {
+      seenSurfaces.delete(item.deleteSurface.surfaceId);
+    }
+
+    normalized.push(item);
+  }
+
+  return normalized;
+}
+
+/**
+ * Merges newly received A2UI items into an existing payload across streaming chunks.
+ * If newItems re-declares an existing surface via `createSurface`, prior messages for that
+ * surface in existingItems are replaced rather than duplicated.
+ */
+export function mergeA2uiItems(
+  existingItems: readonly RenderA2uiItem[],
+  newItems: readonly RenderA2uiItem[],
+): RenderA2uiItem[] {
+  const normalizedNew = normalizeA2uiItems(newItems);
+  if (!existingItems || existingItems.length === 0) return normalizedNew;
+  if (!normalizedNew || normalizedNew.length === 0) return [...existingItems];
+
+  const newCreateSurfaces = new Set<string>();
+  for (const item of normalizedNew) {
+    if (item.createSurface?.surfaceId) {
+      newCreateSurfaces.add(item.createSurface.surfaceId);
+    }
+  }
+
+  const filteredExisting =
+    newCreateSurfaces.size > 0
+      ? existingItems.filter(item => {
+          const surfaceId =
+            item.createSurface?.surfaceId ??
+            item.updateComponents?.surfaceId ??
+            item.updateDataModel?.surfaceId ??
+            item.deleteSurface?.surfaceId;
+          return surfaceId == null || !newCreateSurfaces.has(surfaceId);
+        })
+      : existingItems;
+
+  return [...filteredExisting, ...normalizedNew];
 }
 
 /**

--- a/shell/src/app/agent-chat/converters/surface-partitioner.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.ts
@@ -266,6 +266,13 @@ export function hasA2uiCanvasComponent(items: RenderA2uiItem[]): boolean {
 }
 
 /**
+ * The only A2UI protocol version Composer speaks.
+ *
+ * Stamped onto outgoing client events and used as the default for inbound items that omit it.
+ */
+export const A2UI_PROTOCOL_VERSION = 'v0.9';
+
+/**
  * Canonical MIME types for A2UI data parts across Google3 and A2A specs.
  * 'application/a2ui+json' is the primary standard (see SharedWeb A2UI pipeline).
  * 'application/json+a2ui' is supported as a backward-compatible alias.
@@ -279,9 +286,11 @@ export function isA2uiMimeType(mimeType?: string | null): boolean {
 }
 
 /**
- * Canonical server-to-client A2UI update keys for both v0.9 and v0.8 protocols.
- * Follows `isA2uiServerPart` from SharedWeb A2UI pipeline
- * (google3/java/com/google/learning/agents/ui/sharedweb/a2a/a2ui_helper.ts).
+ * Canonical server-to-client A2UI v0.9 update keys.
+ *
+ * Mirrors `isA2uiServerPart` from the SharedWeb A2UI pipeline
+ * (google3/java/com/google/learning/agents/ui/sharedweb/a2a/a2ui_helper.ts). Composer only
+ * supports v0.9, so the superseded v0.8 spellings are deliberately absent.
  */
 export const A2UI_SERVER_UPDATE_KEYS = [
   'createSurface',
@@ -289,8 +298,6 @@ export const A2UI_SERVER_UPDATE_KEYS = [
   'updateDataModel',
   'deleteSurface',
   'beginRendering',
-  'surfaceUpdate',
-  'dataModelUpdate',
 ] as const;
 
 /**
@@ -328,7 +335,9 @@ export function normalizeA2uiItems(items: readonly unknown[]): RenderA2uiItem[] 
     const itemObj = raw as Record<string, unknown>;
     const item = {
       version:
-        typeof itemObj['version'] === 'string' && itemObj['version'] ? itemObj['version'] : 'v0.9',
+        typeof itemObj['version'] === 'string' && itemObj['version']
+          ? itemObj['version']
+          : A2UI_PROTOCOL_VERSION,
       ...itemObj,
     } as RenderA2uiItem;
 

--- a/shell/src/app/agent-chat/converters/surface-partitioner.ts
+++ b/shell/src/app/agent-chat/converters/surface-partitioner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {RenderA2uiItem} from 'a2ui-bridge';
+import {A2UI_UPDATE_KEYS, RenderA2uiItem} from 'a2ui-bridge';
 import {CanvasArtifact} from '../chat-message/types';
 
 interface ExtractedCanvasInfo {
@@ -286,25 +286,10 @@ export function isA2uiMimeType(mimeType?: string | null): boolean {
 }
 
 /**
- * Canonical server-to-client A2UI v0.9 update keys.
- *
- * Mirrors `isA2uiServerPart` from the SharedWeb A2UI pipeline
- * (google3/java/com/google/learning/agents/ui/sharedweb/a2a/a2ui_helper.ts). Composer only
- * supports v0.9, so the superseded v0.8 spellings are deliberately absent.
- */
-export const A2UI_SERVER_UPDATE_KEYS = [
-  'createSurface',
-  'updateComponents',
-  'updateDataModel',
-  'deleteSurface',
-  'beginRendering',
-] as const;
-
-/**
  * Checks if a candidate object is a valid A2UI server-to-client update specification item.
  *
  * An object is recognized as an A2UI item if it contains at least one of the canonical
- * update operation keys ({@link A2UI_SERVER_UPDATE_KEYS}) with a defined non-null value.
+ * update operation keys ({@link A2UI_UPDATE_KEYS}) with a defined non-null value.
  * Used during streaming ingestion to partition genuine A2UI UI payloads from
  * non-A2UI messages (such as agent tool/function calls or echoed client actions) so they are preserved
  * without causing canvas dispatch errors.
@@ -315,9 +300,7 @@ export const A2UI_SERVER_UPDATE_KEYS = [
 export function isA2uiItem(item: unknown): boolean {
   if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
   const obj = item as Record<string, unknown>;
-  return A2UI_SERVER_UPDATE_KEYS.some(
-    key => key in obj && obj[key] !== undefined && obj[key] !== null,
-  );
+  return A2UI_UPDATE_KEYS.some(key => key in obj && obj[key] !== undefined && obj[key] !== null);
 }
 
 /**

--- a/shell/src/app/chat/a2a/a2a-types.spec.ts
+++ b/shell/src/app/chat/a2a/a2a-types.spec.ts
@@ -16,15 +16,40 @@
 
 import {describe, it, expect} from 'vitest';
 import {
+  A2aMessageRole,
   A2aProtoTaskState,
   A2aV03TaskState,
   A2aV1TaskState,
   isTerminalTaskState,
+  normalizeMessageRole,
   normalizeTaskState,
   TERMINAL_PROTO_TASK_STATES,
 } from './a2a-types';
 
 describe('a2a-types', () => {
+  describe('normalizeMessageRole', () => {
+    it('maps user spellings across protocol revisions', () => {
+      expect(normalizeMessageRole('user')).toBe(A2aMessageRole.USER);
+      expect(normalizeMessageRole('ROLE_USER')).toBe(A2aMessageRole.USER);
+      expect(normalizeMessageRole('  User  ')).toBe(A2aMessageRole.USER);
+    });
+
+    it('maps agent spellings including assistant and model aliases', () => {
+      expect(normalizeMessageRole('agent')).toBe(A2aMessageRole.AGENT);
+      expect(normalizeMessageRole('ROLE_AGENT')).toBe(A2aMessageRole.AGENT);
+      expect(normalizeMessageRole('assistant')).toBe(A2aMessageRole.AGENT);
+      expect(normalizeMessageRole('model')).toBe(A2aMessageRole.AGENT);
+    });
+
+    it('returns undefined for absent, unrecognized, or non-string roles', () => {
+      expect(normalizeMessageRole(undefined)).toBeUndefined();
+      expect(normalizeMessageRole(null)).toBeUndefined();
+      expect(normalizeMessageRole('')).toBeUndefined();
+      expect(normalizeMessageRole('system')).toBeUndefined();
+      expect(normalizeMessageRole(42)).toBeUndefined();
+    });
+  });
+
   describe('normalizeTaskState', () => {
     it('returns unknown for null, undefined, or empty string', () => {
       expect(normalizeTaskState(null)).toBe('unknown');

--- a/shell/src/app/chat/a2a/a2a-types.ts
+++ b/shell/src/app/chat/a2a/a2a-types.ts
@@ -209,6 +209,48 @@ export interface A2aMessage {
 }
 
 /**
+ * Author of an A2A message, normalized across protocol revisions.
+ *
+ * The wire format varies by transport: v0.3 JSON uses the lowercase spellings, the protobuf
+ * mapping uses the `ROLE_`-prefixed enum names, and some agents emit the OpenAI-style
+ * `assistant`. Use {@link normalizeMessageRole} to collapse those spellings onto this enum.
+ *
+ * This is deliberately separate from the `MessageRole` used by the design-generation chat
+ * pipeline: that enum models our internal LLM conversation (system/user/model/error), whereas
+ * this one mirrors what the A2A protocol puts on the wire.
+ */
+export enum A2aMessageRole {
+  USER = 'user',
+  AGENT = 'agent',
+}
+
+/** Wire spellings that identify a user-authored message. */
+const USER_ROLE_TOKENS: ReadonlySet<string> = new Set(['user', 'role_user']);
+
+/** Wire spellings that identify an agent-authored message. */
+const AGENT_ROLE_TOKENS: ReadonlySet<string> = new Set([
+  'agent',
+  'role_agent',
+  'assistant',
+  'model',
+]);
+
+/**
+ * Maps a raw protocol role onto {@link A2aMessageRole}.
+ *
+ * @param role The role token as it appeared on the wire, in any casing.
+ * @returns The normalized role, or undefined when the value is absent or unrecognized, in which
+ *     case callers should fall back to task state to infer authorship.
+ */
+export function normalizeMessageRole(role: unknown): A2aMessageRole | undefined {
+  if (typeof role !== 'string') return undefined;
+  const token = role.trim().toLowerCase();
+  if (USER_ROLE_TOKENS.has(token)) return A2aMessageRole.USER;
+  if (AGENT_ROLE_TOKENS.has(token)) return A2aMessageRole.AGENT;
+  return undefined;
+}
+
+/**
  * Known A2A v1.0 task states (from protobuf enum mapping).
  */
 export enum A2aV1TaskState {


### PR DESCRIPTION
## Summary

Improves A2A chat streaming ingestion and the agent message UI, and
hardens surface recreation in the preview bridge.

### Bridge
- Pre-delete a surface before recreating it so repeated `createSurface`
  commands cannot collide with a stale renderer instance
  (`Surface <id> already exists`).

### Chat view
- Merge streamed A2UI items per surface instead of blindly appending, so
  a re-declared surface replaces its prior messages.
- Deduplicate repeated thought chunks, including partial-prefix replays.
- Stop minting client-side context IDs. The first turn is sent without
  one so the agent can assign it; later turns replay the ID adopted from
  the stream.
- Tag outgoing a2ui action data parts with `application/a2ui+json` and a
  normalized `{version, action, userAction}` envelope.

### Stream parser
- Route text from non-terminal (`submitted`/`working`) status events to
  the thinking panel instead of the main transcript.
- Filter echoed user messages so the agent does not duplicate the user's
  prompt on the main canvas.

### Chat message
- Replace the thinking accordion with a show/hide thoughts control that
  defaults to expanded while the turn has only reasoning, then collapses
  once visible content streams in. A manual toggle wins until the
  content state changes.
- Add an agent initial avatar and a feedback/copy action bar.
- Style the new elements with `--mat-sys` tokens.

### Surface partitioner
- Own the A2UI server update keys and MIME type constants rather than
  importing them from the bridge.
- Add `mergeA2uiItems` and deduplicate redundant `createSurface`
  commands during normalization.

## Testing

- `yarn test`: 72 files, 1357 tests passing.
- `yarn e2e-headless`: 48 passing.
- `yarn lint` and `yarn prettier` clean.

Existing bridge, parser, and chat view tests were updated for the new
behavior (`processMessages` call counts, action metadata shape, and
status text routing).
