### PR TITLE
Show the action's prompt, not its name, when a surface is submitted

### DIFF
--- a/shell/src/app/agent-chat/a2a-chat-view.spec.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.spec.ts
@@ -662,7 +662,7 @@ describe('A2aChatView', () => {
     // User turn
     const userMsg = messages[0];
     expect(userMsg.sender).toBe('user');
-    expect(userMsg.text).toBe('Action: select_demo');
+    expect(userMsg.text).toBe('User action triggered.');
 
     // Transport call verification
     expect(mockA2aTransport.sendMessageStream).toHaveBeenCalledWith(
@@ -670,7 +670,7 @@ describe('A2aChatView', () => {
       expect.objectContaining({
         role: 'user',
         parts: expect.arrayContaining([
-          {text: 'Action: select_demo'},
+          {text: 'User action triggered.'},
           expect.objectContaining({
             // The v0.9 schema permits exactly `version` and `action`.
             data: {
@@ -691,6 +691,79 @@ describe('A2aChatView', () => {
     const agentMsg = messages[1];
     expect(agentMsg.sender).toBe('agent');
     expect(agentMsg.text).toBe('Hello from mock streaming!');
+  });
+
+  it('shows context.prompt as the user turn when the action supplies one', async () => {
+    mockMessageStream$.next({
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {
+        version: 'v0.9',
+        action: {
+          name: 'select_demo',
+          context: {prompt: '  Select Material Demo  ', demoId: 'material_gallery'},
+        },
+      },
+      origin: 'http://localhost:3000',
+      timestamp: Date.now(),
+    });
+
+    await fixture.whenStable();
+
+    const messages = fixture.componentInstance['messages']();
+    const userMsg = messages[messages.length - 2];
+    expect(userMsg.sender).toBe('user');
+    expect(userMsg.text).toBe('Select Material Demo');
+
+    expect(mockA2aTransport.sendMessageStream).toHaveBeenCalledWith(
+      'http://localhost:8000',
+      expect.objectContaining({
+        role: 'user',
+        parts: expect.arrayContaining([{text: 'Select Material Demo'}]),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('reads context.prompt from an action nested under event', async () => {
+    mockMessageStream$.next({
+      type: PreviewBridgeMessageType.SEND_TO_SERVER,
+      payload: {
+        version: 'v0.9',
+        action: {event: {name: 'submit', context: {prompt: 'Review my contract'}}},
+      },
+      origin: 'http://localhost:3000',
+      timestamp: Date.now(),
+    });
+
+    await fixture.whenStable();
+
+    const messages = fixture.componentInstance['messages']();
+    expect(messages[messages.length - 2].text).toBe('Review my contract');
+  });
+
+  it('falls back to generic action text for blank or non-string prompts', async () => {
+    for (const context of [{prompt: '   '}, {prompt: 42}, {}]) {
+      mockMessageStream$.next({
+        type: PreviewBridgeMessageType.SEND_TO_SERVER,
+        payload: {version: 'v0.9', action: {name: 'submit', context}},
+        origin: 'http://localhost:3000',
+        timestamp: Date.now(),
+      });
+
+      await fixture.whenStable();
+
+      const messages = fixture.componentInstance['messages']();
+      expect(messages[messages.length - 2].text).toBe('User action triggered.');
+    }
+  });
+
+  it('falls back to generic action text when the action is not an object', async () => {
+    fixture.componentInstance['handleSendToServerAction']('not an action object');
+
+    await fixture.whenStable();
+
+    const messages = fixture.componentInstance['messages']();
+    expect(messages[messages.length - 2].text).toBe('User action triggered.');
   });
 
   it('handles falsy actions like boolean false or number 0 in handleSendToServerAction without dropping them', async () => {

--- a/shell/src/app/agent-chat/a2a-chat-view.ts
+++ b/shell/src/app/agent-chat/a2a-chat-view.ts
@@ -30,6 +30,7 @@ import {
   AppConfigProvider,
 } from '../settings/app-config-provider/app-config-provider';
 import {HostCommunication} from '../shell/host-communication/host-communication';
+import {asRecord} from '../utils/json';
 import {isValidEndpointUrl, normalizeHttpUrl} from '../utils/url';
 import {generateUuid as uuid} from '../utils/uuid';
 
@@ -62,6 +63,40 @@ import {MessageInspectorEvent} from './message-inspector/message-inspector-event
  * rewrite of the current step from the start of a new one.
  */
 const THOUGHT_STEP_SEPARATOR = '\n\n';
+
+/** Text shown for a surface action that does not describe itself. */
+const DEFAULT_USER_ACTION_TEXT = 'User action triggered.';
+
+/**
+ * Key under which a surface may nest the action proper.
+ *
+ * The caller has already unwrapped the v0.9 `{version, action}` envelope, so
+ * only the surface's own `event` wrapper remains to be peeled.
+ */
+const ACTION_WRAPPER_FIELD = 'event';
+
+/**
+ * Returns the chat text for a user action submitted from a surface.
+ *
+ * Surfaces may supply `context.prompt`, which reads as something the user
+ * would have typed. Anything else, including the action's internal `name`, is
+ * an implementation detail, so it falls back to a generic phrase rather than
+ * exposing the wire format to the user.
+ */
+function resolveUserActionText(action: unknown): string {
+  const outer = asRecord(action);
+  if (!outer) {
+    return DEFAULT_USER_ACTION_TEXT;
+  }
+
+  const inner = asRecord(outer[ACTION_WRAPPER_FIELD]) ?? outer;
+  const context = asRecord(inner['context']) ?? asRecord(outer['context']);
+  const prompt = context?.['prompt'];
+  if (typeof prompt !== 'string') {
+    return DEFAULT_USER_ACTION_TEXT;
+  }
+  return prompt.trim() || DEFAULT_USER_ACTION_TEXT;
+}
 
 /**
  * Top-level view container managing end-to-end Agent-to-Agent (A2A) testing,
@@ -339,16 +374,7 @@ export class A2aChatView implements OnInit {
 
     const contextId = this.activeContextId();
 
-    let actionText = 'User action triggered.';
-    if (typeof action === 'object' && action !== null) {
-      const obj = action as Record<string, unknown>;
-      const eventObj = (obj['event'] || obj) as Record<string, unknown>;
-      if (typeof eventObj['name'] === 'string' && eventObj['name']) {
-        actionText = `Action: ${eventObj['name']}`;
-      } else if (typeof obj['name'] === 'string' && obj['name']) {
-        actionText = `Action: ${obj['name']}`;
-      }
-    }
+    const actionText = resolveUserActionText(action);
 
     const userUiMessage: UiMessage = {
       id: uuid(),


### PR DESCRIPTION
# Description

Activating a control on an A2UI surface posted `Action:
select_legal_team` as the user's turn, exposing a wire-format identifier
in the conversation.

Surfaces can describe an action in human terms through `context.prompt`.
That text is now used as the user's turn, so the transcript reads as if
the user had typed it. Actions without a usable prompt fall back to a
generic phrase rather than leaking the identifier. This matches Gemini
Enterprise.

The resolution logic moves out of the event handler into a module-level
function with a type guard, replacing a chain of casts that assumed the
nested `event`, `action` and `context` values were objects.

This is change 5 of 6 in a stack and targets `fix/a2ui-protocol-echo-filtering`.

## Verification

`yarn prettier:check`, `yarn lint`, `yarn tsc` and `yarn test` pass on the
tip of the stack.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
