### PR TITLE
Stop logging surface resize traffic in the raw messages panel

### DIFF
--- a/shell/src/app/debug/raw-messages/raw-messages.spec.ts
+++ b/shell/src/app/debug/raw-messages/raw-messages.spec.ts
@@ -156,6 +156,26 @@ describe('RawMessages', () => {
     expect(await harness.hasPlaceholder()).toBe(true);
   });
 
+  it('ignores SURFACE_RESIZE messages completely', async () => {
+    // A guest reports these on every reflow, which would evict real traffic.
+    emitMessage({
+      type: PreviewBridgeMessageType.SURFACE_RESIZE,
+      payload: {height: 420, width: 640},
+      origin: 'http://localhost',
+      timestamp: 1715940000000,
+    });
+    emitMessage({
+      type: 'KEPT_MSG',
+      payload: {},
+      origin: 'http://localhost',
+      timestamp: 1715940000001,
+    });
+    fixture.detectChanges();
+
+    expect(await harness.getLoggedMessagesCount()).toBe(1);
+    expect(await harness.getMessageTextAt(0)).toContain('KEPT_MSG');
+  });
+
   it('formats timestamps as HH:mm:ss.SSS correctly', async () => {
     const epoch = new Date();
     epoch.setHours(12);
@@ -277,6 +297,41 @@ describe('RawMessages', () => {
     expect(await newHarness.getMessageTextAt(1)).toContain('POST_MSG_3');
     expect(await newHarness.getMessageTextAt(2)).toContain('LLM_REQUEST');
     expect(await newHarness.getMessageTextAt(3)).toContain('POST_MSG_1');
+  });
+
+  it('drops excluded types from the seeded postMessage history', async () => {
+    vi.spyOn(hostCommMock, 'getHistoryBuffer').mockReturnValue([
+      {
+        type: PreviewBridgeMessageType.SURFACE_RESIZE,
+        payload: {height: 420},
+        origin: 'http://localhost',
+        timestamp: 1000,
+      },
+      {
+        type: PreviewBridgeMessageType.CONSOLE_LOG,
+        payload: {msg: 'hello'},
+        origin: 'http://localhost',
+        timestamp: 2000,
+      },
+      {
+        type: 'POST_MSG_1',
+        payload: {},
+        origin: 'http://localhost',
+        timestamp: 3000,
+      },
+    ]);
+
+    // Recreate the fixture so the constructor reads the seeded history.
+    fixture.destroy();
+    const newFixture = TestBed.createComponent(RawMessages);
+    newFixture.detectChanges();
+    const newHarness = await TestbedHarnessEnvironment.harnessForFixture(
+      newFixture,
+      RawMessagesHarness,
+    );
+
+    expect(await newHarness.getLoggedMessagesCount()).toBe(1);
+    expect(await newHarness.getMessageTextAt(0)).toContain('POST_MSG_1');
   });
 
   it('filters out duplicate entries matching timestamp and type', async () => {

--- a/shell/src/app/debug/raw-messages/raw-messages.ts
+++ b/shell/src/app/debug/raw-messages/raw-messages.ts
@@ -49,6 +49,19 @@ export interface RawLogEntry {
 }
 
 /**
+ * Message types the panel never logs.
+ *
+ * Both carry high-frequency traffic that would evict the protocol messages
+ * this view exists to show: `CONSOLE_LOG` is already surfaced by the errors
+ * panel, and a guest reports `SURFACE_RESIZE` on every reflow of its content,
+ * once per rendered surface.
+ */
+const EXCLUDED_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  PreviewBridgeMessageType.CONSOLE_LOG,
+  PreviewBridgeMessageType.SURFACE_RESIZE,
+]);
+
+/**
  * A debug drawer component presenting a scrolling diagnostic view
  * of raw postMessage traffic across the iframe boundary.
  */
@@ -74,7 +87,7 @@ export class RawMessages {
   };
 
   private readonly postMessageListener = (envelope: MessageEnvelope) => {
-    if (envelope.type === PreviewBridgeMessageType.CONSOLE_LOG) {
+    if (EXCLUDED_MESSAGE_TYPES.has(envelope.type)) {
       return;
     }
     this.addLogEntry({
@@ -89,7 +102,7 @@ export class RawMessages {
   constructor() {
     const historyBuffer = this.hostComm.getHistoryBuffer();
     const initialHosts: RawLogEntry[] = historyBuffer
-      .filter(env => env.type !== PreviewBridgeMessageType.CONSOLE_LOG)
+      .filter(env => !EXCLUDED_MESSAGE_TYPES.has(env.type))
       .map(env => ({
         type: env.type,
         payload: env.payload,

--- a/shell/src/app/shell/host-communication/host-communication.spec.ts
+++ b/shell/src/app/shell/host-communication/host-communication.spec.ts
@@ -364,6 +364,48 @@ describe('HostCommunication', () => {
     expect(history[0].type).toBe(PreviewBridgeMessageType.RENDERER_READY);
   });
 
+  it('excludes SURFACE_RESIZE messages from the messageHistoryBuffer but still broadcasts them', () => {
+    const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
+    service.registerIframe(mockIframeWindow);
+
+    const emitted: MessageEnvelope[] = [];
+    const sub = service.messageStream$.subscribe(envelope => {
+      emitted.push(envelope);
+    });
+
+    for (let height = 100; height < 200; height++) {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          source: mockIframeWindow,
+          origin: 'http://localhost:3000',
+          data: {
+            type: PreviewBridgeMessageType.SURFACE_RESIZE,
+            payload: {height, width: 320},
+          },
+        }),
+      );
+    }
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: mockIframeWindow,
+        origin: 'http://localhost:3000',
+        data: {type: PreviewBridgeMessageType.RENDERER_READY},
+      }),
+    );
+
+    const history = service.getHistoryBuffer();
+    expect(history.length).toBe(1);
+    expect(history[0].type).toBe(PreviewBridgeMessageType.RENDERER_READY);
+
+    // RenderedFrame relies on the stream to size its iframe, so the messages
+    // must still be delivered to subscribers.
+    expect(emitted.length).toBe(101);
+    expect(emitted[0].payload).toEqual({height: 100, width: 320});
+
+    sub.unsubscribe();
+  });
+
   it('buffers early messages when no iframe is registered and replays them upon registration', () => {
     const mockIframeWindow = {postMessage: vi.fn()} as unknown as Window;
 

--- a/shell/src/app/shell/host-communication/host-communication.ts
+++ b/shell/src/app/shell/host-communication/host-communication.ts
@@ -49,6 +49,21 @@ declare global {
   }
 }
 
+/** Maximum number of envelopes retained in the message history buffer. */
+const MAX_HISTORY_BUFFER_SIZE = 100;
+
+/**
+ * Message types that are broadcast but never retained in the history buffer.
+ *
+ * `SURFACE_RESIZE` is emitted by every inline surface on every layout change,
+ * so buffering it evicts the entire history within seconds. `CONSOLE_LOG` is
+ * also unbuffered, but its handler returns before reaching the buffer because
+ * it is routed to the error logger instead.
+ */
+const UNBUFFERED_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  PreviewBridgeMessageType.SURFACE_RESIZE,
+]);
+
 /**
  * Core service managing cross-frame message passing and event dispatching
  * between the primary workspace shell and rendering client frames.
@@ -81,6 +96,14 @@ export class HostCommunication implements OnDestroy {
     initialValue: null,
   });
 
+  /**
+   * Recent envelopes retained to seed the raw messages panel when it opens.
+   *
+   * Capped at `MAX_HISTORY_BUFFER_SIZE`, so a high-frequency type would evict
+   * everything else within seconds. Those types are listed in
+   * `UNBUFFERED_MESSAGE_TYPES` and skipped here, but are still broadcast on
+   * `messageStream$`.
+   */
   private readonly messageHistoryBuffer: MessageEnvelope[] = [];
   private readonly earlyMessageBuffer: MessageEvent[] = [];
   private readonly outboundMessageBuffer: Array<{
@@ -249,9 +272,11 @@ export class HostCommunication implements OnDestroy {
         }
       }
 
-      this.messageHistoryBuffer.push(envelope);
-      if (this.messageHistoryBuffer.length > 100) {
-        this.messageHistoryBuffer.shift();
+      if (!UNBUFFERED_MESSAGE_TYPES.has(type)) {
+        this.messageHistoryBuffer.push(envelope);
+        if (this.messageHistoryBuffer.length > MAX_HISTORY_BUFFER_SIZE) {
+          this.messageHistoryBuffer.shift();
+        }
       }
 
       this.latestEnvelopeSignal.set(envelope);


### PR DESCRIPTION
# Description

A guest reports `SURFACE_RESIZE` on every reflow of its content, and each
rendered surface runs its own guest, so a single host layout change — a
window resize, a splitter drag, a scrollbar appearing — emits one message
per surface. During a streaming response these filled the panel's
100 entry window and evicted the `RENDER_A2UI` and `DATA_MODEL_CHANGE`
traffic the view exists to show.

The type is now excluded alongside `CONSOLE_LOG`. The two exclusions were
previously checked in two separate places, once for the live stream and
once for the history replayed when the panel opens; both now read a single
set, so they cannot drift apart.

```diff
-    if (envelope.type === PreviewBridgeMessageType.CONSOLE_LOG) {
+    if (EXCLUDED_MESSAGE_TYPES.has(envelope.type)) {
       return;
     }
```

This hides the resize payloads from the panel entirely rather than offering
a toggle. If those payloads turn out to be worth inspecting — they are the
data you would read to diagnose a host/guest resize feedback loop — a type
filter in the template would be the follow-up.

## Verification

`yarn prettier:check`, `yarn lint`, `yarn tsc` and `yarn test` pass.

## Pre-launch Checklist

- [ ] I signed the [CLA].
- [ ] I read the [Contributors Guide].
- [ ] I read the [Style Guide].
- [ ] I have added updates to the [CHANGELOG].
- [ ] I updated/added relevant documentation.
- [x] My code changes (if any) have tests.
- [ ] If my branch is on fork, I have verified that [scripts/e2e_test.sh](../scripts/e2e_test.sh) passes.

<!-- Links -->

[CHANGELOG]: ../CHANGELOG.md
[CLA]: https://cla.developers.google.com/
[Contributors Guide]: ../CONTRIBUTING.md
[discussion board]: https://github.com/google/A2UI/discussions
[Style Guide]: ../CONTRIBUTING.md#coding-style
