### PR TITLE
Render and download non-image attachments in chat messages

### DIFF
--- a/shell/src/app/agent-chat/chat-message/chat-message.ng.html
+++ b/shell/src/app/agent-chat/chat-message/chat-message.ng.html
@@ -17,13 +17,7 @@
 <div class="message-row" [class]="message().sender">
   @if (message().sender === 'user') {
     <div class="user-message-bubble">
-      @if (hasImages()) {
-        <div class="msg-images-tray">
-          @for (img of message().images; track img.name || img.previewUrl || $index) {
-            <img [src]="img.previewUrl || img.data" [alt]="img.name" class="msg-image-thumb" />
-          }
-        </div>
-      }
+      <ng-container [ngTemplateOutlet]="attachmentTray"></ng-container>
       {{ message().text }}
     </div>
   } @else {
@@ -40,13 +34,7 @@
       </div>
 
       <div class="agent-message-body">
-        @if (hasImages()) {
-          <div class="msg-images-tray">
-            @for (img of message().images; track img.name || img.previewUrl || $index) {
-              <img [src]="img.previewUrl || img.data" [alt]="img.name" class="msg-image-thumb" />
-            }
-          </div>
-        }
+        <ng-container [ngTemplateOutlet]="attachmentTray"></ng-container>
 
         @if (message().thinking) {
           <div class="thinking-container">
@@ -167,3 +155,29 @@
     </div>
   }
 </div>
+
+<ng-template #attachmentTray>
+  @if (attachments().length > 0) {
+    <div class="msg-images-tray">
+      @for (attachment of attachments(); track attachment.key) {
+        @if (attachment.previewSrc) {
+          <img [src]="attachment.previewSrc" [alt]="attachment.file.name" class="msg-image-thumb" />
+        } @else {
+          <button
+            type="button"
+            class="msg-file-chip"
+            (click)="downloadAttachment(attachment.file)"
+            [attr.aria-label]="'Download ' + attachment.file.name"
+            [matTooltip]="'Download ' + attachment.file.name"
+          >
+            <mat-icon class="msg-file-icon">{{ attachment.icon }}</mat-icon>
+            <span class="msg-file-name" [title]="attachment.file.name">
+              {{ attachment.file.name }}
+            </span>
+            <mat-icon class="msg-file-download-icon">download</mat-icon>
+          </button>
+        }
+      }
+    </div>
+  }
+</ng-template>

--- a/shell/src/app/agent-chat/chat-message/chat-message.scss
+++ b/shell/src/app/agent-chat/chat-message/chat-message.scss
@@ -23,6 +23,67 @@
   width: 100%;
   box-sizing: border-box;
 
+  // The attachment tray is shared by user and agent bubbles, so its download
+  // chips are styled once here instead of once per sender.
+  .msg-file-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 6px 12px;
+    border: 1px solid var(--mat-sys-outline-variant);
+    border-radius: 10px;
+    background: var(--mat-sys-surface-container);
+    // Undo the user agent's button styling.
+    appearance: none;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease;
+
+    &:hover {
+      background: var(--mat-sys-surface-container-high);
+      border-color: var(--mat-sys-primary);
+    }
+
+    .msg-file-icon {
+      flex-shrink: 0;
+      width: 20px;
+      height: 20px;
+      // Material Symbols are sized in px, matching the box they occupy.
+      font-size: 20px;
+      color: var(--mat-sys-primary);
+    }
+
+    .msg-file-name {
+      overflow: hidden;
+      font-size: var(--mat-sys-label-medium-size);
+      font-weight: var(--mat-sys-label-medium-weight);
+      color: var(--mat-sys-on-surface);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .msg-file-download-icon {
+      flex-shrink: 0;
+      width: 16px;
+      height: 16px;
+      margin-left: 2px;
+      font-size: 16px;
+      color: var(--mat-sys-on-surface-variant);
+      opacity: 0.6;
+    }
+
+    &:hover .msg-file-download-icon,
+    &:focus-visible .msg-file-download-icon {
+      color: var(--mat-sys-primary);
+      opacity: 1;
+    }
+  }
+
   &.user {
     justify-content: flex-end;
 

--- a/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {DOCUMENT} from '@angular/common';
 import {signal} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -265,6 +266,148 @@ describe('A2aChatMessage', () => {
     fixture.detectChanges();
 
     expect(await harness.getImageCount()).toBe(1);
+    expect(await harness.getFileChipCount()).toBe(0);
+  });
+
+  it('renders non-image attachments as download chips', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-files',
+      sender: 'user',
+      text: 'Here are the docs',
+      timestamp: Date.now(),
+      images: [
+        {name: 'document.pdf', mimeType: 'application/pdf', data: 'cGRm'},
+        {
+          name: 'contract.docx',
+          mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          data: 'ZG9jeA==',
+        },
+        {name: 'notes.txt', mimeType: 'text/plain', data: 'dHh0'},
+      ],
+    });
+    fixture.detectChanges();
+
+    expect(await harness.getFileChipCount()).toBe(3);
+    expect(await harness.getImageCount()).toBe(0);
+  });
+
+  it('renders the same attachment tray for user and agent messages', async () => {
+    const images = [{name: 'document.pdf', mimeType: 'application/pdf', data: 'cGRm'}];
+    for (const sender of ['user', 'agent']) {
+      fixture.componentRef.setInput('message', {
+        id: `msg-${sender}`,
+        sender,
+        text: 'See attached',
+        timestamp: Date.now(),
+        images,
+      });
+      fixture.detectChanges();
+
+      expect(await harness.getFileChipCount()).toBe(1);
+    }
+  });
+
+  it('does not preview an image attachment under a non-image MIME type', async () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-spoofed',
+      sender: 'agent',
+      text: 'Done',
+      timestamp: Date.now(),
+      images: [{name: 'photo.png', mimeType: 'text/html', data: 'PGI+aGk8L2I+'}],
+    });
+    fixture.detectChanges();
+
+    expect(await harness.getImageCount()).toBe(0);
+    expect(await harness.getFileChipCount()).toBe(1);
+  });
+
+  it('reuses a locally generated preview and skips previews without data', () => {
+    fixture.componentRef.setInput('message', {
+      id: 'msg-preview',
+      sender: 'user',
+      text: 'See attached',
+      timestamp: Date.now(),
+      images: [
+        {name: 'local.png', mimeType: 'image/png', data: 'aW1n', previewUrl: 'blob:local-preview'},
+        {
+          name: 'inline.png',
+          mimeType: 'image/png',
+          data: 'aW1n',
+          previewUrl: 'data:image/png;base64,aW1n',
+        },
+        {
+          name: 'remote.png',
+          mimeType: 'image/png',
+          data: 'aW1n',
+          previewUrl: 'https://example.test/remote.png',
+        },
+        {name: 'empty.png', mimeType: 'image/png', data: ''},
+      ],
+    });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['attachments']().map(a => a.previewSrc)).toEqual([
+      'blob:local-preview',
+      'data:image/png;base64,aW1n',
+      // A preview URL the component did not build is ignored in favour of the
+      // attachment's own payload.
+      'data:image/png;base64,aW1n',
+      '',
+    ]);
+  });
+
+  it('downloads an attachment as an opaque blob under a sanitized name', async () => {
+    const injectedDocument = TestBed.inject(DOCUMENT);
+    const anchor = injectedDocument.createElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    const createElementSpy = vi
+      .spyOn(injectedDocument, 'createElement')
+      .mockImplementation(() => anchor);
+    const createObjectUrlSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:fake-object-url');
+    const revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    try {
+      fixture.componentInstance['downloadAttachment']({
+        name: '../../etc/report.pdf',
+        mimeType: 'text/html',
+        data: 'cGRmZGF0YQ==',
+      });
+
+      expect(clickSpy).toHaveBeenCalled();
+      expect(anchor.download).toBe('report.pdf');
+      // The agent's MIME type must not reach the blob.
+      const blob = createObjectUrlSpy.mock.calls[0][0] as Blob;
+      expect(blob.type).toBe('application/octet-stream');
+      // The URL has to outlive the click for the download to start.
+      expect(revokeObjectUrlSpy).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+      expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:fake-object-url');
+    } finally {
+      vi.useRealTimers();
+      createElementSpy.mockRestore();
+      createObjectUrlSpy.mockRestore();
+      revokeObjectUrlSpy.mockRestore();
+    }
+  });
+
+  it('does nothing when an attachment has no decodable content', () => {
+    const createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL');
+
+    try {
+      fixture.componentInstance['downloadAttachment']({
+        name: 'empty.pdf',
+        mimeType: 'application/pdf',
+        data: '',
+      });
+
+      expect(createObjectUrlSpy).not.toHaveBeenCalled();
+    } finally {
+      createObjectUrlSpy.mockRestore();
+    }
   });
 
   it('emits openCanvas and closeCanvas when canvas button is clicked on A2UI payload with hasCanvas', async () => {

--- a/shell/src/app/agent-chat/chat-message/chat-message.ts
+++ b/shell/src/app/agent-chat/chat-message/chat-message.ts
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-import {Component, computed, input, output, signal} from '@angular/core';
+import {DOCUMENT, NgTemplateOutlet} from '@angular/common';
+import {Component, computed, inject, input, output, signal} from '@angular/core';
 import {MatButtonModule} from '@angular/material/button';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatIconModule} from '@angular/material/icon';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {RenderA2uiItem} from 'a2ui-bridge';
+import {objectUrlFromSafeSource, setAnchorHref} from 'safevalues/dom';
+import {
+  decodeBase64,
+  getMaterialFileIcon,
+  inferMimeType,
+  isImageAttachment,
+  sanitizeDownloadFileName,
+} from '../../chat/a2a/a2a-attachments';
 import {RenderedFrame} from '../../preview/rendered/rendered-frame';
 import {renderMarkdown} from '../../utils/markdown';
 import {A2A_PROTOCOL_ICON_URL} from '../converters/a2a-ui-converter';
-import {CanvasArtifact, UiMessage} from './types';
+import {CanvasArtifact, UiAttachedImage, UiMessage} from './types';
 
 /**
  * A user's explicit expand/collapse choice for the thinking accordion, tagged with the
@@ -33,6 +42,62 @@ import {CanvasArtifact, UiMessage} from './types';
 interface ManualThinkingToggle {
   readonly hadContent: boolean;
   readonly expanded: boolean;
+}
+
+/** One attachment of a message, prepared for rendering. */
+interface AttachmentView {
+  /** The attachment itself, passed back when the user downloads it. */
+  readonly file: UiAttachedImage;
+  /** Stable key for `@for` tracking. */
+  readonly key: string;
+  /** `src` of the inline preview, or '' when the attachment is not previewable. */
+  readonly previewSrc: string;
+  /** Material Symbols glyph shown on the download chip. */
+  readonly icon: string;
+}
+
+/**
+ * MIME type given to every downloaded attachment.
+ *
+ * The attachment's own type is agent controlled, and letting it decide how the
+ * browser treats the file would allow, say, an HTML payload to be opened in
+ * the page's origin rather than saved.
+ */
+const DOWNLOAD_MIME_TYPE = 'application/octet-stream';
+
+/** Prefix of MIME types that may be previewed inline. */
+const IMAGE_MIME_PREFIX = 'image/';
+
+/**
+ * Delay before a download's object URL is released.
+ *
+ * Browsers resolve the URL asynchronously after the click, so releasing it in
+ * the same task cancels the download in some of them.
+ */
+const OBJECT_URL_REVOKE_DELAY_MS = 100;
+
+/** URL prefixes accepted for a locally generated image preview. */
+const LOCAL_PREVIEW_PREFIXES: readonly string[] = ['data:image/', 'blob:'];
+
+/**
+ * Returns the `src` of an attachment's inline preview, or '' if it has none.
+ *
+ * Only images are previewed, and only under an image MIME type, so an agent
+ * cannot get an attachment rendered as something other than a picture.
+ */
+function imagePreviewSrc(file: UiAttachedImage): string {
+  if (!isImageAttachment(file.mimeType, file.name)) {
+    return '';
+  }
+  const previewUrl = file.previewUrl ?? '';
+  if (LOCAL_PREVIEW_PREFIXES.some(prefix => previewUrl.startsWith(prefix))) {
+    return previewUrl;
+  }
+  const mimeType = inferMimeType(file.name, file.mimeType);
+  if (!file.data || !mimeType.startsWith(IMAGE_MIME_PREFIX)) {
+    return '';
+  }
+  return `data:${mimeType};base64,${file.data}`;
 }
 
 /**
@@ -47,12 +112,15 @@ interface ManualThinkingToggle {
     MatExpansionModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
+    NgTemplateOutlet,
     RenderedFrame,
   ],
   templateUrl: './chat-message.ng.html',
   styleUrl: './chat-message.scss',
 })
 export class A2aChatMessage {
+  private readonly document = inject(DOCUMENT);
+
   /** UI message object containing sender role, text, thinking trace, and optional A2UI payload. */
   readonly message = input.required<UiMessage>();
   /** URL for the agent's display avatar icon. */
@@ -129,9 +197,21 @@ export class A2aChatMessage {
     return m.inlineA2uiPayload || (!m.hasCanvas ? m.a2uiPayload : undefined);
   });
 
