### PR TITLE
Keep A2UI protocol traffic out of the agent transcript

### DIFF
--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.spec.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.spec.ts
@@ -480,7 +480,7 @@ describe('A2aStreamEventParser', () => {
     expect(parsed.isCompleted).toBe(true);
   });
 
-  it('routes echoed user prompt in TASK_STATE_SUBMITTED to thoughtChunk so agent does not duplicate user text on main canvas', () => {
+  it('drops the echoed user prompt in TASK_STATE_SUBMITTED from the agent transcript', () => {
     const event: TaskStatusUpdateEvent = {
       taskId: 'task-user-echo',
       contextId: 'ctx-user-echo',
@@ -499,7 +499,114 @@ describe('A2aStreamEventParser', () => {
 
     const parsed = parser.parse(event);
     expect(parsed.textChunk).toBeUndefined();
-    expect(parsed.thoughtChunk).toBe('hi');
+    expect(parsed.thoughtChunk).toBeUndefined();
+  });
+
+  it('does not render A2UI action echoes into the transcript', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-action-data',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [
+          {
+            data: {
+              version: 'v0.9',
+              action: {
+                name: 'select_legal_team',
+                surfaceId: 'coco_contract_form',
+                sourceComponentId: 'submit_button',
+                context: {team_id: '25'},
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toBeUndefined();
+    expect(parsed.a2uiItems.length).toBe(0);
+    expect(parsed.toolCalls ?? []).toEqual([]);
+  });
+
+  it('does not render A2UI action echoes sent as stringified JSON', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-action-string',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [
+          {
+            data: {
+              data: JSON.stringify({
+                name: 'select_legal_team',
+                surfaceId: 'coco_contract_form',
+                context: {team_id: '25'},
+              }),
+            },
+          },
+        ],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toBeUndefined();
+    // The action's `name` must not be mistaken for a tool invocation.
+    expect(parsed.toolCalls ?? []).toEqual([]);
+  });
+
+  it('recognises an action echo from any single marker field', () => {
+    for (const marker of ['surfaceId', 'sourceComponentId', 'context']) {
+      const event: TaskStatusUpdateEvent = {
+        taskId: `task-action-${marker}`,
+        message: {
+          role: 'ROLE_AGENT',
+          parts: [{data: {name: 'select_legal_team', [marker]: 'coco_contract_form'}}],
+        },
+      };
+
+      const parsed = parser.parse(event);
+      expect(parsed.textChunk, marker).toBeUndefined();
+      expect(parsed.toolCalls ?? [], marker).toEqual([]);
+    }
+  });
+
+  it('still reports a named payload that carries no action markers as a tool call', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-tool-call',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [{data: {name: 'lookup_weather', args: {city: 'Zurich'}}}],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.toolCalls?.map(call => call.name)).toEqual(['lookup_weather']);
+  });
+
+  it('still renders generic structured data as a JSON code block', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-generic-data',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [{data: {temperature: 21, unit: 'C'}}],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toContain('"temperature": 21');
+  });
+
+  it('still renders data whose nested action carries no protocol markers', () => {
+    const event: TaskStatusUpdateEvent = {
+      taskId: 'task-nested-action-data',
+      message: {
+        role: 'ROLE_AGENT',
+        parts: [{data: {action: {status: 'pending'}}}],
+      },
+    };
+
+    const parsed = parser.parse(event);
+    expect(parsed.textChunk).toContain('"status": "pending"');
   });
 
   it('filters out user messages with role user outside of task submission', () => {

--- a/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
+++ b/shell/src/app/agent-chat/converters/a2a-stream-event-parser.service.ts
@@ -29,6 +29,7 @@ import {
   TaskStatusUpdateEvent,
 } from '../../chat/a2a/a2a-types';
 import {UiToolCall} from '../chat-message/types';
+import {asRecord} from '../../utils/json';
 
 import {isA2uiItem, normalizeA2uiItems} from './surface-partitioner';
 
@@ -104,6 +105,39 @@ export function extractToolCall(item: unknown): UiToolCall | null {
     };
   }
   return null;
+}
+
+/**
+ * Fields that only an A2UI action carries.
+ *
+ * An action is identified by its `name` plus at least one of these, which
+ * distinguishes it from the many other payloads that happen to have a `name`.
+ */
+const A2UI_ACTION_MARKER_FIELDS: readonly string[] = ['context', 'sourceComponentId', 'surfaceId'];
+
+/** Key under which an A2UI action may be nested in a data part. */
+const A2UI_ACTION_WRAPPER_FIELD = 'action';
+
+/**
+ * Whether a data part is an A2UI client action echoed back by the agent.
+ *
+ * Actions describe what the user did on a surface. They are part of the
+ * protocol rather than something the agent said, so they must not be rendered
+ * into the transcript.
+ */
+function isA2uiActionEcho(data: unknown): boolean {
+  const record = asRecord(data);
+  if (!record) {
+    return false;
+  }
+  const nestedAction = asRecord(record[A2UI_ACTION_WRAPPER_FIELD]);
+  if (nestedAction) {
+    return isA2uiActionEcho(nestedAction);
+  }
+  return (
+    typeof record['name'] === 'string' &&
+    A2UI_ACTION_MARKER_FIELDS.some(field => record[field] !== undefined)
+  );
 }
 
 /**
@@ -303,8 +337,9 @@ export class A2aStreamEventParser {
     }
 
     const msgRecord = primaryMessage as Record<string, unknown>;
-    // Outside of non-completed status, filter out user messages.
-    if (this.isUserMessage(msgRecord, unwrapped) && !isNonCompleted) {
+    // Agents echo the prompt back while a task is in flight. The chat view
+    // already shows the user's turn, so never repeat it in the agent's.
+    if (this.isUserMessage(msgRecord, unwrapped)) {
       return;
     }
 
@@ -522,6 +557,13 @@ export class A2aStreamEventParser {
       result.a2uiItems.push(...a2uiNormalized);
     }
 
+    // An action echo reports what the user did on a surface. It is protocol
+    // traffic rather than agent output, so it is neither a tool call nor
+    // something to print, however closely it resembles one.
+    if (isA2uiActionEcho(unwrappedData)) {
+      return;
+    }
+
     // Extract tool calls
     const toolCalls = this.extractToolCallsFromItems(items);
     if (toolCalls.length > 0) {
@@ -562,11 +604,17 @@ export class A2aStreamEventParser {
 
     const envelope = data as {mimeType?: string; data?: unknown; name?: string};
 
-    // Case 1: Stringified JSON array (e.g. serialized A2UI component list)
-    if (typeof envelope.data === 'string' && envelope.data.trim().startsWith('[')) {
-      try {
-        return {unwrappedData: JSON.parse(envelope.data), isMedia: false};
-      } catch {}
+    // Case 1: Stringified JSON (e.g. a serialized A2UI component list or action)
+    if (typeof envelope.data === 'string') {
+      const trimmed = envelope.data.trim();
+      if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+        try {
+          return {unwrappedData: JSON.parse(trimmed), isMedia: false};
+        } catch {
+          // Not JSON after all; fall through to the remaining cases. The
+          // stream must keep flowing whatever a payload turns out to be.
+        }
+      }
     }
 
     // Case 2: Base64 media data payload (image, audio, video, PDF)

--- a/shell/src/app/utils/json.ts
+++ b/shell/src/app/utils/json.ts
@@ -93,3 +93,16 @@ export function tryParseJsonArray(content?: string | null): unknown[] | null {
 export function formatJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
+
+/**
+ * Narrows a parsed JSON value to an indexable object.
+ *
+ * @param value The value to narrow, typically decoded from an agent payload.
+ * @return The value as a record, or null if it is not a plain object.
+ */
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}


### PR DESCRIPTION
# Description

Two kinds of protocol traffic were being rendered to the user as if the
agent had said them:

*   A2UI action echoes. When the user activates a control on a surface,
    the action is reported back on the stream. Having no other handling,
    it fell through to the "generic structured data" branch and was
    printed as a JSON code block under the agent's reply. Worse, an
    action carries a `name`, so the tool call extractor also claimed it
    and drew a tool chip.
*   The user's own prompt, which agents echo while a task is in flight.
    It was routed to the thinking panel, where it appeared as the agent
    thinking the user's words back at them.

Action echoes are now recognized by their protocol marker fields and
skipped, and echoed user messages are dropped in all task states since
the chat view already renders the user's turn. Any A2UI items carried
alongside an action are still extracted, and genuinely generic data is
still rendered as before.

The data envelope unwrapper also accepts stringified JSON objects, not
just arrays, so an action serialized as a string is recognized rather
than printed.

This matches how Gemini Enterprise renders the same stream.

This is change 4 of 6 in a stack and targets `feat/chat-message-attachment-download`.

## Verification

`yarn prettier:check`, `yarn lint`, `yarn tsc` and `yarn test` pass on the
tip of the stack.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
