### PR TITLE
Stop double-framing inline A2UI surfaces in chat

### DIFF
--- a/shell/src/app/agent-chat/chat-message/chat-message.scss
+++ b/shell/src/app/agent-chat/chat-message/chat-message.scss
@@ -323,21 +323,22 @@
           }
         }
 
+        // The A2UI payload draws its own cards. Framing the surface here would
+        // put a second border and shadow around every one of them, so the host
+        // is only a sizing slot.
         .inline-surface-card {
           width: 100%;
           min-width: 320px;
           max-width: 800px;
-          background: #ffffff;
-          border: 1px solid #dadce0;
-          border-radius: 12px;
-          overflow: hidden;
           margin-top: 8px;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 
           a2ui-composer-rendered-frame {
             display: block;
             width: 100%;
-            min-height: 280px;
+
+            ::ng-deep .rendered-frame-container {
+              background-color: transparent;
+            }
           }
         }
 

--- a/shell/src/app/preview/rendered/rendered-frame.ng.html
+++ b/shell/src/app/preview/rendered/rendered-frame.ng.html
@@ -16,7 +16,8 @@
 <div
   class="rendered-frame-container"
   [class.is-locked]="isLocked()"
-  [style.height]="frameHeight() ? frameHeight() + 'px' : '100%'"
+  [style.height]="frameHeightPx() ?? '100%'"
+  [style.min-height]="frameHeightPx()"
 >
   @if (safeRendererUrl()) {
     <iframe
@@ -25,6 +26,7 @@
       sandbox="allow-scripts allow-same-origin allow-forms"
       class="preview-iframe"
       title="Rendered Preview"
+      [style.min-height]="frameHeightPx()"
       (load)="syncPayloadOnIframeLoad()"
     ></iframe>
   } @else {

--- a/shell/src/app/preview/rendered/rendered-frame.spec.ts
+++ b/shell/src/app/preview/rendered/rendered-frame.spec.ts
@@ -326,6 +326,18 @@ describe('RenderedFrame Live Preview Viewport', () => {
     expect(newFixture.componentInstance.frameHeight()).toBe(520);
   });
 
+  it('exposes a reported height as a CSS length and none otherwise', () => {
+    const component = fixture.componentInstance;
+    expect(component['frameHeightPx']()).toBeUndefined();
+
+    component.dynamicHeight.set(320);
+    expect(component['frameHeightPx']()).toBe('320px');
+
+    // A guest reporting no usable height must not pin the container's height.
+    component.dynamicHeight.set(0);
+    expect(component['frameHeightPx']()).toBeUndefined();
+  });
+
   it('re-dispatches sendRenderA2UI when RENDERER_READY or A2UI_CATALOG arrives from bridge', () => {
     const payload = [{version: 'v0.9', createSurface: {surfaceId: 's1', catalogId: 'c1'}}];
     const messageStreamSignal = signal<unknown>(null);

--- a/shell/src/app/preview/rendered/rendered-frame.ts
+++ b/shell/src/app/preview/rendered/rendered-frame.ts
@@ -65,6 +65,19 @@ export class RenderedFrame {
     return h && h > 0 ? h : null;
   });
 
+  /**
+   * `frameHeight` as a CSS length, or undefined when the guest has not
+   * reported one.
+   *
+   * Applied as both `height` and `min-height` so that a reported height wins
+   * over the stylesheet's minimum, which would otherwise leave a tall empty
+   * area below a short surface.
+   */
+  protected readonly frameHeightPx = computed<string | undefined>(() => {
+    const height = this.frameHeight();
+    return height === null ? undefined : `${height}px`;
+  });
+
   /** Programmatic streams active locking Signal, mapping visual lock bounds. */
   protected readonly isLocked = this.chatState.isProgrammaticStreamActive;
 


### PR DESCRIPTION
# Description

An inline surface was wrapped in a hardcoded white card with its own
border, radius and shadow. The A2UI payload already draws cards, so
every card in a surface appeared inside a second frame, and the
wrapper's opaque white background overrode the app's own surface colour.

The wrapper is now a plain sizing slot and the frame container is
transparent, which is how Gemini Enterprise renders the same payloads.

The fixed 280px minimum is also dropped once the guest renderer reports
its real height, so a short surface no longer leaves a tall empty area
beneath it. The height expression was repeated in the template, so it
moves into a `frameHeightPx` computed.

This is change 6 of 6 in a stack and targets `fix/a2ui-action-prompt-turn`.

## Verification

`yarn prettier:check`, `yarn lint`, `yarn tsc` and `yarn test` pass on the
tip of the stack.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