-  protected readonly hasImages = computed<boolean>(() => {
-    return Boolean(this.message().images?.length);
-  });
+  /**
+   * Attachments of this message, prepared for rendering.
+   *
+   * Classifying attachments here rather than in the template keeps the work
+   * off the change detection path, where it would rerun for every attachment
+   * on every cycle.
+   */
+  protected readonly attachments = computed<AttachmentView[]>(() =>
+    (this.message().images ?? []).map((file, index) => ({
+      file,
+      key: `${index}:${file.name}`,
+      previewSrc: imagePreviewSrc(file),
+      icon: getMaterialFileIcon(file.mimeType, file.name),
+    })),
+  );
 
   /**
    * Whether the message has streamed any user-visible, non-thinking content yet.
@@ -240,6 +320,35 @@ export class A2aChatMessage {
   protected openCanvasArtifact(payload: RenderA2uiItem[]): void {
     if (payload?.length) {
       this.openCanvas.emit(payload);
+    }
+  }
+
+  /**
+   * Saves an attachment to the user's machine.
+   *
+   * The payload is decoded and handed to the browser as an opaque binary blob
+   * so that neither the file's contents nor its agent-supplied MIME type can
+   * cause it to be rendered in this origin instead of saved.
+   */
+  protected downloadAttachment(file: UiAttachedImage): void {
+    const bytes = decodeBase64(file.data);
+    if (!bytes) {
+      console.warn('Attachment has no decodable content to download', file.name);
+      return;
+    }
+
+    const objectUrl = objectUrlFromSafeSource(new Blob([bytes], {type: DOWNLOAD_MIME_TYPE}));
+    try {
+      const link = this.document.createElement('a');
+      setAnchorHref(link, objectUrl);
+      link.download = sanitizeDownloadFileName(file.name);
+      link.click();
+    } finally {
+      // The blob stays alive until the URL is released. `URL` is the same
+      // global that safevalues created the object URL from.
+      setTimeout(() => {
+        URL.revokeObjectURL(objectUrl.toString());
+      }, OBJECT_URL_REVOKE_DELAY_MS);
     }
   }
 }

--- a/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
+++ b/shell/src/app/agent-chat/chat-message/test/chat-message.harness.ts
@@ -32,6 +32,7 @@ export class A2aChatMessageHarness extends ComponentHarness {
     MatButtonHarness.with({selector: '.close-canvas-btn'}),
   );
   private getImageElements = this.locatorForAll('.msg-image-thumb');
+  private getFileChips = this.locatorForAll('.msg-file-chip');
   private getToolChips = this.locatorForAll('.tool-call-chip');
   private getPendingIndicator = this.locatorForOptional('.pending-response-indicator');
   private getStreamingCursor = this.locatorForOptional('.streaming-cursor');
@@ -101,6 +102,16 @@ export class A2aChatMessageHarness extends ComponentHarness {
   async getImageCount(): Promise<number> {
     const images = await this.getImageElements();
     return images.length;
+  }
+
+  async getFileChipCount(): Promise<number> {
+    const chips = await this.getFileChips();
+    return chips.length;
+  }
+
+  async clickFileChip(index: number): Promise<void> {
+    const chips = await this.getFileChips();
+    return chips[index].click();
   }
 
   async getToolCallCount(): Promise<number> {

--- a/shell/src/app/agent-chat/chat-message/types.ts
+++ b/shell/src/app/agent-chat/chat-message/types.ts
@@ -18,16 +18,19 @@ import {RenderA2uiItem} from 'a2ui-bridge';
 import {A2aMessage} from '../../chat/a2a/a2a-types';
 
 /**
- * Image attachment payload attached to a chat message.
+ * File attached to a chat message.
+ *
+ * Named for images for historical reasons; it carries attachments of any kind,
+ * and only images have a `previewUrl`.
  */
 export interface UiAttachedImage {
-  /** Name of the attached image file. */
+  /** Name of the attached file. */
   name: string;
-  /** MIME content type of the image (e.g. 'image/png'). */
+  /** MIME content type of the file (e.g. 'application/pdf'). */
   mimeType: string;
-  /** Base64-encoded raw binary data of the image. */
+  /** Base64-encoded raw binary content of the file. */
   data: string;
-  /** Optional object URL or data URI used for local image preview. */
+  /** Optional object URL or data URI used for a local image preview. */
   previewUrl?: string;
 }
 


### PR DESCRIPTION
# Description

Every attachment was rendered as `<img src="...">`, so a PDF or a
spreadsheet appeared as a broken image with no way to open it. Non-image
attachments now render as a download chip with a type-specific icon, and
images keep their inline preview.

The attachment tray was duplicated between the user and agent branches
of the template, and its styles were duplicated again in the stylesheet.
Both are now declared once, as an `ng-template` rendered from both
branches and a single rule on `.message-row`.

Two things are deliberately conservative, because attachment metadata on
agent messages is agent controlled:

*   Downloads decode the payload and hand the browser an
    `application/octet-stream` blob through `objectUrlFromSafeSource`,
    instead of building a `data:` URL from the reported MIME type.
    `sanitizeUrl` would not have helped here: it accepts `data:` URLs
    without inspecting their MIME type. The file name is stripped of
    directory components and control characters, and the object URL is
    revoked once the download starts.
*   An attachment is only previewed inline if it resolves to an image
    MIME type, so a payload cannot be rendered as something other than a
    picture.

Classification now happens in a `computed` view model rather than
through template method calls, which ran once per attachment on every
change detection cycle. The chip is a real `<button>`, so it is keyboard
operable with both Enter and Space and gets a focus ring.

This is change 3 of 6 in a stack and targets `feat/input-area-file-attachments`.

## Upstreaming notes

`objectUrlFromSafeSource` is imported from `safevalues/dom`, which is
the entry point that exports it in the published package.

## Verification

`yarn prettier:check`, `yarn lint`, `yarn tsc` and `yarn test` pass on the
tip of the stack.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
